### PR TITLE
Support task add/remove for pixi.toml and pyproject.toml

### DIFF
--- a/conda_workspaces/parsers/base.py
+++ b/conda_workspaces/parsers/base.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
+import tomlkit
+
 if TYPE_CHECKING:
     from pathlib import Path
     from typing import ClassVar
+
+    from tomlkit.container import Container
+    from tomlkit.items import InlineTable
 
     from ..models import Task, WorkspaceConfig
 
@@ -49,11 +54,51 @@ class ManifestParser(ABC):
     def add_task(self, path: Path, name: str, task: Task) -> None:
         """Persist a new task definition into *path*."""
         raise NotImplementedError(
-            f"Writing tasks to {path.name} is not supported. Use conda.toml instead."
+            f"{type(self).__name__} does not support writing tasks to {path.name}."
         )
 
     def remove_task(self, path: Path, name: str) -> None:
         """Remove the task named *name* from *path*."""
         raise NotImplementedError(
-            f"Writing tasks to {path.name} is not supported. Use conda.toml instead."
+            f"{type(self).__name__} does not support writing tasks to {path.name}."
         )
+
+    def task_to_toml_inline(self, task: Task) -> str | InlineTable:
+        """Convert a *task* to a TOML-serializable value (string or inline table)."""
+        table = tomlkit.inline_table()
+        if task.cmd is not None:
+            table.append("cmd", task.cmd)
+        if task.depends_on:
+            table.append("depends-on", [d.to_toml() for d in task.depends_on])
+        if task.description:
+            table.append("description", task.description)
+        if task.env:
+            table.append("env", dict(task.env))
+        if task.cwd:
+            table.append("cwd", task.cwd)
+        if task.clean_env:
+            table.append("clean-env", True)
+        if task.default_environment:
+            table.append("default-environment", task.default_environment)
+        if task.args:
+            table.append("args", [a.to_toml() for a in task.args])
+        if task.inputs:
+            table.append("inputs", list(task.inputs))
+        if task.outputs:
+            table.append("outputs", list(task.outputs))
+
+        if len(table) == 1 and "cmd" in table:
+            return str(table["cmd"])
+        return table
+
+    def remove_target_overrides(self, container: Container, name: str) -> None:
+        """Remove *name* from every ``[target.<platform>.tasks]`` under *container*."""
+        target = container.get("target")
+        if not target:
+            return
+        for _platform, tdata in target.items():
+            if tdata is None:
+                continue
+            tt = tdata.get("tasks")
+            if tt is not None and name in tt:
+                del tt[name]

--- a/conda_workspaces/parsers/pixi_toml.py
+++ b/conda_workspaces/parsers/pixi_toml.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 
 import tomlkit
 
-from ..exceptions import TaskParseError, WorkspaceParseError
+from ..exceptions import TaskNotFoundError, TaskParseError, WorkspaceParseError
 from ..models import WorkspaceConfig
 from .base import ManifestParser
 from .normalize import parse_feature_tasks, parse_tasks_and_targets
@@ -86,3 +86,22 @@ class PixiTomlParser(ManifestParser):
         tasks = parse_tasks_and_targets(data)
         parse_feature_tasks(data, tasks)
         return tasks
+
+    def add_task(self, path: Path, name: str, task: Task) -> None:
+        if path.exists():
+            doc = tomlkit.loads(path.read_text(encoding="utf-8"))
+        else:
+            doc = tomlkit.document()
+
+        tasks_section = doc.setdefault("tasks", tomlkit.table())
+        tasks_section[name] = self.task_to_toml_inline(task)
+        path.write_text(tomlkit.dumps(doc), encoding="utf-8")
+
+    def remove_task(self, path: Path, name: str) -> None:
+        doc = tomlkit.loads(path.read_text(encoding="utf-8"))
+        tasks_section = doc.get("tasks", {})
+        if name not in tasks_section:
+            raise TaskNotFoundError(name, list(tasks_section.keys()))
+        del tasks_section[name]
+        self.remove_target_overrides(doc, name)
+        path.write_text(tomlkit.dumps(doc), encoding="utf-8")

--- a/conda_workspaces/parsers/pyproject_toml.py
+++ b/conda_workspaces/parsers/pyproject_toml.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 import tomlkit
 
-from ..exceptions import TaskParseError, WorkspaceParseError
+from ..exceptions import TaskNotFoundError, TaskParseError, WorkspaceParseError
 from ..models import WorkspaceConfig
 from .base import ManifestParser
 from .normalize import parse_feature_tasks, parse_tasks_and_targets
@@ -21,7 +21,8 @@ from .toml import _parse_channels, _parse_features_and_envs
 
 if TYPE_CHECKING:
     from pathlib import Path
-    from typing import Any
+
+    from tomlkit.items import Table
 
     from ..models import Task
 
@@ -65,7 +66,6 @@ class PyprojectTomlParser(ManifestParser):
         conda = tool.get("conda", {})
         pixi = tool.get("pixi", {})
 
-        source: dict[str, Any]
         if conda.get("workspace"):
             source = conda
         elif pixi.get("workspace"):
@@ -116,3 +116,49 @@ class PyprojectTomlParser(ManifestParser):
         tasks = parse_tasks_and_targets(source)
         parse_feature_tasks(source, tasks)
         return tasks
+
+    def tool_section_for_tasks(self, doc: tomlkit.TOMLDocument) -> Table:
+        """Return the ``tool`` sub-table that owns tasks.
+
+        Uses the same precedence as ``parse_tasks``: non-empty
+        ``tool.conda`` wins, then non-empty ``tool.pixi``, then
+        falls back to ``tool.conda`` for new manifests.
+        """
+        tool = doc.setdefault("tool", tomlkit.table())
+        conda = tool.get("conda")
+        pixi = tool.get("pixi")
+        if conda is not None and len(conda) > 0:
+            return tool.setdefault("conda", tomlkit.table())
+        if pixi is not None and len(pixi) > 0:
+            return tool.setdefault("pixi", tomlkit.table())
+        return tool.setdefault("conda", tomlkit.table())
+
+    def add_task(self, path: Path, name: str, task: Task) -> None:
+        if path.exists():
+            doc = tomlkit.loads(path.read_text(encoding="utf-8"))
+        else:
+            doc = tomlkit.document()
+
+        parent = self.tool_section_for_tasks(doc)
+        tasks_section = parent.setdefault("tasks", tomlkit.table())
+        tasks_section[name] = self.task_to_toml_inline(task)
+        path.write_text(tomlkit.dumps(doc), encoding="utf-8")
+
+    def remove_task(self, path: Path, name: str) -> None:
+        doc = tomlkit.loads(path.read_text(encoding="utf-8"))
+        tool = doc.get("tool", {})
+        available: list[str] = []
+        for sec_name in ("conda", "pixi"):
+            sec = tool.get(sec_name)
+            if sec is None:
+                continue
+            tasks_tbl = sec.get("tasks")
+            if tasks_tbl is None:
+                continue
+            available.extend(tasks_tbl.keys())
+            if name in tasks_tbl:
+                del tasks_tbl[name]
+                self.remove_target_overrides(sec, name)
+                path.write_text(tomlkit.dumps(doc), encoding="utf-8")
+                return
+        raise TaskNotFoundError(name, sorted(set(available)))

--- a/conda_workspaces/parsers/toml.py
+++ b/conda_workspaces/parsers/toml.py
@@ -37,89 +37,11 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-def _task_to_toml_inline(task: Task) -> str | InlineTable:
-    """Convert a Task to a TOML-serializable value (string or inline table)."""
-    defn = tomlkit.inline_table()
-    if task.cmd is not None:
-        defn.append("cmd", task.cmd)
-    if task.depends_on:
-        defn.append("depends-on", [d.to_toml() for d in task.depends_on])
-    if task.description:
-        defn.append("description", task.description)
-    if task.env:
-        defn.append("env", dict(task.env))
-    if task.cwd:
-        defn.append("cwd", task.cwd)
-    if task.clean_env:
-        defn.append("clean-env", True)
-    if task.default_environment:
-        defn.append("default-environment", task.default_environment)
-    if task.args:
-        defn.append("args", [a.to_toml() for a in task.args])
-    if task.inputs:
-        defn.append("inputs", list(task.inputs))
-    if task.outputs:
-        defn.append("outputs", list(task.outputs))
-
-    if len(defn) == 1 and "cmd" in defn:
-        return str(defn["cmd"])
-    return defn
-
-
-def tasks_to_toml(tasks: dict[str, Task]) -> str:
-    """Serialize a full task dict to ``conda.toml`` TOML string."""
-    doc = tomlkit.document()
-
-    task_table = tomlkit.table()
-    for name, task in tasks.items():
-        task_table.add(name, _task_to_toml_inline(task))
-    doc.add("tasks", task_table)
-
-    targets: dict[str, dict[str, str | InlineTable]] = {}
-    for name, task in tasks.items():
-        if not task.platforms:
-            continue
-        for platform, override in task.platforms.items():
-            ov = tomlkit.inline_table()
-            if override.cmd is not None:
-                ov.append("cmd", override.cmd)
-            if override.env is not None:
-                ov.append("env", dict(override.env))
-            if override.cwd is not None:
-                ov.append("cwd", override.cwd)
-            if override.clean_env is not None:
-                ov.append("clean-env", override.clean_env)
-            if override.inputs is not None:
-                ov.append("inputs", list(override.inputs))
-            if override.outputs is not None:
-                ov.append("outputs", list(override.outputs))
-            if override.args is not None:
-                ov.append("args", [a.to_toml() for a in override.args])
-            if override.depends_on is not None:
-                ov.append("depends-on", [d.to_toml() for d in override.depends_on])
-            targets.setdefault(platform, {})[name] = (
-                str(ov["cmd"]) if len(ov) == 1 and "cmd" in ov else ov
-            )
-
-    for platform, platform_tasks in targets.items():
-        target_tbl = tomlkit.table(is_super_table=True)
-        tasks_tbl = tomlkit.table()
-        for tname, tval in platform_tasks.items():
-            tasks_tbl.add(tname, tval)
-        target_tbl.add("tasks", tasks_tbl)
-        doc.setdefault("target", tomlkit.table(is_super_table=True)).add(
-            platform, target_tbl
-        )
-
-    return tomlkit.dumps(doc)
-
-
 class CondaTomlParser(ManifestParser):
     """Parse ``conda.toml`` manifests (workspace and tasks).
 
     This is the conda-native format that mirrors pixi.toml structure
     but uses ``[workspace]`` exclusively (no ``[project]`` fallback).
-    It is also the only format that supports writing tasks.
     """
 
     filenames = ("conda.toml",)
@@ -173,7 +95,7 @@ class CondaTomlParser(ManifestParser):
             doc = tomlkit.document()
 
         tasks_section = doc.setdefault("tasks", tomlkit.table())
-        tasks_section[name] = _task_to_toml_inline(task)
+        tasks_section[name] = self.task_to_toml_inline(task)
         path.write_text(tomlkit.dumps(doc), encoding="utf-8")
 
     def remove_task(self, path: Path, name: str) -> None:
@@ -182,7 +104,61 @@ class CondaTomlParser(ManifestParser):
         if name not in tasks_section:
             raise TaskNotFoundError(name, list(tasks_section.keys()))
         del tasks_section[name]
+        self.remove_target_overrides(doc, name)
         path.write_text(tomlkit.dumps(doc), encoding="utf-8")
+
+
+def tasks_to_toml(tasks: dict[str, Task]) -> str:
+    """Serialize a full task dict to ``conda.toml`` TOML string."""
+    parser = CondaTomlParser()
+    doc = tomlkit.document()
+
+    task_table = tomlkit.table()
+    for name, task in tasks.items():
+        task_table.add(name, parser.task_to_toml_inline(task))
+    doc.add("tasks", task_table)
+
+    targets: dict[str, dict[str, str | InlineTable]] = {}
+    for name, task in tasks.items():
+        if not task.platforms:
+            continue
+        for platform, override in task.platforms.items():
+            override_table = tomlkit.inline_table()
+            if override.cmd is not None:
+                override_table.append("cmd", override.cmd)
+            if override.env is not None:
+                override_table.append("env", dict(override.env))
+            if override.cwd is not None:
+                override_table.append("cwd", override.cwd)
+            if override.clean_env is not None:
+                override_table.append("clean-env", override.clean_env)
+            if override.inputs is not None:
+                override_table.append("inputs", list(override.inputs))
+            if override.outputs is not None:
+                override_table.append("outputs", list(override.outputs))
+            if override.args is not None:
+                override_table.append("args", [a.to_toml() for a in override.args])
+            if override.depends_on is not None:
+                override_table.append(
+                    "depends-on",
+                    [d.to_toml() for d in override.depends_on],
+                )
+            if len(override_table) == 1 and "cmd" in override_table:
+                targets.setdefault(platform, {})[name] = str(override_table["cmd"])
+            else:
+                targets.setdefault(platform, {})[name] = override_table
+
+    for platform, platform_tasks in targets.items():
+        target_tbl = tomlkit.table(is_super_table=True)
+        tasks_tbl = tomlkit.table()
+        for tname, tval in platform_tasks.items():
+            tasks_tbl.add(tname, tval)
+        target_tbl.add("tasks", tasks_tbl)
+        doc.setdefault("target", tomlkit.table(is_super_table=True)).add(
+            platform, target_tbl
+        )
+
+    return tomlkit.dumps(doc)
 
 
 def _parse_channels(raw: list[Any]) -> list[Channel]:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,11 @@ parents. The first matching file is used.
 2. `pixi.toml` — pixi-native format (reads `[tasks]` directly)
 3. `pyproject.toml` — reads `[tool.conda.tasks]` or `[tool.pixi.tasks]`
 
