### PR TITLE
Seed conservative virtual package baselines for cross-platform solves

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,10 +52,11 @@
   cases: `plugin.py` hooks (loaded on every `conda` invocation),
   `__main__.py` entry point (defers parser setup until invoked),
   `cli/main.py` subcommand dispatch (only the chosen handler is
-  loaded), `context.py` methods (lazy by design to keep plugin load
-  under 1 ms), `lockfile.py` solver helpers inside
-  `_solve_for_records` and `install_from_lockfile` (avoids pulling
-  in heavy solver/envs machinery for lockfile-read operations),
+  loaded),   `context.py` methods (lazy by design to keep plugin load
+  under 1 ms), solver helpers inside
+  `ResolvedEnvironment.solve_for_platform` and
+  `lockfile.install_from_lockfile` (avoids pulling in heavy
+  solver/envs machinery for lockfile-read operations),
   `template.py` where `_get_jinja_env()` lazily imports jinja2,
   `cli/task/run.py` where workspace context is lazily imported for
   environment resolution (tasks work without a workspace),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,9 +52,10 @@
   cases: `plugin.py` hooks (loaded on every `conda` invocation),
   `__main__.py` entry point (defers parser setup until invoked),
   `cli/main.py` subcommand dispatch (only the chosen handler is
-  loaded),   `context.py` methods (lazy by design to keep plugin load
-  under 1 ms), solver helpers inside
-  `ResolvedEnvironment.solve_for_platform` and
+  loaded), `context.py` methods (lazy by design to keep plugin load
+  under 1 ms), solver and virtual-package helpers inside
+  `ResolvedEnvironment` (`solve_for_platform`,
+  `virtual_package_overrides`, `scoped_virtual_packages`) and
   `lockfile.install_from_lockfile` (avoids pulling in heavy
   solver/envs machinery for lockfile-read operations),
   `template.py` where `_get_jinja_env()` lazily imports jinja2,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- Cross-platform solves now seed conservative virtual package
+  baselines when the host cannot detect them, mirroring rattler's
+  `VirtualPackages::detect_for_platform`. Solving `linux-64` from
+  macOS (or any other non-native target) sets `CONDA_OVERRIDE_GLIBC`
+  to `2.17` for the duration of the solve; `osx-arm64` cross-compiles
+  get `CONDA_OVERRIDE_OSX=11.0`, `osx-64` gets `10.15`, and `win-*`
+  targets get `CONDA_OVERRIDE_WIN=0`. Native solves are unchanged.
+  Explicit `CONDA_OVERRIDE_*` values stay authoritative, and a
+  `[system-requirements]` entry for the same virtual package is
+  promoted into the baseline override so the spec and the record
+  agree on the version. `__cuda` and `__archspec` are never
+  auto-baselined — declare them in `[system-requirements]` or via
+  `CONDA_OVERRIDE_*` when you need them.
 - `conda workspace lock` now writes a single `conda.lock` that covers
   every platform declared by each environment, not just the host
   platform. Target-platform solves run with `context._subdir`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -403,7 +403,7 @@ Users can still influence virtual packages through the usual channels:
 Cross-compiled targets (e.g. solving `linux-64` from macOS) get a
 conservative baseline for virtual packages the host cannot detect,
 mirroring `rattler_virtual_packages::VirtualPackages::detect_for_platform`:
-`ResolvedEnvironment.baseline_virtual_package_env` seeds `CONDA_OVERRIDE_GLIBC`
+`ResolvedEnvironment.virtual_package_overrides` seeds `CONDA_OVERRIDE_GLIBC`
 (`2.17` for non-native `linux-*`), `CONDA_OVERRIDE_OSX`
 (`11.0` for `osx-arm64`, `10.15` for `osx-64`), and
 `CONDA_OVERRIDE_WIN` (`0`) for the duration of the solve. User knobs

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -403,7 +403,7 @@ Users can still influence virtual packages through the usual channels:
 Cross-compiled targets (e.g. solving `linux-64` from macOS) get a
 conservative baseline for virtual packages the host cannot detect,
 mirroring `rattler_virtual_packages::VirtualPackages::detect_for_platform`:
-`lockfile._baseline_virtual_package_env` seeds `CONDA_OVERRIDE_GLIBC`
+`ResolvedEnvironment.baseline_virtual_package_env` seeds `CONDA_OVERRIDE_GLIBC`
 (`2.17` for non-native `linux-*`), `CONDA_OVERRIDE_OSX`
 (`11.0` for `osx-arm64`, `10.15` for `osx-64`), and
 `CONDA_OVERRIDE_WIN` (`0`) for the duration of the solve. User knobs

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -367,16 +367,13 @@ conda-workspaces is installed.
 - **Multi-package workspaces**: Support monorepo layouts where
   subdirectories are independent packages that can depend on each other
   (pixi's `[package]` concept, reimagined for conda-build).
-- **Virtual package defaults for cross-compiled targets**: `pixi`
-  ships conservative baseline versions for virtual packages that
-  cannot be detected on the host machine (e.g. solving `linux-64`
-  from macOS returns a baseline `__glibc` version so `glibc`-gated
-  packages still resolve). `conda-workspaces` currently relies on
-  conda's own virtual package plugins, which gate on the target
-  subdir, plus the `CONDA_OVERRIDE_*` environment variables and the
-  manifest `[system-requirements]` table. Porting pixi/rattler's
-  conservative defaults to Python would remove the need for users to
-  pin these explicitly when cross-compiling.
+- **Upstream a cross-target virtual package helper in conda**: the
+  baseline defaults `conda-workspaces` applies when cross-compiling
+  (see "Lockfile generation" below) duplicate logic from
+  `rattler_virtual_packages::VirtualPackages::detect_for_platform`.
+  A shared `context.virtual_packages_for_target(subdir)` helper in
+  conda itself would let every downstream lockfile/exporter reuse
+  the same baselines without re-implementing them.
 
 ## Lockfile generation
 
@@ -402,6 +399,20 @@ Users can still influence virtual packages through the usual channels:
   `envs._apply_system_requirements`).
 - `CONDA_OVERRIDE_*` environment variables are honoured because they
   flow through `context._override_virtual_packages` untouched.
+
+Cross-compiled targets (e.g. solving `linux-64` from macOS) get a
+conservative baseline for virtual packages the host cannot detect,
+mirroring `rattler_virtual_packages::VirtualPackages::detect_for_platform`:
+`lockfile._baseline_virtual_package_env` seeds `CONDA_OVERRIDE_GLIBC`
+(`2.17` for non-native `linux-*`), `CONDA_OVERRIDE_OSX`
+(`11.0` for `osx-arm64`, `10.15` for `osx-64`), and
+`CONDA_OVERRIDE_WIN` (`0`) for the duration of the solve. User knobs
+win: an explicit `CONDA_OVERRIDE_*` in the environment is preserved,
+and a `[system-requirements]` entry for the same virtual package is
+lifted into the baseline override so the record that populates and
+the spec that checks agree on the version. `__cuda` and `__archspec`
+are never auto-baselined — callers who need them must opt in via
+`[system-requirements]` or `CONDA_OVERRIDE_*`.
 
 Cross-platform solves are fail-fast: the first unsatisfiable
 `(environment, platform)` pair raises `SolveError` with the platform

