### PR TITLE
Unify conda.lock write path with the env exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- Internal refactor of the `conda.lock` write path: `generate_lockfile`
+  now builds `conda.models.environment.Environment` objects and
+  delegates YAML serialisation to the same `multiplatform_export` hook
+  used by `conda export --format=conda-workspaces-lock-v1`, removing
+  the previously duplicated `_build_lockfile_dict` helper.  `conda
+  workspace lock` and `conda export` now produce byte-identical
+  output.
 - Internal refactor of the `conda.lock` read path: ``conda_workspaces.lockfile``
   now owns both the write path and the `CondaEnvironmentSpecifier`
   plugin (`CondaLockLoader`), and delegates YAML -> `Environment`

--- a/conda_workspaces/lockfile.py
+++ b/conda_workspaces/lockfile.py
@@ -30,18 +30,21 @@ The file layout is::
         ...
 
 On the *write* side, :func:`generate_lockfile` solves each environment
-and records the result.  On the *read* side, :func:`install_from_lockfile`
-extracts the package list for one environment + platform via
-:class:`CondaLockLoader` and installs the exact URLs, bypassing the
-solver entirely.
+and delegates YAML serialisation to the ``multiplatform_export`` hook
+in :mod:`.env_export` (the same path ``conda export`` uses), so every
+``conda.lock`` on disk comes out of a single formatter.  On the *read*
+side, :func:`install_from_lockfile` extracts the package list for one
+environment + platform via :class:`CondaLockLoader` and installs the
+exact URLs, bypassing the solver entirely.
 """
 
 from __future__ import annotations
 
+import os
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from conda.common.serialize.yaml import dump as yaml_dump
 from conda.plugins.types import EnvironmentSpecBase
 
 from .exceptions import LockfileNotFoundError, SolveError
@@ -192,47 +195,6 @@ class CondaLockLoader(EnvironmentSpecBase):
         return _rattler_lock_v6_to_env(name=name, platform=platform, **payload)
 
 
-def _build_lockfile_dict(
-    environments: dict[tuple[str, str], list],
-    channels_by_env: dict[str, list[str]],
-) -> dict[str, Any]:
-    """Build the lockfile dict from solved package records.
-
-    *environments* maps ``(env_name, platform)`` pairs to lists of
-    :class:`~conda.models.records.PackageRecord` objects.
-
-    *channels_by_env* maps environment names to ordered channel URLs.
-    """
-    from conda_lockfiles.rattler_lock.v6 import _record_to_dict
-
-    seen_urls: set[str] = set()
-    packages: list[dict[str, Any]] = []
-    envs_dict: dict[str, dict[str, Any]] = {}
-
-    for (env_name, platform), records in sorted(environments.items()):
-        if env_name not in envs_dict:
-            channels = channels_by_env.get(env_name, [])
-            envs_dict[env_name] = {
-                "channels": [{"url": ch} for ch in channels],
-                "packages": {},
-            }
-
-        platform_refs: list[dict[str, str]] = []
-        for pkg in sorted(records, key=lambda p: p.name):
-            platform_refs.append({"conda": pkg.url})
-            if pkg.url not in seen_urls:
-                packages.append(_record_to_dict(pkg))
-                seen_urls.add(pkg.url)
-
-        envs_dict[env_name]["packages"][platform] = platform_refs
-
-    return {
-        "version": LOCKFILE_VERSION,
-        "environments": envs_dict,
-        "packages": packages,
-    }
-
-
 def _solve_for_records(
     ctx: WorkspaceContext,
     resolved: ResolvedEnvironment,
@@ -294,19 +256,20 @@ def generate_lockfile(
 
     Solves each environment in *resolved_envs* and writes the results
     to a single ``conda.lock`` YAML file at the workspace root.
-    Solver output is suppressed to avoid noise since the caller
-    provides its own status messages.
+    Serialisation is delegated to :func:`.env_export.multiplatform_export`
+    so this function and ``conda export --format=conda-workspaces-lock-v1``
+    produce byte-identical output.  Solver output is suppressed to avoid
+    noise since the caller provides its own status messages.
 
     Returns the path to the generated lockfile.
     """
-    import os
-    import sys
-
     from conda.base.context import context as conda_context
+    from conda.models.environment import Environment, EnvironmentConfig
+
+    from .env_export import multiplatform_export
 
     platform = ctx.platform
