### PR TITLE
docs: organize sidebar into Diataxis sections

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -170,13 +170,32 @@ and task execution.
 
 ```{toctree}
 :hidden:
+:caption: Tutorials
 
 quickstart
 tutorials/index
-features
-configuration
+```
+
+```{toctree}
+:hidden:
+:caption: Reference
+
 reference/cli
 reference/api
+configuration
+```
+
+```{toctree}
+:hidden:
+:caption: Explanation
+
+features
 motivation
+```
+
+```{toctree}
+:hidden:
+:caption: Project
+
 changelog
 ```


### PR DESCRIPTION
## Summary

- Split the flat toctree in `docs/index.md` into captioned Diataxis sections: Tutorials, Reference, Explanation, Project.
- Matches the sidebar structure used in conda-express docs.

## Test plan

- [x] `pixi run -e docs docs` builds with no warnings