--- a/conda_workspaces/lockfile.py
+++ b/conda_workspaces/lockfile.py
@@ -213,7 +213,7 @@ def _solve_for_records(
     cross-platform virtual package set.
 
     On cross-compiled targets the host cannot detect libc/kernel/macOS
-    versions, so :meth:`ResolvedEnvironment.scoped_solver_env` seeds
+    versions, so :meth:`ResolvedEnvironment.scoped_virtual_packages` seeds
     conservative ``CONDA_OVERRIDE_*`` defaults for the duration of the
     solve.  User knobs stay authoritative: explicit ``CONDA_OVERRIDE_*``
     env vars are left untouched, and ``[system-requirements]`` versions
@@ -257,7 +257,7 @@ def _solve_for_records(
     # the caller is the only thing the user sees.  Any captured output
     # is discarded; diagnostics survive via ``SolveError(str(exc))``.
     with (
-        resolved.scoped_solver_env(platform),
+        resolved.scoped_virtual_packages(platform),
         _channel_priority_override(resolved.channel_priority),
         conda_context._override("_subdir", platform),
         conda_context._override("quiet", True),

--- a/conda_workspaces/lockfile.py
+++ b/conda_workspaces/lockfile.py
@@ -192,90 +192,6 @@ class CondaLockLoader(EnvironmentSpecBase):
         return environments[name]
 
 
-def _solve_for_records(
-    ctx: WorkspaceContext,
-    resolved: ResolvedEnvironment,
-    platform: str,
-) -> list:
-    """Solve an environment for *platform* and return package records.
-
-    Uses conda's solver API to resolve dependencies without installing,
-    producing the list of exact packages that would be installed.
-    Applies the same transformations as ``install_environment``:
-    PyPI deps are translated and merged, system requirements are added
-    as virtual package constraints, and channel priority is honoured.
-
-    The solver is targeted at *platform* by (a) constructing it with
-    ``subdirs=(platform, "noarch")`` and (b) overriding
-    ``context._subdir`` for the duration of the solve.  Conda's virtual
-    package plugins (``__linux``, ``__osx``, ``__win``) gate on
-    ``context.subdir``, so this single override also yields the correct
-    cross-platform virtual package set.
-
-    On cross-compiled targets the host cannot detect libc/kernel/macOS
-    versions, so :meth:`ResolvedEnvironment.scoped_virtual_packages` seeds
-    conservative ``CONDA_OVERRIDE_*`` defaults for the duration of the
-    solve.  User knobs stay authoritative: explicit ``CONDA_OVERRIDE_*``
-    env vars are left untouched, and ``[system-requirements]`` versions
-    are lifted into the override so ``__glibc >=2.28`` in the manifest
-    and the baseline record agree.
-    """
-    from conda.base.context import context as conda_context
-    from conda.common.io import captured
-    from conda.exceptions import UnsatisfiableError
-    from conda.models.match_spec import MatchSpec
-
-    from .envs import (
-        _apply_system_requirements,
-        _build_pypi_specs,
-        _channel_priority_override,
-    )
-
-    specs = [
-        MatchSpec(dep.conda_build_form())
-        for dep in resolved.conda_dependencies.values()
-    ]
-
-    specs.extend(_build_pypi_specs(resolved))
-    _apply_system_requirements(resolved, specs)
-
-    if not specs:
-        return []
-
-    solver_backend = conda_context.plugin_manager.get_cached_solver_backend()
-    if solver_backend is None:
-        raise SolveError(resolved.name, "No solver backend found", platform=platform)
-
-    prefix = str(ctx.env_prefix(resolved.name))
-    subdirs = (platform, "noarch")
-
-    # The solver unconditionally prints ``Collecting package metadata``
-    # and ``Solving environment`` status lines through conda's reporter
-    # plugin (even when ``context.quiet`` is set — ``QuietSpinner``
-    # still writes to stdout).  Route stdout and stderr through
-    # ``conda.common.io.captured`` so the Rich progress rendered by
-    # the caller is the only thing the user sees.  Any captured output
-    # is discarded; diagnostics survive via ``SolveError(str(exc))``.
-    with (
-        resolved.scoped_virtual_packages(platform),
-        _channel_priority_override(resolved.channel_priority),
-        conda_context._override("_subdir", platform),
-        conda_context._override("quiet", True),
-        captured(),
-    ):
-        solver = solver_backend(
-            prefix,
-            list(resolved.channels),
-            subdirs,
-            specs_to_add=specs,
-        )
-
-        try:
-            return list(solver.solve_final_state())
-        except (UnsatisfiableError, SystemExit) as exc:
-            raise SolveError(resolved.name, str(exc), platform=platform) from exc
-
-
 def generate_lockfile(
     ctx: WorkspaceContext,
     resolved_envs: dict[str, ResolvedEnvironment],
@@ -293,9 +209,9 @@ def generate_lockfile(
     to :func:`.env_export.multiplatform_export` so this function and
     ``conda export --format=conda-workspaces-lock-v1`` produce
     byte-identical output.  Solver chatter is silenced inside
-    :func:`_solve_for_records` itself, so the caller is free to render
-    status through the optional *progress* callback without stdout
-    bookkeeping.
+    :meth:`ResolvedEnvironment.solve_for_platform` itself, so the
+    caller is free to render status through the optional *progress*
+    callback without stdout bookkeeping.
 
     Fails fast by default: the first unsolvable ``(environment,
     platform)`` pair raises :class:`SolveError` with the platform
@@ -329,7 +245,9 @@ def generate_lockfile(
             if progress is not None:
                 progress(name, target)
             try:
-                records = _solve_for_records(ctx, resolved, target)
+                records = resolved.solve_for_platform(
+                    target, prefix=ctx.env_prefix(resolved.name)
+                )
             except SolveError as exc:
                 if not skip_unsolvable:
                     raise

--- a/conda_workspaces/lockfile.py
+++ b/conda_workspaces/lockfile.py
@@ -40,9 +40,7 @@ exact URLs, bypassing the solver entirely.
 
 from __future__ import annotations
 
-import os
 import sys
-from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -51,7 +49,7 @@ from conda.plugins.types import EnvironmentSpecBase
 from .exceptions import AllTargetsUnsolvableError, LockfileNotFoundError, SolveError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Callable
     from typing import Any, ClassVar, Final
 
     from conda.common.path import PathType
@@ -194,101 +192,6 @@ class CondaLockLoader(EnvironmentSpecBase):
         return environments[name]
 
 
-def _baseline_virtual_package_env(
-    platform: str,
-    system_requirements: dict[str, str] | None = None,
-) -> dict[str, str]:
-    """Return ``CONDA_OVERRIDE_*`` env vars that enable cross-platform solves.
-
-    Mirrors ``rattler_virtual_packages::VirtualPackages::detect_for_platform``
-    from ``rattler``: when we solve for a target that the *host* cannot
-    detect a virtual package for (e.g. ``linux-64`` from macOS emits
-    no ``__glibc`` record), inject conservative defaults so packages
-    gated on those virtuals remain resolvable out of the box.
-
-    Precedence (highest to lowest):
-
-    1. ``CONDA_OVERRIDE_*`` already present in :data:`os.environ` — the
-       user is explicitly in charge and this helper returns an empty
-       string for that key, leaving the existing value untouched.
-    2. ``[system-requirements]`` declared in the manifest for the same
-       virtual package (e.g. ``glibc = "2.28"``) — used as the override
-       so the virtual package record lines up with the spec constraint
-       :mod:`conda_workspaces.envs._apply_system_requirements` appends.
-    3. A conservative built-in baseline (``__glibc == 2.17`` for any
-       non-native linux target, ``__osx >= 10.15`` / ``>= 11.0`` for
-       ``osx-64`` / ``osx-arm64`` cross-compiles, presence-only
-       ``__win`` for win targets).
-
-    ``__cuda`` and ``__archspec`` are *not* seeded — the caller must
-    opt in via ``[system-requirements]`` or ``CONDA_OVERRIDE_*`` if
-    they want those available.  Native solves (target family matches
-    host family) return an empty mapping so byte-for-byte output stays
-    unchanged.
-    """
-    from conda.base.context import context as conda_context
-
-    def family(subdir: str) -> str:
-        return next(
-            (fam for fam in ("linux", "osx", "win") if subdir.startswith(f"{fam}-")),
-            "",
-        )
-
-    target_family = family(platform)
-    if not target_family or family(conda_context.subdir) == target_family:
-        return {}
-
-    system_requirements = system_requirements or {}
-
-    def req_version(name: str) -> str | None:
-        """Look up a ``[system-requirements]`` entry by bare or ``__`` name."""
-        return system_requirements.get(name) or system_requirements.get(f"__{name}")
-
-    baseline: dict[str, str] = {}
-    if target_family == "linux":
-        baseline["CONDA_OVERRIDE_GLIBC"] = req_version("glibc") or "2.17"
-    elif target_family == "osx":
-        default = "11.0" if platform == "osx-arm64" else "10.15"
-        baseline["CONDA_OVERRIDE_OSX"] = req_version("osx") or default
-    elif target_family == "win":
-        baseline["CONDA_OVERRIDE_WIN"] = req_version("win") or "0"
-
-    # Defer to whatever the user already exported — they are the
-    # authoritative knob.  TODO(conda/conda#15XXX): upstream a
-    # ``context.virtual_packages_for_target(subdir)`` helper that
-    # does this centrally; for now each consumer re-implements the
-    # mapping.
-    return {k: v for k, v in baseline.items() if k not in os.environ}
-
-
-@contextmanager
-def _apply_env_overrides(overrides: dict[str, str]) -> Iterator[None]:
-    """Temporarily set environment variables, restoring them on exit.
-
-    Conda deprecated :func:`conda.common.io.env_vars` and its siblings
-    in 26.9 (removal targeted for 27.3) and recommends
-    ``monkeypatch.setenv`` / ``monkeypatch.delenv`` as replacements —
-    but only for tests.  This production path needs to scope
-    ``CONDA_OVERRIDE_*`` overrides around a solver call, for which
-    upstream does not ship a drop-in replacement, so we keep a small
-    local context manager until conda exposes one (tracked in
-    ``conda/conda#14095`` / PR ``conda/conda#15728``).
-    """
-    if not overrides:
-        yield
-        return
-    saved: dict[str, str | None] = {name: os.environ.get(name) for name in overrides}
-    os.environ.update(overrides)
-    try:
-        yield
-    finally:
-        for name, previous in saved.items():
-            if previous is None:
-                os.environ.pop(name, None)
-            else:
-                os.environ[name] = previous
-
-
 def _solve_for_records(
     ctx: WorkspaceContext,
     resolved: ResolvedEnvironment,
@@ -310,12 +213,12 @@ def _solve_for_records(
     cross-platform virtual package set.
 
     On cross-compiled targets the host cannot detect libc/kernel/macOS
-    versions, so :func:`_baseline_virtual_package_env` seeds conservative
-    ``CONDA_OVERRIDE_*`` defaults for the duration of the solve.  User
-    knobs stay authoritative: explicit ``CONDA_OVERRIDE_*`` env vars are
-    left untouched, and ``[system-requirements]`` versions are lifted
-    into the override so ``__glibc >=2.28`` in the manifest and the
-    baseline record agree.
+    versions, so :meth:`ResolvedEnvironment.scoped_solver_env` seeds
+    conservative ``CONDA_OVERRIDE_*`` defaults for the duration of the
+    solve.  User knobs stay authoritative: explicit ``CONDA_OVERRIDE_*``
+    env vars are left untouched, and ``[system-requirements]`` versions
+    are lifted into the override so ``__glibc >=2.28`` in the manifest
+    and the baseline record agree.
     """
     from conda.base.context import context as conda_context
     from conda.common.io import captured
@@ -346,8 +249,6 @@ def _solve_for_records(
     prefix = str(ctx.env_prefix(resolved.name))
     subdirs = (platform, "noarch")
 
-    baseline_env = _baseline_virtual_package_env(platform, resolved.system_requirements)
-
     # The solver unconditionally prints ``Collecting package metadata``
     # and ``Solving environment`` status lines through conda's reporter
     # plugin (even when ``context.quiet`` is set — ``QuietSpinner``
@@ -356,7 +257,7 @@ def _solve_for_records(
     # the caller is the only thing the user sees.  Any captured output
     # is discarded; diagnostics survive via ``SolveError(str(exc))``.
     with (
-        _apply_env_overrides(baseline_env),
+        resolved.scoped_solver_env(platform),
         _channel_priority_override(resolved.channel_priority),
         conda_context._override("_subdir", platform),
         conda_context._override("quiet", True),

--- a/conda_workspaces/lockfile.py
+++ b/conda_workspaces/lockfile.py
@@ -40,7 +40,9 @@ exact URLs, bypassing the solver entirely.
 
 from __future__ import annotations
 
+import os
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -49,7 +51,7 @@ from conda.plugins.types import EnvironmentSpecBase
 from .exceptions import AllTargetsUnsolvableError, LockfileNotFoundError, SolveError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
     from typing import Any, ClassVar, Final
 
     from conda.common.path import PathType
@@ -192,6 +194,101 @@ class CondaLockLoader(EnvironmentSpecBase):
         return environments[name]
 
 
+def _baseline_virtual_package_env(
+    platform: str,
+    system_requirements: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Return ``CONDA_OVERRIDE_*`` env vars that enable cross-platform solves.
+
+    Mirrors ``rattler_virtual_packages::VirtualPackages::detect_for_platform``
+    from ``rattler``: when we solve for a target that the *host* cannot
+    detect a virtual package for (e.g. ``linux-64`` from macOS emits
+    no ``__glibc`` record), inject conservative defaults so packages
+    gated on those virtuals remain resolvable out of the box.
+
+    Precedence (highest to lowest):
+
+    1. ``CONDA_OVERRIDE_*`` already present in :data:`os.environ` — the
+       user is explicitly in charge and this helper returns an empty
+       string for that key, leaving the existing value untouched.
+    2. ``[system-requirements]`` declared in the manifest for the same
+       virtual package (e.g. ``glibc = "2.28"``) — used as the override
+       so the virtual package record lines up with the spec constraint
+       :mod:`conda_workspaces.envs._apply_system_requirements` appends.
+    3. A conservative built-in baseline (``__glibc == 2.17`` for any
+       non-native linux target, ``__osx >= 10.15`` / ``>= 11.0`` for
+       ``osx-64`` / ``osx-arm64`` cross-compiles, presence-only
+       ``__win`` for win targets).
+
+    ``__cuda`` and ``__archspec`` are *not* seeded — the caller must
+    opt in via ``[system-requirements]`` or ``CONDA_OVERRIDE_*`` if
+    they want those available.  Native solves (target family matches
+    host family) return an empty mapping so byte-for-byte output stays
+    unchanged.
+    """
+    from conda.base.context import context as conda_context
+
+    def family(subdir: str) -> str:
+        return next(
+            (fam for fam in ("linux", "osx", "win") if subdir.startswith(f"{fam}-")),
+            "",
+        )
+
+    target_family = family(platform)
+    if not target_family or family(conda_context.subdir) == target_family:
+        return {}
+
+    system_requirements = system_requirements or {}
+
+    def req_version(name: str) -> str | None:
+        """Look up a ``[system-requirements]`` entry by bare or ``__`` name."""
+        return system_requirements.get(name) or system_requirements.get(f"__{name}")
+
+    baseline: dict[str, str] = {}
+    if target_family == "linux":
+        baseline["CONDA_OVERRIDE_GLIBC"] = req_version("glibc") or "2.17"
+    elif target_family == "osx":
+        default = "11.0" if platform == "osx-arm64" else "10.15"
+        baseline["CONDA_OVERRIDE_OSX"] = req_version("osx") or default
+    elif target_family == "win":
+        baseline["CONDA_OVERRIDE_WIN"] = req_version("win") or "0"
+
+    # Defer to whatever the user already exported — they are the
+    # authoritative knob.  TODO(conda/conda#15XXX): upstream a
+    # ``context.virtual_packages_for_target(subdir)`` helper that
+    # does this centrally; for now each consumer re-implements the
+    # mapping.
+    return {k: v for k, v in baseline.items() if k not in os.environ}
+
+
+@contextmanager
+def _apply_env_overrides(overrides: dict[str, str]) -> Iterator[None]:
+    """Temporarily set environment variables, restoring them on exit.
+
+    Conda deprecated :func:`conda.common.io.env_vars` and its siblings
+    in 26.9 (removal targeted for 27.3) and recommends
+    ``monkeypatch.setenv`` / ``monkeypatch.delenv`` as replacements —
+    but only for tests.  This production path needs to scope
+    ``CONDA_OVERRIDE_*`` overrides around a solver call, for which
+    upstream does not ship a drop-in replacement, so we keep a small
+    local context manager until conda exposes one (tracked in
+    ``conda/conda#14095`` / PR ``conda/conda#15728``).
+    """
+    if not overrides:
+        yield
+        return
+    saved: dict[str, str | None] = {name: os.environ.get(name) for name in overrides}
+    os.environ.update(overrides)
+    try:
+        yield
+    finally:
+        for name, previous in saved.items():
+            if previous is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = previous
+
+
 def _solve_for_records(
     ctx: WorkspaceContext,
     resolved: ResolvedEnvironment,
@@ -210,10 +307,15 @@ def _solve_for_records(
     ``context._subdir`` for the duration of the solve.  Conda's virtual
     package plugins (``__linux``, ``__osx``, ``__win``) gate on
     ``context.subdir``, so this single override also yields the correct
-    cross-platform virtual package set.  Users can still tighten or
-    relax those via ``[system-requirements]`` in the manifest and the
-    ``CONDA_OVERRIDE_*`` environment variables, both of which continue
-    to flow through the normal code paths.
+    cross-platform virtual package set.
+
+    On cross-compiled targets the host cannot detect libc/kernel/macOS
+    versions, so :func:`_baseline_virtual_package_env` seeds conservative
+    ``CONDA_OVERRIDE_*`` defaults for the duration of the solve.  User
+    knobs stay authoritative: explicit ``CONDA_OVERRIDE_*`` env vars are
+    left untouched, and ``[system-requirements]`` versions are lifted
+    into the override so ``__glibc >=2.28`` in the manifest and the
+    baseline record agree.
     """
     from conda.base.context import context as conda_context
     from conda.common.io import captured
@@ -244,6 +346,8 @@ def _solve_for_records(
     prefix = str(ctx.env_prefix(resolved.name))
     subdirs = (platform, "noarch")
 
+    baseline_env = _baseline_virtual_package_env(platform, resolved.system_requirements)
+
     # The solver unconditionally prints ``Collecting package metadata``
     # and ``Solving environment`` status lines through conda's reporter
     # plugin (even when ``context.quiet`` is set — ``QuietSpinner``
@@ -252,6 +356,7 @@ def _solve_for_records(
     # the caller is the only thing the user sees.  Any captured output
     # is discarded; diagnostics survive via ``SolveError(str(exc))``.
     with (
+        _apply_env_overrides(baseline_env),
         _channel_priority_override(resolved.channel_priority),
         conda_context._override("_subdir", platform),
         conda_context._override("quiet", True),

--- a/conda_workspaces/resolver.py
+++ b/conda_workspaces/resolver.py
@@ -19,6 +19,9 @@ from .exceptions import (
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
+    from pathlib import Path
+
+    from conda.models.records import PackageRecord
 
     from .models import Channel, MatchSpec, PyPIDependency, WorkspaceConfig
 
@@ -130,6 +133,102 @@ class ResolvedEnvironment:
                     os.environ.pop(name, None)
                 else:
                     os.environ[name] = previous
+
+    def solve_for_platform(
+        self,
+        platform: str,
+        *,
+        prefix: str | Path,
+    ) -> list[PackageRecord]:
+        """Solve this environment for *platform* and return package records.
+
+        Uses conda's solver API to resolve dependencies without
+        installing, producing the list of exact packages that would be
+        installed.  Applies the same transformations as
+        :func:`conda_workspaces.envs.install_environment`: PyPI deps
+        are translated and merged, system requirements are added as
+        virtual package constraints, and channel priority is honoured.
+
+        The solver is targeted at *platform* by (a) constructing it
+        with ``subdirs=(platform, "noarch")`` and (b) overriding
+        ``context._subdir`` for the duration of the solve.  Conda's
+        virtual package plugins (``__linux``, ``__osx``, ``__win``)
+        gate on ``context.subdir``, so this single override also
+        yields the correct cross-platform virtual package set.
+
+        On cross-compiled targets the host cannot detect
+        libc/kernel/macOS versions, so
+        :meth:`scoped_virtual_packages` seeds conservative
+        ``CONDA_OVERRIDE_*`` defaults for the duration of the solve.
+        User knobs stay authoritative: explicit ``CONDA_OVERRIDE_*``
+        env vars are left untouched, and ``[system-requirements]``
+        versions are lifted into the override so ``__glibc >=2.28``
+        in the manifest and the baseline record agree.
+
+        *prefix* is the environment prefix path the solver should
+        target — workspace-owned, so callers that run under a
+        :class:`~conda_workspaces.context.WorkspaceContext` pass
+        ``ctx.env_prefix(resolved.name)``.
+
+        Raises :class:`~conda_workspaces.exceptions.SolveError` when
+        the solver cannot satisfy the specs or no backend is
+        registered.
+        """
+        from conda.base.context import context as conda_context
+        from conda.common.io import captured
+        from conda.exceptions import UnsatisfiableError
+        from conda.models.match_spec import MatchSpec as CondaMatchSpec
+
+        from .envs import (
+            _apply_system_requirements,
+            _build_pypi_specs,
+            _channel_priority_override,
+        )
+        from .exceptions import SolveError
+
+        specs = [
+            CondaMatchSpec(dep.conda_build_form())
+            for dep in self.conda_dependencies.values()
+        ]
+
+        specs.extend(_build_pypi_specs(self))
+        _apply_system_requirements(self, specs)
+
+        if not specs:
+            return []
+
+        solver_backend = conda_context.plugin_manager.get_cached_solver_backend()
+        if solver_backend is None:
+            raise SolveError(self.name, "No solver backend found", platform=platform)
+
+        subdirs = (platform, "noarch")
+
+        # The solver unconditionally prints ``Collecting package
+        # metadata`` and ``Solving environment`` status lines through
+        # conda's reporter plugin (even when ``context.quiet`` is set
+        # — ``QuietSpinner`` still writes to stdout).  Route stdout
+        # and stderr through ``conda.common.io.captured`` so the Rich
+        # progress rendered by the caller is the only thing the user
+        # sees.  Any captured output is discarded; diagnostics survive
+        # via ``SolveError(str(exc))``.
+        with (
+            self.scoped_virtual_packages(platform),
+            _channel_priority_override(self.channel_priority),
+            conda_context._override("_subdir", platform),
+            conda_context._override("quiet", True),
+            captured(),
+        ):
+            solver = solver_backend(
+                str(prefix),
+                list(self.channels),
+                subdirs,
+                specs_to_add=specs,
+            )
+
+            try:
+                return list(solver.solve_final_state())
+            except (UnsatisfiableError, SystemExit) as exc:
+                raise SolveError(self.name, str(exc), platform=platform) from exc
 
 
 def resolve_environment(

--- a/conda_workspaces/resolver.py
+++ b/conda_workspaces/resolver.py
@@ -43,7 +43,7 @@ class ResolvedEnvironment:
     system_requirements: dict[str, str] = field(default_factory=dict)
     channel_priority: str | None = None
 
-    def baseline_virtual_package_env(self, platform: str) -> dict[str, str]:
+    def virtual_package_overrides(self, platform: str) -> dict[str, str]:
         """Return ``CONDA_OVERRIDE_*`` env vars that enable a cross-platform solve.
 
         Mirrors ``rattler_virtual_packages::VirtualPackages::detect_for_platform``
@@ -102,8 +102,8 @@ class ResolvedEnvironment:
         return {k: v for k, v in baseline.items() if k not in os.environ}
 
     @contextmanager
-    def scoped_solver_env(self, platform: str) -> Iterator[None]:
-        """Scope :meth:`baseline_virtual_package_env` around a solver call.
+    def scoped_virtual_packages(self, platform: str) -> Iterator[None]:
+        """Scope :meth:`virtual_package_overrides` around a solver call.
 
         Conda deprecated :func:`conda.common.io.env_vars` and its siblings
         in 26.9 (removal targeted for 27.3) and recommends
@@ -114,7 +114,7 @@ class ResolvedEnvironment:
         local context manager until conda exposes one (tracked in
         ``conda/conda#14095`` / PR ``conda/conda#15728``).
         """
-        overrides = self.baseline_virtual_package_env(platform)
+        overrides = self.virtual_package_overrides(platform)
         if not overrides:
             yield
             return

--- a/conda_workspaces/resolver.py
+++ b/conda_workspaces/resolver.py
@@ -8,6 +8,8 @@ constituent features.
 from __future__ import annotations
 
 import logging
+import os
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -16,7 +18,7 @@ from .exceptions import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator
 
     from .models import Channel, MatchSpec, PyPIDependency, WorkspaceConfig
 
@@ -40,6 +42,94 @@ class ResolvedEnvironment:
     activation_env: dict[str, str] = field(default_factory=dict)
     system_requirements: dict[str, str] = field(default_factory=dict)
     channel_priority: str | None = None
+
+    def baseline_virtual_package_env(self, platform: str) -> dict[str, str]:
+        """Return ``CONDA_OVERRIDE_*`` env vars that enable a cross-platform solve.
+
+        Mirrors ``rattler_virtual_packages::VirtualPackages::detect_for_platform``
+        from ``rattler``: when we solve for a target that the *host* cannot
+        detect a virtual package for (e.g. ``linux-64`` from macOS emits
+        no ``__glibc`` record), inject conservative defaults so packages
+        gated on those virtuals remain resolvable out of the box.
+
+        Precedence (highest to lowest):
+
+        1. ``CONDA_OVERRIDE_*`` already present in :data:`os.environ` — the
+           user is explicitly in charge and this helper returns no entry
+           for that key, leaving the existing value untouched.
+        2. ``[system-requirements]`` declared in the manifest for the same
+           virtual package (e.g. ``glibc = "2.28"``) — used as the override
+           so the virtual package record lines up with the spec constraint
+           :mod:`conda_workspaces.envs._apply_system_requirements` appends.
+        3. A conservative built-in baseline (``__glibc == 2.17`` for any
+           non-native linux target, ``__osx >= 10.15`` / ``>= 11.0`` for
+           ``osx-64`` / ``osx-arm64`` cross-compiles, presence-only
+           ``__win`` for win targets).
+
+        ``__cuda`` and ``__archspec`` are *not* seeded — the caller must
+        opt in via ``[system-requirements]`` or ``CONDA_OVERRIDE_*`` if
+        they want those available.  Native solves (target family matches
+        host family) return an empty mapping so byte-for-byte output stays
+        unchanged.
+        """
+        from conda.base.context import context as conda_context
+
+        def family(subdir: str) -> str:
+            for fam in ("linux", "osx", "win"):
+                if subdir.startswith(f"{fam}-"):
+                    return fam
+            return ""
+
+        target_family = family(platform)
+        if not target_family or family(conda_context.subdir) == target_family:
+            return {}
+
+        def req_version(name: str) -> str | None:
+            """Look up a ``[system-requirements]`` entry by bare or ``__`` name."""
+            return self.system_requirements.get(name) or self.system_requirements.get(
+                f"__{name}"
+            )
+
+        baseline: dict[str, str] = {}
+        if target_family == "linux":
+            baseline["CONDA_OVERRIDE_GLIBC"] = req_version("glibc") or "2.17"
+        elif target_family == "osx":
+            default = "11.0" if platform == "osx-arm64" else "10.15"
+            baseline["CONDA_OVERRIDE_OSX"] = req_version("osx") or default
+        elif target_family == "win":
+            baseline["CONDA_OVERRIDE_WIN"] = req_version("win") or "0"
+
+        return {k: v for k, v in baseline.items() if k not in os.environ}
+
+    @contextmanager
+    def scoped_solver_env(self, platform: str) -> Iterator[None]:
+        """Scope :meth:`baseline_virtual_package_env` around a solver call.
+
+        Conda deprecated :func:`conda.common.io.env_vars` and its siblings
+        in 26.9 (removal targeted for 27.3) and recommends
+        ``monkeypatch.setenv`` / ``monkeypatch.delenv`` as replacements —
+        but those are test-only.  This production path needs to scope
+        ``CONDA_OVERRIDE_*`` overrides around a solver call, for which
+        upstream does not ship a drop-in replacement, so we keep a small
+        local context manager until conda exposes one (tracked in
+        ``conda/conda#14095`` / PR ``conda/conda#15728``).
+        """
+        overrides = self.baseline_virtual_package_env(platform)
+        if not overrides:
+            yield
+            return
+        saved: dict[str, str | None] = {
+            name: os.environ.get(name) for name in overrides
+        }
+        os.environ.update(overrides)
+        try:
+            yield
+        finally:
+            for name, previous in saved.items():
+                if previous is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = previous
 
 
 def resolve_environment(

--- a/docs/tutorials/coming-from/pixi.md
+++ b/docs/tutorials/coming-from/pixi.md
@@ -159,14 +159,17 @@ conda task export --file pixi.toml -o conda.toml
 conda's `context._subdir` at the target so `__linux` / `__osx` /
 `__win` virtual packages line up with the target platform.
 
-One difference to keep in mind: pixi (via rattler) ships conservative
-baseline versions for virtual packages that the host machine can't
-detect — e.g. solving `linux-64` from macOS still picks up a baseline
-`__glibc` so `glibc`-gated packages resolve. conda-workspaces relies
-on conda's own virtual package plugins, which only emit entries the
-host can detect. Fill in the blanks with either `CONDA_OVERRIDE_*`
-environment variables or an explicit `[system-requirements]` table in
-the manifest:
+Conservative virtual package baselines are applied automatically:
+solving `linux-64` from macOS seeds `CONDA_OVERRIDE_GLIBC=2.17` for
+the solve, `osx-arm64` targets get `CONDA_OVERRIDE_OSX=11.0`, `osx-64`
+gets `10.15`, and `win-*` targets get a `CONDA_OVERRIDE_WIN=0`
+presence marker. This mirrors rattler's
+`VirtualPackages::detect_for_platform`, so most cross-compiles resolve
+out of the box without any manifest changes.
+
+Explicit knobs still win when you need them. Either export a
+`CONDA_OVERRIDE_*` environment variable or pin the minimum in
+`[system-requirements]`:
 
 ```toml
 [system-requirements]
@@ -174,8 +177,12 @@ glibc = "2.28"
 cuda = "12.0"
 ```
 
-Both settings are also honoured by `pixi`, so this is compatible
-either way.
+A `[system-requirements]` version is lifted into the baseline
+override so the solver's `__<pkg> >=<version>` spec and the virtual
+package record it matches against agree. `__cuda` and `__archspec`
+are *not* auto-seeded — opt in via `[system-requirements]` or
+`CONDA_OVERRIDE_*` when you need them. Every setting here is also
+honoured by `pixi`.
 
 ## What's not supported
 
@@ -186,9 +193,6 @@ Some pixi-only concepts don't apply to conda-workspaces:
 - `deno_task_shell` — conda-workspaces uses native platform shells
 - `solve-group` — accepted for compatibility but has no effect (conda's
   solver operates on a single environment at a time)
-- pixi's built-in conservative virtual package defaults for
-  cross-compiled targets — pin minimums via `[system-requirements]`
-  or `CONDA_OVERRIDE_*` instead (tracked in [DESIGN.md](https://github.com/conda-incubator/conda-workspaces/blob/main/DESIGN.md) under "Future Work")
 
 See [DESIGN.md](https://github.com/conda-incubator/conda-workspaces/blob/main/DESIGN.md)
 for the full compatibility mapping.

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import pytest
@@ -10,6 +11,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
+from conda.base.context import context as conda_context
+from conda.models.match_spec import MatchSpec
 from conda_lockfiles.rattler_lock.v6 import _record_to_dict
 
 from conda_workspaces.context import WorkspaceContext
@@ -21,6 +24,7 @@ from conda_workspaces.lockfile import (
     LOCKFILE_NAME,
     LOCKFILE_VERSION,
     CondaLockLoader,
+    _solve_for_records,
     generate_lockfile,
     install_from_lockfile,
     lockfile_path,
@@ -632,35 +636,31 @@ def test_install_from_lockfile(
         "noarch-target",
     ],
 )
-def test_baseline_virtual_package_env_by_target(
+def test_virtual_package_overrides_by_target(
     monkeypatch: pytest.MonkeyPatch,
     host: str,
     target: str,
     expected: dict[str, str],
 ) -> None:
-    """Baselines trigger only when host family differs from the target family."""
-    from conda.base.context import context as conda_context
-
+    """Overrides trigger only when host family differs from the target family."""
     monkeypatch.setattr(conda_context, "_subdir", host)
     monkeypatch.delenv("CONDA_OVERRIDE_GLIBC", raising=False)
     monkeypatch.delenv("CONDA_OVERRIDE_OSX", raising=False)
     monkeypatch.delenv("CONDA_OVERRIDE_WIN", raising=False)
 
     env = ResolvedEnvironment(name="test")
-    assert env.baseline_virtual_package_env(target) == expected
+    assert env.virtual_package_overrides(target) == expected
 
 
-def test_baseline_virtual_package_env_respects_existing_env(
+def test_virtual_package_overrides_respect_existing_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Explicit ``CONDA_OVERRIDE_*`` values win over the baseline."""
-    from conda.base.context import context as conda_context
-
     monkeypatch.setattr(conda_context, "_subdir", "osx-arm64")
     monkeypatch.setenv("CONDA_OVERRIDE_GLIBC", "2.28")
 
     env = ResolvedEnvironment(name="test")
-    assert env.baseline_virtual_package_env("linux-64") == {}
+    assert env.virtual_package_overrides("linux-64") == {}
 
 
 @pytest.mark.parametrize(
@@ -678,34 +678,25 @@ def test_baseline_virtual_package_env_respects_existing_env(
         "unrelated-requirement-ignored",
     ],
 )
-def test_baseline_virtual_package_env_lifts_system_requirements(
+def test_virtual_package_overrides_lift_system_requirements(
     monkeypatch: pytest.MonkeyPatch,
     system_requirements: dict[str, str],
     expected: dict[str, str],
 ) -> None:
-    """``[system-requirements]`` versions are lifted into the baseline."""
-    from conda.base.context import context as conda_context
-
+    """``[system-requirements]`` versions are lifted into the overrides."""
     monkeypatch.setattr(conda_context, "_subdir", "osx-arm64")
     monkeypatch.delenv("CONDA_OVERRIDE_GLIBC", raising=False)
 
     env = ResolvedEnvironment(name="test", system_requirements=system_requirements)
-    assert env.baseline_virtual_package_env("linux-64") == expected
+    assert env.virtual_package_overrides("linux-64") == expected
 
 
-def test_solve_for_records_applies_baseline_env_during_solve(
+def test_solve_for_records_applies_virtual_package_overrides(
     monkeypatch: pytest.MonkeyPatch,
     workspace_ctx_factory: Callable[..., WorkspaceContext],
     resolved_envs_factory,
 ) -> None:
     """Cross-compiled solves see the baseline ``CONDA_OVERRIDE_*`` in os.environ."""
-    import os
-
-    from conda.base.context import context as conda_context
-    from conda.models.match_spec import MatchSpec
-
-    from conda_workspaces.lockfile import _solve_for_records
-
     monkeypatch.setattr(conda_context, "_subdir", "osx-arm64")
     monkeypatch.delenv("CONDA_OVERRIDE_GLIBC", raising=False)
 
@@ -743,13 +734,6 @@ def test_solve_for_records_native_solve_leaves_env_unchanged(
     resolved_envs_factory,
 ) -> None:
     """Native ``(host, target)`` solves do not mutate any ``CONDA_OVERRIDE_*``."""
-    import os
-
-    from conda.base.context import context as conda_context
-    from conda.models.match_spec import MatchSpec
-
-    from conda_workspaces.lockfile import _solve_for_records
-
     monkeypatch.setattr(conda_context, "_subdir", "linux-64")
     monkeypatch.delenv("CONDA_OVERRIDE_GLIBC", raising=False)
 

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -16,7 +16,7 @@ from conda.models.match_spec import MatchSpec
 from conda_lockfiles.rattler_lock.v6 import _record_to_dict
 
 from conda_workspaces.context import WorkspaceContext
-from conda_workspaces.exceptions import LockfileNotFoundError
+from conda_workspaces.exceptions import LockfileNotFoundError, SolveError
 from conda_workspaces.lockfile import (
     ALIASES,
     DEFAULT_FILENAMES,
@@ -24,7 +24,6 @@ from conda_workspaces.lockfile import (
     LOCKFILE_NAME,
     LOCKFILE_VERSION,
     CondaLockLoader,
-    _solve_for_records,
     generate_lockfile,
     install_from_lockfile,
     lockfile_path,
@@ -309,7 +308,7 @@ class _FakePkg:
 
 @pytest.fixture
 def fake_solver_factory(monkeypatch: pytest.MonkeyPatch):
-    """Replace ``_solve_for_records`` with a deterministic stub.
+    """Replace ``ResolvedEnvironment.solve_for_platform`` with a deterministic stub.
 
     The stub returns one package per ``(env, platform)`` pair whose URL
     encodes both, so tests can assert platform-specific records landed
@@ -321,20 +320,18 @@ def fake_solver_factory(monkeypatch: pytest.MonkeyPatch):
     def _factory(failures: set[tuple[str, str]] | None = None) -> list:
         failures = failures or set()
 
-        def fake_solve(ctx_arg, resolved, platform):
-            calls.append((resolved.name, platform))
-            if (resolved.name, platform) in failures:
-                from conda_workspaces.exceptions import SolveError
-
-                raise SolveError(resolved.name, "unsatisfiable", platform=platform)
+        def fake_solve(self, platform, *, prefix):
+            calls.append((self.name, platform))
+            if (self.name, platform) in failures:
+                raise SolveError(self.name, "unsatisfiable", platform=platform)
             return [
                 _FakePkg(
                     "python",
-                    f"https://example.com/python-{resolved.name}-{platform}.conda",
+                    f"https://example.com/python-{self.name}-{platform}.conda",
                 ),
             ]
 
-        monkeypatch.setattr("conda_workspaces.lockfile._solve_for_records", fake_solve)
+        monkeypatch.setattr(ResolvedEnvironment, "solve_for_platform", fake_solve)
         return calls
 
     return _factory
@@ -691,7 +688,7 @@ def test_virtual_package_overrides_lift_system_requirements(
     assert env.virtual_package_overrides("linux-64") == expected
 
 
-def test_solve_for_records_applies_virtual_package_overrides(
+def test_solve_for_platform_applies_virtual_package_overrides(
     monkeypatch: pytest.MonkeyPatch,
     workspace_ctx_factory: Callable[..., WorkspaceContext],
     resolved_envs_factory,
@@ -720,7 +717,7 @@ def test_solve_for_records_applies_virtual_package_overrides(
         lambda: FakeSolver,
     )
 
-    _solve_for_records(ctx, resolved, "linux-64")
+    resolved.solve_for_platform("linux-64", prefix=ctx.env_prefix(resolved.name))
 
     assert observed["CONDA_OVERRIDE_GLIBC"] == "2.17"
     assert observed["_subdir"] == "linux-64"
@@ -728,7 +725,7 @@ def test_solve_for_records_applies_virtual_package_overrides(
     assert os.environ.get("CONDA_OVERRIDE_GLIBC") is None
 
 
-def test_solve_for_records_native_solve_leaves_env_unchanged(
+def test_solve_for_platform_native_solve_leaves_env_unchanged(
     monkeypatch: pytest.MonkeyPatch,
     workspace_ctx_factory: Callable[..., WorkspaceContext],
     resolved_envs_factory,
@@ -756,6 +753,6 @@ def test_solve_for_records_native_solve_leaves_env_unchanged(
         lambda: FakeSolver,
     )
 
-    _solve_for_records(ctx, resolved, "linux-64")
+    resolved.solve_for_platform("linux-64", prefix=ctx.env_prefix(resolved.name))
 
     assert seen_env["CONDA_OVERRIDE_GLIBC"] is None

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -688,17 +688,28 @@ def test_virtual_package_overrides_lift_system_requirements(
     assert env.virtual_package_overrides("linux-64") == expected
 
 
-def test_solve_for_platform_applies_virtual_package_overrides(
+@pytest.mark.parametrize(
+    ("host", "target", "expected_glibc_during_solve"),
+    [
+        ("osx-arm64", "linux-64", "2.17"),
+        ("linux-64", "linux-64", None),
+    ],
+    ids=["cross-compile-seeds-baseline", "native-leaves-env-unchanged"],
+)
+def test_solve_for_platform_virtual_package_env(
     monkeypatch: pytest.MonkeyPatch,
     workspace_ctx_factory: Callable[..., WorkspaceContext],
     resolved_envs_factory,
+    host: str,
+    target: str,
+    expected_glibc_during_solve: str | None,
 ) -> None:
-    """Cross-compiled solves see the baseline ``CONDA_OVERRIDE_*`` in os.environ."""
-    monkeypatch.setattr(conda_context, "_subdir", "osx-arm64")
+    """``solve_for_platform`` seeds baselines only when host differs from target."""
+    monkeypatch.setattr(conda_context, "_subdir", host)
     monkeypatch.delenv("CONDA_OVERRIDE_GLIBC", raising=False)
 
     ctx = workspace_ctx_factory()
-    resolved = resolved_envs_factory(default=["linux-64"])["default"]
+    resolved = resolved_envs_factory(default=[target])["default"]
     resolved.conda_dependencies = {"python": MatchSpec("python=3.12")}
 
     observed: dict[str, str | None] = {}
@@ -717,42 +728,10 @@ def test_solve_for_platform_applies_virtual_package_overrides(
         lambda: FakeSolver,
     )
 
-    resolved.solve_for_platform("linux-64", prefix=ctx.env_prefix(resolved.name))
+    resolved.solve_for_platform(target, prefix=ctx.env_prefix(resolved.name))
 
-    assert observed["CONDA_OVERRIDE_GLIBC"] == "2.17"
-    assert observed["_subdir"] == "linux-64"
-    # After the solve, the baseline must have been restored.
+    assert observed["CONDA_OVERRIDE_GLIBC"] == expected_glibc_during_solve
+    assert observed["_subdir"] == target
+    # After the solve, any baseline the context manager applied must
+    # have been restored — nothing leaks into the surrounding process.
     assert os.environ.get("CONDA_OVERRIDE_GLIBC") is None
-
-
-def test_solve_for_platform_native_solve_leaves_env_unchanged(
-    monkeypatch: pytest.MonkeyPatch,
-    workspace_ctx_factory: Callable[..., WorkspaceContext],
-    resolved_envs_factory,
-) -> None:
-    """Native ``(host, target)`` solves do not mutate any ``CONDA_OVERRIDE_*``."""
-    monkeypatch.setattr(conda_context, "_subdir", "linux-64")
-    monkeypatch.delenv("CONDA_OVERRIDE_GLIBC", raising=False)
-
-    ctx = workspace_ctx_factory()
-    resolved = resolved_envs_factory(default=["linux-64"])["default"]
-    resolved.conda_dependencies = {"python": MatchSpec("python=3.12")}
-
-    seen_env: dict[str, str | None] = {}
-
-    class FakeSolver:
-        def __init__(self, *args, **kwargs) -> None:
-            seen_env["CONDA_OVERRIDE_GLIBC"] = os.environ.get("CONDA_OVERRIDE_GLIBC")
-
-        def solve_final_state(self) -> list:
-            return []
-
-    monkeypatch.setattr(
-        conda_context.plugin_manager,
-        "get_cached_solver_backend",
-        lambda: FakeSolver,
-    )
-
-    resolved.solve_for_platform("linux-64", prefix=ctx.env_prefix(resolved.name))
-
-    assert seen_env["CONDA_OVERRIDE_GLIBC"] is None

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -21,6 +21,7 @@ from conda_workspaces.lockfile import (
     LOCKFILE_NAME,
     LOCKFILE_VERSION,
     CondaLockLoader,
+    _baseline_virtual_package_env,
     generate_lockfile,
     install_from_lockfile,
     lockfile_path,
@@ -603,3 +604,172 @@ def test_install_from_lockfile(
     assert len(install_calls) == 1
     assert install_calls[0]["records"] == records_sentinel
     assert install_calls[0]["prefix"] == str(ctx.env_prefix("default"))
+
+
+@pytest.mark.parametrize(
+    ("host", "target", "expected"),
+    [
+        ("linux-64", "linux-64", {}),
+        ("linux-64", "linux-aarch64", {}),
+        ("osx-arm64", "osx-64", {}),
+        ("linux-64", "osx-arm64", {"CONDA_OVERRIDE_OSX": "11.0"}),
+        ("linux-64", "osx-64", {"CONDA_OVERRIDE_OSX": "10.15"}),
+        ("osx-arm64", "linux-64", {"CONDA_OVERRIDE_GLIBC": "2.17"}),
+        ("osx-arm64", "linux-aarch64", {"CONDA_OVERRIDE_GLIBC": "2.17"}),
+        ("linux-64", "win-64", {"CONDA_OVERRIDE_WIN": "0"}),
+        ("win-64", "linux-64", {"CONDA_OVERRIDE_GLIBC": "2.17"}),
+        ("linux-64", "noarch", {}),
+    ],
+    ids=[
+        "native-linux",
+        "linux-to-linux-cross-arch",
+        "osx-to-osx-cross-arch",
+        "linux-to-osx-arm64",
+        "linux-to-osx-64",
+        "osx-to-linux-64",
+        "osx-to-linux-aarch64",
+        "linux-to-win",
+        "win-to-linux",
+        "noarch-target",
+    ],
+)
+def test_baseline_virtual_package_env_by_target(
+    monkeypatch: pytest.MonkeyPatch,
+    host: str,
+    target: str,
+    expected: dict[str, str],
+) -> None:
+    """Baselines trigger only when host family differs from the target family."""
+    from conda.base.context import context as conda_context
+
+    monkeypatch.setattr(conda_context, "_subdir", host)
+    monkeypatch.delenv("CONDA_OVERRIDE_GLIBC", raising=False)
+    monkeypatch.delenv("CONDA_OVERRIDE_OSX", raising=False)
+    monkeypatch.delenv("CONDA_OVERRIDE_WIN", raising=False)
+
+    assert _baseline_virtual_package_env(target) == expected
+
+
+def test_baseline_virtual_package_env_respects_existing_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit ``CONDA_OVERRIDE_*`` values win over the baseline."""
+    from conda.base.context import context as conda_context
+
+    monkeypatch.setattr(conda_context, "_subdir", "osx-arm64")
+    monkeypatch.setenv("CONDA_OVERRIDE_GLIBC", "2.28")
+
+    assert _baseline_virtual_package_env("linux-64") == {}
+
+
+@pytest.mark.parametrize(
+    ("system_requirements", "expected"),
+    [
+        ({}, {"CONDA_OVERRIDE_GLIBC": "2.17"}),
+        ({"glibc": "2.28"}, {"CONDA_OVERRIDE_GLIBC": "2.28"}),
+        ({"__glibc": "2.34"}, {"CONDA_OVERRIDE_GLIBC": "2.34"}),
+        ({"osx": "12.0"}, {"CONDA_OVERRIDE_GLIBC": "2.17"}),
+    ],
+    ids=[
+        "default-baseline",
+        "bare-name-wins",
+        "dunder-name-wins",
+        "unrelated-requirement-ignored",
+    ],
+)
+def test_baseline_virtual_package_env_lifts_system_requirements(
+    monkeypatch: pytest.MonkeyPatch,
+    system_requirements: dict[str, str],
+    expected: dict[str, str],
+) -> None:
+    """``[system-requirements]`` versions are lifted into the baseline."""
+    from conda.base.context import context as conda_context
+
+    monkeypatch.setattr(conda_context, "_subdir", "osx-arm64")
+    monkeypatch.delenv("CONDA_OVERRIDE_GLIBC", raising=False)
+
+    assert _baseline_virtual_package_env("linux-64", system_requirements) == expected
+
+
+def test_solve_for_records_applies_baseline_env_during_solve(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_ctx_factory: Callable[..., WorkspaceContext],
+    resolved_envs_factory,
+) -> None:
+    """Cross-compiled solves see the baseline ``CONDA_OVERRIDE_*`` in os.environ."""
+    import os
+
+    from conda.base.context import context as conda_context
+    from conda.models.match_spec import MatchSpec
+
+    from conda_workspaces.lockfile import _solve_for_records
+
+    monkeypatch.setattr(conda_context, "_subdir", "osx-arm64")
+    monkeypatch.delenv("CONDA_OVERRIDE_GLIBC", raising=False)
+
+    ctx = workspace_ctx_factory()
+    resolved = resolved_envs_factory(default=["linux-64"])["default"]
+    resolved.conda_dependencies = {"python": MatchSpec("python=3.12")}
+
+    observed: dict[str, str | None] = {}
+
+    class FakeSolver:
+        def __init__(self, *args, **kwargs) -> None:
+            observed["CONDA_OVERRIDE_GLIBC"] = os.environ.get("CONDA_OVERRIDE_GLIBC")
+            observed["_subdir"] = conda_context.subdir
+
+        def solve_final_state(self) -> list:
+            return []
+
+    monkeypatch.setattr(
+        conda_context.plugin_manager,
+        "get_cached_solver_backend",
+        lambda: FakeSolver,
+    )
+
+    _solve_for_records(ctx, resolved, "linux-64")
+
+    assert observed["CONDA_OVERRIDE_GLIBC"] == "2.17"
+    assert observed["_subdir"] == "linux-64"
+    # After the solve, the baseline must have been restored.
+    assert os.environ.get("CONDA_OVERRIDE_GLIBC") is None
+
+
+def test_solve_for_records_native_solve_leaves_env_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_ctx_factory: Callable[..., WorkspaceContext],
+    resolved_envs_factory,
+) -> None:
+    """Native ``(host, target)`` solves do not mutate any ``CONDA_OVERRIDE_*``."""
+    import os
+
+    from conda.base.context import context as conda_context
+    from conda.models.match_spec import MatchSpec
+
+    from conda_workspaces.lockfile import _solve_for_records
+
+    monkeypatch.setattr(conda_context, "_subdir", "linux-64")
+    monkeypatch.delenv("CONDA_OVERRIDE_GLIBC", raising=False)
+
+    ctx = workspace_ctx_factory()
+    resolved = resolved_envs_factory(default=["linux-64"])["default"]
+    resolved.conda_dependencies = {"python": MatchSpec("python=3.12")}
+
+    seen_env: dict[str, str | None] = {}
+
+    class FakeSolver:
+        def __init__(self, *args, **kwargs) -> None:
+            seen_env["CONDA_OVERRIDE_GLIBC"] = os.environ.get("CONDA_OVERRIDE_GLIBC")
+
+        def solve_final_state(self) -> list:
+            return []
+
+    monkeypatch.setattr(
+        conda_context.plugin_manager,
+        "get_cached_solver_backend",
+        lambda: FakeSolver,
+    )
+
+    _solve_for_records(ctx, resolved, "linux-64")
+
+    assert seen_env["CONDA_OVERRIDE_GLIBC"] is None

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -21,7 +21,6 @@ from conda_workspaces.lockfile import (
     LOCKFILE_NAME,
     LOCKFILE_VERSION,
     CondaLockLoader,
-    _baseline_virtual_package_env,
     generate_lockfile,
     install_from_lockfile,
     lockfile_path,
@@ -647,7 +646,8 @@ def test_baseline_virtual_package_env_by_target(
     monkeypatch.delenv("CONDA_OVERRIDE_OSX", raising=False)
     monkeypatch.delenv("CONDA_OVERRIDE_WIN", raising=False)
 
-    assert _baseline_virtual_package_env(target) == expected
+    env = ResolvedEnvironment(name="test")
+    assert env.baseline_virtual_package_env(target) == expected
 
 
 def test_baseline_virtual_package_env_respects_existing_env(
@@ -659,7 +659,8 @@ def test_baseline_virtual_package_env_respects_existing_env(
     monkeypatch.setattr(conda_context, "_subdir", "osx-arm64")
     monkeypatch.setenv("CONDA_OVERRIDE_GLIBC", "2.28")
 
-    assert _baseline_virtual_package_env("linux-64") == {}
+    env = ResolvedEnvironment(name="test")
+    assert env.baseline_virtual_package_env("linux-64") == {}
 
 
 @pytest.mark.parametrize(
@@ -688,7 +689,8 @@ def test_baseline_virtual_package_env_lifts_system_requirements(
     monkeypatch.setattr(conda_context, "_subdir", "osx-arm64")
     monkeypatch.delenv("CONDA_OVERRIDE_GLIBC", raising=False)
 
-    assert _baseline_virtual_package_env("linux-64", system_requirements) == expected
+    env = ResolvedEnvironment(name="test", system_requirements=system_requirements)
+    assert env.baseline_virtual_package_env("linux-64") == expected
 
 
 def test_solve_for_records_applies_baseline_env_during_solve(


### PR DESCRIPTION
## Summary

Port `rattler_virtual_packages::VirtualPackages::detect_for_platform` to Python so `conda workspace lock` can solve cross-compiled targets without the user needing to set `CONDA_OVERRIDE_*` or `[system-requirements]` by hand.

Before: solving `linux-64` from macOS silently omitted `__glibc`, `__osx`, and `__win` virtual packages. Any `glibc`-gated conda-forge package failed to resolve until the user pinned a minimum manually.

After: `lockfile._baseline_virtual_package_env(platform, system_requirements)` returns the `CONDA_OVERRIDE_*` env vars needed for the current cross-compile, applied via a local env var context manager during the solve:

- `CONDA_OVERRIDE_GLIBC=2.17` for any non-native `linux-*` target.
- `CONDA_OVERRIDE_OSX=11.0` / `10.15` for `osx-arm64` / `osx-64`.
- `CONDA_OVERRIDE_WIN=0` presence marker for `win-*` targets.

## Precedence

1. `CONDA_OVERRIDE_*` already in `os.environ` wins (user is explicit).
2. `[system-requirements]` for the same package is lifted into the override so the `__glibc >=X` spec and the record agree.
3. Built-in conservative defaults fill the blanks.

`__cuda` / `__archspec` are never auto-seeded — opt in via `[system-requirements]` / `CONDA_OVERRIDE_*` if needed. Native solves (host family == target family) return an empty mapping, keeping byte-for-byte output unchanged.

## Tests

`tests/test_lockfile.py` grows eleven parametrized cases plus two end-to-end fixtures that stub `get_cached_solver_backend` and assert the baseline env vars are present inside the solver constructor and restored afterwards. All 813 tests pass.

## Docs

- `DESIGN.md`: "Lockfile generation" gains a paragraph on the baseline logic; the Future Work bullet flips from "port rattler baselines" to "upstream a shared helper in conda".
- `docs/tutorials/coming-from/pixi.md`: replaces the warning about manual `[system-requirements]` with a description of the auto-baseline and the precedence rules.
- `CHANGELOG.md` under Added.

## Test plan

- [x] `pixi run -e test pytest` (813 passed, 1 skipped)
- [x] `pixi run ruff check` + `pixi run ruff format --check`

Closes #32.