-    environments: dict[tuple[str, str], list] = {}
-    channels_by_env: dict[str, list[str]] = {}
+    envs: list[Environment] = []
 
     with conda_context._override("quiet", True):
         real_stdout = sys.stdout
@@ -315,17 +278,22 @@ def generate_lockfile(
             sys.stdout = devnull
             for name, resolved in resolved_envs.items():
                 records = _solve_for_records(ctx, resolved)
-                environments[(name, platform)] = records
-                channels_by_env[name] = [str(ch) for ch in resolved.channels]
+                envs.append(
+                    Environment(
+                        name=name,
+                        platform=platform,
+                        config=EnvironmentConfig(
+                            channels=tuple(str(ch) for ch in resolved.channels),
+                        ),
+                        explicit_packages=records,
+                    )
+                )
         finally:
             sys.stdout = real_stdout
             devnull.close()
 
-    data = _build_lockfile_dict(environments, channels_by_env)
-
     path = lockfile_path(ctx)
-    with path.open("w", encoding="utf-8") as fh:
-        yaml_dump(data, fh)
+    path.write_text(multiplatform_export(envs), encoding="utf-8")
     return path
 
 
@@ -363,8 +331,6 @@ def install_from_lockfile(ctx: WorkspaceContext, env_name: str) -> None:
 
     prefix = ctx.env_prefix(env_name)
     prefix.mkdir(parents=True, exist_ok=True)
-
-    import sys
 
     records = get_package_records_from_explicit(urls)
     install_explicit_packages(

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -21,7 +21,6 @@ from conda_workspaces.lockfile import (
     LOCKFILE_NAME,
     LOCKFILE_VERSION,
     CondaLockLoader,
-    _build_lockfile_dict,
     generate_lockfile,
     install_from_lockfile,
     lockfile_path,
@@ -125,45 +124,6 @@ def test_record_to_dict() -> None:
     assert result["md5"] == "def456"
     assert result["size"] == 1024
     assert "depends" not in result
-
-
-def test_build_lockfile_dict() -> None:
-    """_build_lockfile_dict produces the lockfile top-level structure."""
-
-    class FakePkg:
-        def __init__(self, name: str, url: str):
-            self.name = name
-            self.url = url
-            self._data: dict = {}
-
-        def get(self, key, default=None):
-            return self._data.get(key, default)
-
-    pkg_a = FakePkg("numpy", "https://example.com/numpy-1.24.conda")
-    pkg_b = FakePkg("python", "https://example.com/python-3.10.conda")
-    pkg_c = FakePkg("pytest", "https://example.com/pytest-8.0.conda")
-
-    environments = {
-        ("default", "linux-64"): [pkg_a, pkg_b],
-        ("test", "linux-64"): [pkg_a, pkg_b, pkg_c],
-    }
-    channels_by_env = {
-        "default": ["conda-forge"],
-        "test": ["conda-forge"],
-    }
-
-    result = _build_lockfile_dict(environments, channels_by_env)  # type: ignore[arg-type]
-
-    assert result["version"] == LOCKFILE_VERSION
-    assert "default" in result["environments"]
-    assert "test" in result["environments"]
-
-    assert len(result["environments"]["default"]["packages"]["linux-64"]) == 2
-    assert len(result["environments"]["test"]["packages"]["linux-64"]) == 3
-
-    assert len(result["packages"]) == 3
-
-    assert result["environments"]["default"]["channels"] == [{"url": "conda-forge"}]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- `generate_lockfile` now builds `conda.models.environment.Environment` objects from solved records and delegates YAML serialisation to `env_export.multiplatform_export` — the same hook `CondaEnvironmentExporter` already registers for `conda export --format=conda-workspaces-lock-v1`.
- Drops the duplicated `_build_lockfile_dict` helper (and its unit test) in favour of a single formatter.
- `conda workspace lock` and `conda export` now go through identical serialisation code, so both paths produce byte-identical `conda.lock` output.

## Why

`_build_lockfile_dict` and `env_export._envs_to_dict` were doing the same job twice: walk packages, dedupe by URL, bucket per platform, emit the `conda.lock` dict. The env-exporter version already handled multi-named-environments (it keys on `env.name or "default"`), so the write path just needed to hand it `Environment` objects instead of repeating the work.

Net effect: −67 lines, one formatter, no behavioural change on the write path.

## Test plan

- [x] `pixi run --environment test -- python -m pytest` (766 passed, 1 skipped, unchanged)
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI green