### PR TITLE
Add Dependabot for GitHub Actions and pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      python:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds Dependabot configuration to automatically monitor and update GitHub Actions and pip dependencies on a weekly schedule.
- Groups all updates within each ecosystem into single PRs for easier review.

## Test plan
- [ ] Verify Dependabot picks up the config and opens update PRs as needed.