### PR TITLE
Default task execution to the workspace environment

### DIFF
--- a/conda_workspaces/cli/task/run.py
+++ b/conda_workspaces/cli/task/run.py
@@ -126,12 +126,14 @@ def execute_run(args: argparse.Namespace, *, console: Console | None = None) -> 
     dry_run = getattr(args, "dry_run", False)
     quiet = getattr(args, "quiet", False)
     verbose = getattr(args, "verbose", 0) or 0
+    user_env = getattr(args, "environment", None)
     conda_prefix = _env_prefix_or_none(args)
 
     default_env_name = tasks[target_name].default_environment
-    user_env = getattr(args, "environment", None)
     if default_env_name and not user_env:
         conda_prefix = _env_prefix_or_none(args, default_env_name) or conda_prefix
+    elif not user_env and conda_prefix is None:
+        conda_prefix = _env_prefix_or_none(args, "default")
 
     task_args = _resolve_task_args(tasks[target_name], args.task_args)
 
@@ -358,6 +360,8 @@ def _run_adhoc(
 
     dry_run = getattr(args, "dry_run", False)
     conda_prefix = _env_prefix_or_none(args)
+    if conda_prefix is None and not getattr(args, "environment", None):
+        conda_prefix = _env_prefix_or_none(args, "default")
 
     if dry_run:
         if not getattr(args, "quiet", False):

--- a/tests/cli/task/test_run.py
+++ b/tests/cli/task/test_run.py
@@ -113,6 +113,7 @@ def test_resolve_task_args_missing_required():
 
 
 def test_execute_run_dry_run_single(tmp_path, capsys):
+    """Dry-run of a single task shows 'Would run' with command."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text('[tasks]\ngreet = "echo hello"\n')
 
@@ -125,6 +126,7 @@ def test_execute_run_dry_run_single(tmp_path, capsys):
 
 
 def test_execute_run_dry_run_with_deps(tmp_path, capsys):
+    """Dry-run with deps shows a tree with 'Would run' labels."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks]\nsetup = "echo setup"\n\n'
@@ -139,6 +141,7 @@ def test_execute_run_dry_run_with_deps(tmp_path, capsys):
 
 
 def test_execute_run_dry_run_alias(tmp_path, capsys):
+    """Alias tasks appear as root of the dry-run tree."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks]\nlint = "ruff check ."\ntest = "pytest"\n\n'
@@ -155,6 +158,7 @@ def test_execute_run_dry_run_alias(tmp_path, capsys):
 
 
 def test_execute_run_alias_done(tmp_path, capsys, fake_shell):
+    """Alias tasks show Finished after dependencies finish executing."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks]\nlint = "ruff check ."\ntest = "pytest"\n\n'
@@ -171,6 +175,7 @@ def test_execute_run_alias_done(tmp_path, capsys, fake_shell):
 
 
 def test_execute_run_alias_quiet(tmp_path, capsys, fake_shell):
+    """Quiet mode suppresses all output for alias tasks."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks]\nlint = "ruff check ."\n\n[tasks.check]\ndepends-on = ["lint"]\n'
@@ -183,6 +188,7 @@ def test_execute_run_alias_quiet(tmp_path, capsys, fake_shell):
 
 
 def test_execute_run_list_command(tmp_path, capsys):
+    """List-form commands are joined for dry-run display."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text('[tasks]\nbuild = "cmake --build ."\n')
 
@@ -193,6 +199,7 @@ def test_execute_run_list_command(tmp_path, capsys):
 
 
 def test_execute_run_single_zero_chrome(tmp_path, capsys, fake_shell):
+    """Single task execution produces no status output (zero chrome)."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text('[tasks]\ngreet = "echo hello"\n')
 
@@ -204,6 +211,7 @@ def test_execute_run_single_zero_chrome(tmp_path, capsys, fake_shell):
 
 
 def test_execute_run_quiet(tmp_path, capsys, fake_shell):
+    """Quiet mode suppresses output."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text('[tasks]\ngreet = "echo hello"\n')
 
@@ -214,6 +222,7 @@ def test_execute_run_quiet(tmp_path, capsys, fake_shell):
 
 
 def test_execute_run_failure(tmp_path, fake_shell):
+    """Non-zero exit raises TaskExecutionError."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text('[tasks]\nfail = "exit 1"\n')
 
@@ -223,6 +232,7 @@ def test_execute_run_failure(tmp_path, fake_shell):
 
 
 def test_execute_run_failure_with_deps(tmp_path, capsys, fake_shell):
+    """Failed task in a dep chain shows Failed status."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks]\nsetup = "echo setup"\n\n'
@@ -243,6 +253,7 @@ def test_execute_run_failure_with_deps(tmp_path, capsys, fake_shell):
 
 
 def test_execute_run_dep_chain_markers(tmp_path, capsys, fake_shell):
+    """Dep chain shows Running and Finished for each task."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks]\nsetup = "echo setup"\n\n'
@@ -260,6 +271,7 @@ def test_execute_run_dep_chain_markers(tmp_path, capsys, fake_shell):
 
 
 def test_execute_run_dep_chain_verbose(tmp_path, capsys, fake_shell):
+    """Verbose mode adds command text to Running status."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks]\nsetup = "echo setup"\n\n'
@@ -275,6 +287,7 @@ def test_execute_run_dep_chain_verbose(tmp_path, capsys, fake_shell):
 
 
 def test_execute_run_verbose_with_io(tmp_path, capsys, fake_shell, monkeypatch):
+    """Verbose mode prints inputs/outputs for tasks in a dep chain."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks]\nsetup = "echo ready"\n\n'
@@ -292,6 +305,7 @@ def test_execute_run_verbose_with_io(tmp_path, capsys, fake_shell, monkeypatch):
 
 
 def test_execute_run_cached_in_dep_chain(tmp_path, capsys, fake_shell, monkeypatch):
+    """Cached tasks in a dep chain show Skipped status."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks.lint]\ncmd = "ruff"\ninputs = ["src/*.py"]\noutputs = [".lint"]\n\n'
@@ -310,6 +324,7 @@ def test_execute_run_cached_in_dep_chain(tmp_path, capsys, fake_shell, monkeypat
 def test_execute_run_cached_single_shows_marker(
     tmp_path, capsys, fake_shell, monkeypatch
 ):
+    """Cached single task (no deps) shows Skipped status."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks.build]\ncmd = "make"\ninputs = ["src/*.py"]\noutputs = ["dist/"]\n'
@@ -325,6 +340,7 @@ def test_execute_run_cached_single_shows_marker(
 
 
 def test_execute_run_with_cwd_override(tmp_path, capsys, fake_shell):
+    """--cwd overrides the task's working directory."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text('[tasks]\ngreet = "echo hello"\n')
     subdir = tmp_path / "sub"
@@ -338,6 +354,7 @@ def test_execute_run_with_cwd_override(tmp_path, capsys, fake_shell):
 
 
 def test_execute_run_saves_cache(tmp_path, fake_shell, monkeypatch):
+    """Successful run with inputs/outputs saves to cache."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks.build]\ncmd = "make"\ninputs = ["src/*.py"]\noutputs = ["dist/"]\n'
@@ -355,6 +372,7 @@ def test_execute_run_saves_cache(tmp_path, fake_shell, monkeypatch):
 def test_execute_run_defaults_to_workspace_env(
     workspace_task_file, fake_shell, env_prefix_stub, tmp_path
 ):
+    """When no -e flag is given, tasks run in the workspace default env."""
     default_prefix = tmp_path / ".conda" / "envs" / "default"
     env_prefix_stub["default"] = default_prefix
 
@@ -366,6 +384,7 @@ def test_execute_run_defaults_to_workspace_env(
 def test_execute_run_explicit_env_overrides_default(
     workspace_task_file, fake_shell, env_prefix_stub, tmp_path
 ):
+    """The -e flag overrides the workspace default env."""
     env_prefix_stub["default"] = tmp_path / ".conda" / "envs" / "default"
     test_prefix = tmp_path / ".conda" / "envs" / "myenv"
     env_prefix_stub["myenv"] = test_prefix

--- a/tests/cli/task/test_run.py
+++ b/tests/cli/task/test_run.py
@@ -47,6 +47,46 @@ class FakeShell:
         return self.return_code
 
 
+@pytest.fixture
+def fake_shell(monkeypatch):
+    """Patch SubprocessShell and return the FakeShell instance."""
+    shell = FakeShell()
+    monkeypatch.setattr(run_mod, "SubprocessShell", lambda: shell)
+    return shell
+
+
+@pytest.fixture
+def workspace_task_file(tmp_path):
+    """A conda.toml with both a workspace definition and a simple task."""
+    task_file = tmp_path / "conda.toml"
+    task_file.write_text(
+        '[workspace]\nname = "test"\nchannels = ["conda-forge"]\n'
+        'platforms = ["linux-64", "osx-arm64"]\n\n'
+        '[tasks]\ngreet = "echo hello"\n'
+    )
+    return task_file
+
+
+@pytest.fixture
+def env_prefix_stub(monkeypatch):
+    """Patch _env_prefix_or_none to return deterministic prefixes.
+
+    Returns a dict mapping env names to prefix paths; add entries
+    before calling execute_run.
+    """
+    prefixes: dict[str, Path] = {}
+
+    def _stub(args, env_name=None):
+        if env_name is None:
+            env_name = getattr(args, "environment", None)
+        if env_name and env_name in prefixes:
+            return prefixes[env_name]
+        return None
+
+    monkeypatch.setattr(run_mod, "_env_prefix_or_none", _stub)
+    return prefixes
+
+
 @pytest.mark.parametrize(
     ("args_def", "cli_args", "expected"),
     [
@@ -73,7 +113,6 @@ def test_resolve_task_args_missing_required():
 
 
 def test_execute_run_dry_run_single(tmp_path, capsys):
-    """Dry-run of a single task shows 'Would run' with command."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text('[tasks]\ngreet = "echo hello"\n')
 
@@ -86,7 +125,6 @@ def test_execute_run_dry_run_single(tmp_path, capsys):
 
 
 def test_execute_run_dry_run_with_deps(tmp_path, capsys):
-    """Dry-run with deps shows a tree with 'Would run' labels."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks]\nsetup = "echo setup"\n\n'
@@ -101,7 +139,6 @@ def test_execute_run_dry_run_with_deps(tmp_path, capsys):
 
 
 def test_execute_run_dry_run_alias(tmp_path, capsys):
-    """Alias tasks appear as root of the dry-run tree."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks]\nlint = "ruff check ."\ntest = "pytest"\n\n'
@@ -117,16 +154,13 @@ def test_execute_run_dry_run_alias(tmp_path, capsys):
     assert "test" in output
 
 
-def test_execute_run_alias_done(tmp_path, capsys, monkeypatch):
-    """Alias tasks show Finished after dependencies finish executing."""
+def test_execute_run_alias_done(tmp_path, capsys, fake_shell):
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks]\nlint = "ruff check ."\ntest = "pytest"\n\n'
         '[tasks.check]\ndepends-on = ["lint", "test"]\n'
     )
 
-    fake = FakeShell()
-    monkeypatch.setattr(run_mod, "SubprocessShell", lambda: fake)
     result = execute_run(_run_args(task_file, task_name="check"))
 
     assert result == 0
@@ -136,15 +170,12 @@ def test_execute_run_alias_done(tmp_path, capsys, monkeypatch):
     assert "check" in output
 
 
-def test_execute_run_alias_quiet(tmp_path, capsys, monkeypatch):
-    """Quiet mode suppresses all output for alias tasks."""
+def test_execute_run_alias_quiet(tmp_path, capsys, fake_shell):
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks]\nlint = "ruff check ."\n\n[tasks.check]\ndepends-on = ["lint"]\n'
     )
 
-    fake = FakeShell()
-    monkeypatch.setattr(run_mod, "SubprocessShell", lambda: fake)
     result = execute_run(_run_args(task_file, task_name="check", quiet=True))
 
     assert result == 0
@@ -152,7 +183,6 @@ def test_execute_run_alias_quiet(tmp_path, capsys, monkeypatch):
 
 
 def test_execute_run_list_command(tmp_path, capsys):
-    """List-form commands are joined for dry-run display."""
     task_file = tmp_path / "conda.toml"
     task_file.write_text('[tasks]\nbuild = "cmake --build ."\n')
 
@@ -162,61 +192,48 @@ def test_execute_run_list_command(tmp_path, capsys):
     assert "cmake --build ." in output
 
 
-def test_execute_run_single_zero_chrome(tmp_path, capsys, monkeypatch):
-    """Single task execution produces no status output (zero chrome)."""
+def test_execute_run_single_zero_chrome(tmp_path, capsys, fake_shell):
     task_file = tmp_path / "conda.toml"
     task_file.write_text('[tasks]\ngreet = "echo hello"\n')
 
-    fake = FakeShell()
-    monkeypatch.setattr(run_mod, "SubprocessShell", lambda: fake)
     result = execute_run(_run_args(task_file))
 
     assert result == 0
     assert capsys.readouterr().out == ""
-    assert len(fake.calls) == 1
+    assert len(fake_shell.calls) == 1
 
 
-def test_execute_run_quiet(tmp_path, capsys, monkeypatch):
-    """Quiet mode suppresses output."""
+def test_execute_run_quiet(tmp_path, capsys, fake_shell):
     task_file = tmp_path / "conda.toml"
     task_file.write_text('[tasks]\ngreet = "echo hello"\n')
 
-    fake = FakeShell()
-    monkeypatch.setattr(run_mod, "SubprocessShell", lambda: fake)
     result = execute_run(_run_args(task_file, quiet=True))
 
     assert result == 0
     assert capsys.readouterr().out == ""
 
 
-def test_execute_run_failure(tmp_path, monkeypatch):
-    """Non-zero exit raises TaskExecutionError."""
+def test_execute_run_failure(tmp_path, fake_shell):
     task_file = tmp_path / "conda.toml"
     task_file.write_text('[tasks]\nfail = "exit 1"\n')
 
-    fake = FakeShell(return_code=1)
-    monkeypatch.setattr(run_mod, "SubprocessShell", lambda: fake)
+    fake_shell.return_code = 1
     with pytest.raises(TaskExecutionError, match="fail"):
         execute_run(_run_args(task_file, task_name="fail"))
 
 
-def test_execute_run_failure_with_deps(tmp_path, capsys, monkeypatch):
-    """Failed task in a dep chain shows Failed status."""
+def test_execute_run_failure_with_deps(tmp_path, capsys, fake_shell):
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks]\nsetup = "echo setup"\n\n'
         '[tasks.build]\ncmd = "make"\ndepends-on = ["setup"]\n'
     )
 
-    calls = []
-
-    def fake_run(cmd, env, cwd, conda_prefix=None, clean_env=False):
-        calls.append(cmd)
+    def selective_fail(cmd, env, cwd, conda_prefix=None, clean_env=False):
+        fake_shell.calls.append((cmd, env, cwd, conda_prefix, clean_env))
         return 1 if cmd == "make" else 0
 
-    fake = FakeShell()
-    fake.run = fake_run
-    monkeypatch.setattr(run_mod, "SubprocessShell", lambda: fake)
+    fake_shell.run = selective_fail
     with pytest.raises(TaskExecutionError, match="build"):
         execute_run(_run_args(task_file, task_name="build"))
 
@@ -225,16 +242,13 @@ def test_execute_run_failure_with_deps(tmp_path, capsys, monkeypatch):
     assert "build" in output
 
 
-def test_execute_run_dep_chain_markers(tmp_path, capsys, monkeypatch):
-    """Dep chain shows Running and Finished for each task."""
+def test_execute_run_dep_chain_markers(tmp_path, capsys, fake_shell):
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks]\nsetup = "echo setup"\n\n'
         '[tasks.build]\ncmd = "echo build"\ndepends-on = ["setup"]\n'
     )
 
-    fake = FakeShell()
-    monkeypatch.setattr(run_mod, "SubprocessShell", lambda: fake)
     result = execute_run(_run_args(task_file, task_name="build"))
 
     assert result == 0
@@ -245,16 +259,13 @@ def test_execute_run_dep_chain_markers(tmp_path, capsys, monkeypatch):
     assert "build" in output
 
 
-def test_execute_run_dep_chain_verbose(tmp_path, capsys, monkeypatch):
-    """Verbose mode adds command text to Running status."""
+def test_execute_run_dep_chain_verbose(tmp_path, capsys, fake_shell):
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks]\nsetup = "echo setup"\n\n'
         '[tasks.build]\ncmd = "echo build"\ndepends-on = ["setup"]\n'
     )
 
-    fake = FakeShell()
-    monkeypatch.setattr(run_mod, "SubprocessShell", lambda: fake)
     result = execute_run(_run_args(task_file, task_name="build", verbose=1))
 
     assert result == 0
@@ -263,8 +274,7 @@ def test_execute_run_dep_chain_verbose(tmp_path, capsys, monkeypatch):
     assert "echo build" in output
 
 
-def test_execute_run_verbose_with_io(tmp_path, capsys, monkeypatch):
-    """Verbose mode prints inputs/outputs for tasks in a dep chain."""
+def test_execute_run_verbose_with_io(tmp_path, capsys, fake_shell, monkeypatch):
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks]\nsetup = "echo ready"\n\n'
@@ -272,8 +282,6 @@ def test_execute_run_verbose_with_io(tmp_path, capsys, monkeypatch):
         'outputs = ["dist/"]\ndepends-on = ["setup"]\n'
     )
 
-    fake = FakeShell()
-    monkeypatch.setattr(run_mod, "SubprocessShell", lambda: fake)
     monkeypatch.setattr(run_mod, "is_cached", lambda *a, **kw: False)
     result = execute_run(_run_args(task_file, task_name="build", verbose=1))
 
@@ -283,16 +291,13 @@ def test_execute_run_verbose_with_io(tmp_path, capsys, monkeypatch):
     assert "outputs:" in output
 
 
-def test_execute_run_cached_in_dep_chain(tmp_path, capsys, monkeypatch):
-    """Cached tasks in a dep chain show Skipped status."""
+def test_execute_run_cached_in_dep_chain(tmp_path, capsys, fake_shell, monkeypatch):
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks.lint]\ncmd = "ruff"\ninputs = ["src/*.py"]\noutputs = [".lint"]\n\n'
         '[tasks.build]\ncmd = "make"\ndepends-on = ["lint"]\n'
     )
 
-    fake = FakeShell()
-    monkeypatch.setattr(run_mod, "SubprocessShell", lambda: fake)
     monkeypatch.setattr(run_mod, "is_cached", lambda *a, **kw: True)
     result = execute_run(_run_args(task_file, task_name="build"))
 
@@ -302,15 +307,14 @@ def test_execute_run_cached_in_dep_chain(tmp_path, capsys, monkeypatch):
     assert "cached" in output
 
 
-def test_execute_run_cached_single_shows_marker(tmp_path, capsys, monkeypatch):
-    """Cached single task (no deps) shows Skipped status."""
+def test_execute_run_cached_single_shows_marker(
+    tmp_path, capsys, fake_shell, monkeypatch
+):
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks.build]\ncmd = "make"\ninputs = ["src/*.py"]\noutputs = ["dist/"]\n'
     )
 
-    fake = FakeShell()
-    monkeypatch.setattr(run_mod, "SubprocessShell", lambda: fake)
     monkeypatch.setattr(run_mod, "is_cached", lambda *a, **kw: True)
     result = execute_run(_run_args(task_file, task_name="build"))
 
@@ -320,35 +324,52 @@ def test_execute_run_cached_single_shows_marker(tmp_path, capsys, monkeypatch):
     assert "cached" in output
 
 
-def test_execute_run_with_cwd_override(tmp_path, capsys, monkeypatch):
-    """--cwd overrides the task's working directory."""
+def test_execute_run_with_cwd_override(tmp_path, capsys, fake_shell):
     task_file = tmp_path / "conda.toml"
     task_file.write_text('[tasks]\ngreet = "echo hello"\n')
     subdir = tmp_path / "sub"
     subdir.mkdir()
 
-    fake = FakeShell()
-    monkeypatch.setattr(run_mod, "SubprocessShell", lambda: fake)
     result = execute_run(_run_args(task_file, cwd=subdir))
 
     assert result == 0
-    assert len(fake.calls) == 1
-    assert Path(fake.calls[0][2]) == subdir
+    assert len(fake_shell.calls) == 1
+    assert Path(fake_shell.calls[0][2]) == subdir
 
 
-def test_execute_run_saves_cache(tmp_path, monkeypatch):
-    """Successful run with inputs/outputs saves to cache."""
+def test_execute_run_saves_cache(tmp_path, fake_shell, monkeypatch):
     task_file = tmp_path / "conda.toml"
     task_file.write_text(
         '[tasks.build]\ncmd = "make"\ninputs = ["src/*.py"]\noutputs = ["dist/"]\n'
     )
 
-    fake = FakeShell()
     save_calls: list[tuple] = []
-    monkeypatch.setattr(run_mod, "SubprocessShell", lambda: fake)
     monkeypatch.setattr(run_mod, "is_cached", lambda *a, **kw: False)
     monkeypatch.setattr(run_mod, "save_cache", lambda *a, **kw: save_calls.append(a))
     result = execute_run(_run_args(task_file, task_name="build", quiet=True))
 
     assert result == 0
     assert len(save_calls) == 1
+
+
+def test_execute_run_defaults_to_workspace_env(
+    workspace_task_file, fake_shell, env_prefix_stub, tmp_path
+):
+    default_prefix = tmp_path / ".conda" / "envs" / "default"
+    env_prefix_stub["default"] = default_prefix
+
+    result = execute_run(_run_args(workspace_task_file, environment=None))
+    assert result == 0
+    assert fake_shell.calls[0][3] == default_prefix
+
+
+def test_execute_run_explicit_env_overrides_default(
+    workspace_task_file, fake_shell, env_prefix_stub, tmp_path
+):
+    env_prefix_stub["default"] = tmp_path / ".conda" / "envs" / "default"
+    test_prefix = tmp_path / ".conda" / "envs" / "myenv"
+    env_prefix_stub["myenv"] = test_prefix
+
+    result = execute_run(_run_args(workspace_task_file, environment="myenv"))
+    assert result == 0
+    assert fake_shell.calls[0][3] == test_prefix


### PR DESCRIPTION
Running `ct run <task>` without `-e` would execute in whatever conda environment happened to be active (usually `base`), even when the task was defined in a `conda.toml` that also defines a workspace environment. That's surprising — if you define tasks and environments in the same manifest, the tasks should run in the workspace env by default.

When no `-e` flag is given and the task doesn't declare a `default_environment`, this now falls back to the workspace's `"default"` environment. Applies to both named tasks and ad-hoc commands run via `ct run`. The `-e` flag still takes precedence.

Also refactors `test_run.py` to use a shared `fake_shell` fixture instead of repeating the monkeypatch setup in every test.

Closes #26