+`conda task add` and `conda task remove` edit whichever of these files
+is selected by that search order, using the same tables as above (for
+`pyproject.toml`, under `[tool.conda.tasks]` or `[tool.pixi.tasks]`
+according to the same precedence rules as reading).
+
 When both `[tool.conda]` and `[tool.pixi]` exist in the same
 `pyproject.toml`, the entire `[tool.conda]` table takes precedence. This
 means that if `[tool.conda]` has any content (e.g. workspace settings)

--- a/tests/parsers/test_task_add_remove.py
+++ b/tests/parsers/test_task_add_remove.py
@@ -1,0 +1,71 @@
+"""Parametrized add/remove tests for all task parsers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from conda_workspaces.exceptions import TaskNotFoundError
+from conda_workspaces.models import Task
+from conda_workspaces.parsers.pixi_toml import PixiTomlParser
+from conda_workspaces.parsers.pyproject_toml import PyprojectTomlParser
+
+if TYPE_CHECKING:
+    from conda_workspaces.parsers.base import ManifestParser
+
+
+@pytest.mark.parametrize(
+    ("parser_cls", "fixture"),
+    [
+        pytest.param(PixiTomlParser, "task_pixi_toml", id="pixi"),
+        pytest.param(PyprojectTomlParser, "task_pyproject", id="pyproject"),
+    ],
+)
+def test_add_task(
+    request: pytest.FixtureRequest,
+    parser_cls: type[ManifestParser],
+    fixture: str,
+) -> None:
+    path = request.getfixturevalue(fixture)
+    parser = parser_cls()
+    parser.add_task(path, "new", Task(name="new", cmd="echo new"))
+    tasks = parser.parse_tasks(path)
+    assert "new" in tasks
+    assert tasks["new"].cmd == "echo new"
+
+
+@pytest.mark.parametrize(
+    ("parser_cls", "fixture"),
+    [
+        pytest.param(PixiTomlParser, "task_pixi_toml", id="pixi"),
+        pytest.param(PyprojectTomlParser, "task_pyproject", id="pyproject"),
+    ],
+)
+def test_remove_task(
+    request: pytest.FixtureRequest,
+    parser_cls: type[ManifestParser],
+    fixture: str,
+) -> None:
+    path = request.getfixturevalue(fixture)
+    parser = parser_cls()
+    parser.remove_task(path, "build")
+    tasks = parser.parse_tasks(path)
+    assert "build" not in tasks
+
+
+@pytest.mark.parametrize(
+    ("parser_cls", "fixture"),
+    [
+        pytest.param(PixiTomlParser, "task_pixi_toml", id="pixi"),
+        pytest.param(PyprojectTomlParser, "task_pyproject", id="pyproject"),
+    ],
+)
+def test_remove_nonexistent(
+    request: pytest.FixtureRequest,
+    parser_cls: type[ManifestParser],
+    fixture: str,
+) -> None:
+    path = request.getfixturevalue(fixture)
+    with pytest.raises(TaskNotFoundError):
+        parser_cls().remove_task(path, "nonexistent")

--- a/tests/parsers/test_task_pixi_toml.py
+++ b/tests/parsers/test_task_pixi_toml.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import pytest
 
 from conda_workspaces.exceptions import TaskParseError
-from conda_workspaces.models import Task
 from conda_workspaces.parsers.pixi_toml import PixiTomlParser
 
 
@@ -63,15 +62,3 @@ def test_parse_invalid_toml(tmp_project):
 
     with pytest.raises(TaskParseError):
         PixiTomlParser().parse_tasks(path)
-
-
-@pytest.mark.parametrize(
-    "method, args",
-    [
-        ("add_task", lambda p: (p, "x", Task(name="x", cmd="echo"))),
-        ("remove_task", lambda p: (p, "build")),
-    ],
-)
-def test_write_raises(task_pixi_toml, method, args):
-    with pytest.raises(NotImplementedError):
-        getattr(PixiTomlParser(), method)(*args(task_pixi_toml))

--- a/tests/parsers/test_task_pyproject_toml.py
+++ b/tests/parsers/test_task_pyproject_toml.py
@@ -72,13 +72,13 @@ def test_parse_target_only_task(tmp_project):
     assert tasks["special"].platforms is not None
 
 
-@pytest.mark.parametrize(
-    "method, args",
-    [
-        ("add_task", lambda p: (p, "x", Task(name="x", cmd="echo"))),
-        ("remove_task", lambda p: (p, "build")),
-    ],
-)
-def test_write_raises(task_pyproject, method, args):
-    with pytest.raises(NotImplementedError):
-        getattr(PyprojectTomlParser(), method)(*args(task_pyproject))
+def test_add_task_pixi_only(tmp_project):
+    path = tmp_project / "pyproject.toml"
+    path.write_text(
+        '[project]\nname = "example"\n\n[tool.pixi.workspace]\n'
+        'channels = ["conda-forge"]\nplatforms = ["linux-64"]\n'
+    )
+    parser = PyprojectTomlParser()
+    parser.add_task(path, "build", Task(name="build", cmd="make"))
+    tasks = parser.parse_tasks(path)
+    assert tasks["build"].cmd == "make"

--- a/tests/parsers/test_task_toml.py
+++ b/tests/parsers/test_task_toml.py
@@ -8,11 +8,7 @@ import pytest
 
 from conda_workspaces.exceptions import TaskNotFoundError, TaskParseError
 from conda_workspaces.models import Task, TaskArg, TaskDependency, TaskOverride
-from conda_workspaces.parsers.toml import (
-    CondaTomlParser,
-    _task_to_toml_inline,
-    tasks_to_toml,
-)
+from conda_workspaces.parsers.toml import CondaTomlParser, tasks_to_toml
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -162,7 +158,7 @@ def test_parse_invalid(tmp_project):
 
 def test_to_toml_inline_simple_cmd():
     task = Task(name="build", cmd="make")
-    assert _task_to_toml_inline(task) == "make"
+    assert CondaTomlParser().task_to_toml_inline(task) == "make"
 
 
 def test_to_toml_inline_with_fields():
@@ -176,7 +172,7 @@ def test_to_toml_inline_with_fields():
         inputs=["src/**/*.py"],
         outputs=["results/"],
     )
-    result = _task_to_toml_inline(task)
+    result = CondaTomlParser().task_to_toml_inline(task)
     assert not isinstance(result, str)
     d = dict(result)
     assert d["cmd"] == "pytest"
@@ -191,7 +187,7 @@ def test_to_toml_inline_with_args():
         cmd="pytest {{ path }}",
         args=[TaskArg(name="path", default="tests/")],
     )
-    result = _task_to_toml_inline(task)
+    result = CondaTomlParser().task_to_toml_inline(task)
     assert not isinstance(result, str)
     d = dict(result)
     assert d["args"][0] == {"arg": "path", "default": "tests/"}  # ty: ignore[not-subscriptable]


### PR DESCRIPTION
## Summary

- Implement `add_task` and `remove_task` on `PixiTomlParser` and `PyprojectTomlParser`, closing the `NotImplementedError` gap from the base class
- `PixiTomlParser` writes to top-level `[tasks]`; `PyprojectTomlParser` writes under `[tool.conda.tasks]` or `[tool.pixi.tasks]` using the same precedence as `parse_tasks`
- `remove_task` on all three parsers now clears matching entries from `[target.<platform>.tasks]` via a shared `_remove_task_from_target_overrides` helper
- Update `base.py` fallback error message (no longer directs users to conda.toml) and document that `conda task add`/`remove` work for all three manifest formats

## Test plan

- [x] `pixi run -e test pytest` passes (711 passed, 1 skipped)
- [x] `pixi run -e dev ruff check conda_workspaces tests` passes
- [x] Parametrized tests cover add/remove/not-found for both pixi.toml and pyproject.toml
- [x] Pyproject-specific test verifies writes go under `[tool.pixi.tasks]` when only pixi is populated
- [x] Existing conda.toml add/remove tests continue to pass

Closes #8