### PR TITLE
Support task add/remove for all parsers; document hardlink optimization

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -297,6 +297,27 @@ The environment specifiers also surface PyPI dependencies as
 `external_packages` (under the `"pip"` key) so that conda's own
 reporting and downstream tools can see them.
 
+### 7. Hardlink Optimization
+
+Project-local environments live under `.conda/envs/`, which may be on
+a different filesystem from conda's global package cache (`pkgs_dirs`).
+When they are, conda silently falls back from hardlinks to copies,
+significantly increasing disk usage — especially in CI and Docker
+where the global cache is often on a separate volume.
+
+conda already provides the `CONDA_PKGS_DIRS` environment variable to
+redirect the package cache.  In CI/Docker, set it to a path on the
+same filesystem as the project directory to ensure hardlinks work:
+
+```bash
+export CONDA_PKGS_DIRS="$PWD/.conda/pkgs"
+conda workspace install
+```
+
+conda-workspaces does not manage this setting itself — it defers to
+conda's existing mechanism, which works regardless of whether
+conda-workspaces is installed.
+
 ## Future Work
 
 - **conda-build integration**: Build packages from workspace members
@@ -304,8 +325,6 @@ reporting and downstream tools can see them.
 - **Multi-package workspaces**: Support monorepo layouts where
   subdirectories are independent packages that can depend on each other
   (pixi's `[package]` concept, reimagined for conda-build).
-- **Hardlink optimization**: Use hardlinks from the package cache to
-  reduce disk usage for project-local environments.
 - **Multi-platform lockfiles**: Record packages for all declared
   platforms in `conda.lock`, not only the current host platform.
   Requires cross-platform solving or collecting data from CI runners

--- a/docs/features.md
+++ b/docs/features.md
@@ -439,3 +439,50 @@ my-project/
 Environments are standard conda prefixes. Use `conda workspace run -e <name> -- CMD`
 to run a command in an environment, `conda workspace shell -e <name>` for an
 interactive shell, or `conda activate .conda/envs/<name>` directly.
+
+## CI and Docker
+
+### Optimizing disk usage with hardlinks
+
+conda hardlinks packages from its global cache into environment
+prefixes, which saves significant disk space. In CI and Docker the
+global cache is often on a different filesystem (or volume) from the
+project directory, causing conda to silently fall back to copying
+packages — roughly doubling disk usage per environment.
+
+Set the `CONDA_PKGS_DIRS` environment variable to a project-local path
+before installing so that the cache and environments share a filesystem:
+
+```bash
+export CONDA_PKGS_DIRS="$PWD/.conda/pkgs"
+conda workspace install
+```
+
+::::{tab-set}
+
+:::{tab-item} GitHub Actions
+
+```yaml
+- name: Install workspace
+  run: |
+    export CONDA_PKGS_DIRS="$PWD/.conda/pkgs"
+    conda workspace install
+```
+
+:::
+
+:::{tab-item} GitLab CI
+
+```yaml
+install:
+  script:
+    - export CONDA_PKGS_DIRS="$PWD/.conda/pkgs"
+    - conda workspace install
+```
+
+:::
+
+::::
+
+On developer workstations the global cache is usually on the same
+filesystem and hardlinks work without any extra configuration.


### PR DESCRIPTION
## Summary

- Extend `conda task add` and `conda task remove` to work with `pixi.toml` and `pyproject.toml` in addition to `conda.toml`. Each parser implements `add_task` and `remove_task` via a shared base class, with format-specific TOML table handling.
- Document `CONDA_PKGS_DIRS` as the recommended approach for hardlink optimization in CI/Docker, with GitHub Actions and GitLab CI examples. No manifest-level `pkgs-dir` setting — conda's existing env var handles this cleanly. Closes #5.

## Test plan

- [x] New `tests/parsers/test_task_add_remove.py` covers add/remove across all three parser formats
- [x] Existing parser tests updated to reflect refactored task normalization
- [x] Full test suite passes (711 tests)
- [x] `ruff check` and `ruff format` clean