### PR TITLE
Support CI-split locking with `conda workspace lock --merge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,36 +8,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
-- Cross-platform solves now seed conservative virtual package
-  baselines when the host cannot detect them, mirroring rattler's
-  `VirtualPackages::detect_for_platform`. Solving `linux-64` from
-  macOS (or any other non-native target) sets `CONDA_OVERRIDE_GLIBC`
-  to `2.17` for the duration of the solve; `osx-arm64` cross-compiles
-  get `CONDA_OVERRIDE_OSX=11.0`, `osx-64` gets `10.15`, and `win-*`
-  targets get `CONDA_OVERRIDE_WIN=0`. Native solves are unchanged.
-  Explicit `CONDA_OVERRIDE_*` values stay authoritative, and a
-  `[system-requirements]` entry for the same virtual package is
-  promoted into the baseline override so the spec and the record
-  agree on the version. `__cuda` and `__archspec` are never
-  auto-baselined — declare them in `[system-requirements]` or via
-  `CONDA_OVERRIDE_*` when you need them.
-- New `conda workspace export` command. Delegates to conda's
-  `conda_environment_exporters` plugin hook, so the built-in
-  `environment-yaml` / `environment-json` exporters, the
-  `conda-workspaces-lock-v1` exporter, and any third-party exporter
-  (e.g. `conda-lockfiles`' rattler-lock) are all reachable through
-  the same CLI — `conda workspace export --format ...` produces
-  byte-identical output to `conda export --format ...` for the same
-  `Environment`. Three sources feed the exporter: the declared
-  manifest (default, no solver or install required), `--from-lockfile`
-  (reads an existing `conda.lock` via `CondaLockLoader`), and
-  `--from-prefix` (mirrors `conda export` semantics including
-  `--no-builds`, `--ignore-channels`, `--from-history`). The format
-  is picked by `--format`, auto-detected from `--file`'s basename,
-  or falls back to `environment-yaml`. `--platform` (repeatable)
-  restricts the export and requires a `multiplatform_export`-capable
-  exporter when more than one platform is given. `--dry-run` prints
-  to stdout without writing; `--json` emits a structured result.
+- `conda workspace lock` gained `--output <path>` and `--merge <glob>`
+  for CI-split locking pipelines. `--output` writes the solved
+  lockfile to an arbitrary path (e.g. `conda.lock.linux-64`) instead
+  of the default `<workspace>/conda.lock`, so matrix runners can each
+  emit a per-platform fragment. `--merge` (repeatable, supports
+  globs) stitches fragments back into a single `conda.lock` without
+  running the solver. The merger validates schema version agreement,
+  per-environment channel-list equality, and rejects overlapping
+  `(environment, platform)` pairs; violations raise the new
+  `LockfileMergeError` and nothing is written. The merged output is
+  byte-stable with a single-run `conda workspace lock` over the same
+  inputs. `--merge` is mutually exclusive with `--environment`,
+  `--platform`, `--skip-unsolvable`, and `--output`.
 - `conda workspace lock` now writes a single `conda.lock` that covers
   every platform declared by each environment, not just the host
   platform. Target-platform solves run with `context._subdir`

--- a/conda_workspaces/cli/main.py
+++ b/conda_workspaces/cli/main.py
@@ -160,6 +160,30 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
             " pair can be solved."
         ),
     )
+    lock_parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help=(
+            "Write the lockfile to this path instead of the default"
+            " <workspace>/conda.lock. Useful in CI matrices that emit"
+            " per-platform fragments (e.g. --platform linux-64 --output"
+            " conda.lock.linux-64) to be stitched back with --merge."
+        ),
+    )
+    lock_parser.add_argument(
+        "--merge",
+        action="append",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Merge pre-existing conda.lock fragments into a single"
+            " <workspace>/conda.lock without solving. May be passed"
+            " multiple times; each value is treated as a glob"
+            " (e.g. --merge 'conda.lock.*'). Cannot be combined with"
+            " --environment, --platform, --skip-unsolvable, or --output."
+        ),
+    )
 
     export_parser = sub.add_parser(
         "export",

--- a/conda_workspaces/cli/workspace/lock.py
+++ b/conda_workspaces/cli/workspace/lock.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+from conda.exceptions import CondaValueError
 from rich.console import Console
 
 from ...exceptions import EnvironmentNotFoundError, PlatformError
-from ...lockfile import generate_lockfile
+from ...lockfile import generate_lockfile, merge_lockfiles
 from ...resolver import known_platforms, resolve_all_environments, resolve_environment
 from . import workspace_context_from_args
 
@@ -15,6 +17,36 @@ if TYPE_CHECKING:
     import argparse
 
     from ...exceptions import SolveError
+
+
+def _expand_merge_paths(patterns: list[str]) -> list[Path]:
+    """Expand ``--merge`` values (plain paths or globs) into ``Path`` objects.
+
+    Each pattern is resolved relative to the current working directory.
+    Literal paths are kept as-is; glob patterns go through
+    :meth:`pathlib.Path.glob`.  Results are deduplicated while
+    preserving first-seen order so the merged output stays stable when
+    a user passes overlapping globs.
+    """
+    cwd = Path.cwd()
+    paths: list[Path] = []
+    seen: set[Path] = set()
+    for pattern in patterns:
+        raw = Path(pattern)
+        if any(ch in pattern for ch in "*?["):
+            if raw.is_absolute():
+                anchor = Path(raw.anchor)
+                matches = sorted(anchor.glob(str(raw.relative_to(raw.anchor))))
+            else:
+                matches = sorted(cwd.glob(pattern))
+        else:
+            matches = [raw if raw.is_absolute() else cwd / raw]
+        for match in matches:
+            resolved = match.resolve()
+            if resolved not in seen:
+                seen.add(resolved)
+                paths.append(match)
+    return paths
 
 
 def execute_lock(args: argparse.Namespace, *, console: Console | None = None) -> int:
@@ -26,6 +58,31 @@ def execute_lock(args: argparse.Namespace, *, console: Console | None = None) ->
     env_name = getattr(args, "environment", None)
     requested_platforms: list[str] | None = getattr(args, "platform", None) or None
     skip_unsolvable: bool = bool(getattr(args, "skip_unsolvable", False))
+    merge_patterns: list[str] | None = getattr(args, "merge", None) or None
+    output_path: Path | None = getattr(args, "output", None)
+
+    if merge_patterns:
+        if env_name or requested_platforms or skip_unsolvable or output_path:
+            raise CondaValueError(
+                "--merge cannot be combined with --environment, --platform,"
+                " --skip-unsolvable, or --output."
+            )
+        fragments = _expand_merge_paths(merge_patterns)
+        if not fragments:
+            raise CondaValueError(
+                "--merge matched no files; check the pattern and try again."
+            )
+        console.print(
+            "[bold blue]Merging[/bold blue]"
+            f" [bold]{len(fragments)}[/bold] lockfile fragment"
+            f"{'s' if len(fragments) != 1 else ''}"
+            "[dim]...[/dim]"
+        )
+        for fragment in fragments:
+            console.print(f"  [dim]<-[/dim] {fragment}")
+        merge_lockfiles(fragments, ctx)
+        console.print("[bold cyan]Updated[/bold cyan] [bold]conda.lock[/bold]")
+        return 0
 
     if env_name:
         if env_name not in config.environments:
@@ -62,8 +119,9 @@ def execute_lock(args: argparse.Namespace, *, console: Console | None = None) ->
             f" on [bold]{platform}[/bold][dim]:[/dim] {exc.reason}"
         )
 
+    updating_label = output_path.name if output_path is not None else "conda.lock"
     console.print(
-        "[bold blue]Updating[/bold blue] [bold]conda.lock[/bold][dim]...[/dim]"
+        f"[bold blue]Updating[/bold blue] [bold]{updating_label}[/bold][dim]...[/dim]"
     )
     generate_lockfile(
         ctx,
@@ -72,7 +130,9 @@ def execute_lock(args: argparse.Namespace, *, console: Console | None = None) ->
         progress=_progress,
         skip_unsolvable=skip_unsolvable,
         on_skip=_on_skip if skip_unsolvable else None,
+        output_path=output_path,
     )
-    console.print("[bold cyan]Updated[/bold cyan] [bold]conda.lock[/bold]")
+    target_label = output_path.name if output_path is not None else "conda.lock"
+    console.print(f"[bold cyan]Updated[/bold cyan] [bold]{target_label}[/bold]")
 
     return 0

--- a/conda_workspaces/cli/workspace/lock.py
+++ b/conda_workspaces/cli/workspace/lock.py
@@ -19,36 +19,6 @@ if TYPE_CHECKING:
     from ...exceptions import SolveError
 
 
-def _expand_merge_paths(patterns: list[str]) -> list[Path]:
-    """Expand ``--merge`` values (plain paths or globs) into ``Path`` objects.
-
-    Each pattern is resolved relative to the current working directory.
-    Literal paths are kept as-is; glob patterns go through
-    :meth:`pathlib.Path.glob`.  Results are deduplicated while
-    preserving first-seen order so the merged output stays stable when
-    a user passes overlapping globs.
-    """
-    cwd = Path.cwd()
-    paths: list[Path] = []
-    seen: set[Path] = set()
-    for pattern in patterns:
-        raw = Path(pattern)
-        if any(ch in pattern for ch in "*?["):
-            if raw.is_absolute():
-                anchor = Path(raw.anchor)
-                matches = sorted(anchor.glob(str(raw.relative_to(raw.anchor))))
-            else:
-                matches = sorted(cwd.glob(pattern))
-        else:
-            matches = [raw if raw.is_absolute() else cwd / raw]
-        for match in matches:
-            resolved = match.resolve()
-            if resolved not in seen:
-                seen.add(resolved)
-                paths.append(match)
-    return paths
-
-
 def execute_lock(args: argparse.Namespace, *, console: Console | None = None) -> int:
     """Solve workspace environments and write ``conda.lock``."""
     if console is None:
@@ -67,7 +37,28 @@ def execute_lock(args: argparse.Namespace, *, console: Console | None = None) ->
                 "--merge cannot be combined with --environment, --platform,"
                 " --skip-unsolvable, or --output."
             )
-        fragments = _expand_merge_paths(merge_patterns)
+        # Expand --merge values (plain paths or glob patterns) relative
+        # to the current working directory, deduplicating while
+        # preserving first-seen order so the merged output stays stable
+        # when a user passes overlapping globs.
+        cwd = Path.cwd()
+        fragments: list[Path] = []
+        seen: set[Path] = set()
+        for pattern in merge_patterns:
+            raw = Path(pattern)
+            if any(ch in pattern for ch in "*?["):
+                if raw.is_absolute():
+                    anchor = Path(raw.anchor)
+                    matches = sorted(anchor.glob(str(raw.relative_to(raw.anchor))))
+                else:
+                    matches = sorted(cwd.glob(pattern))
+            else:
+                matches = [raw if raw.is_absolute() else cwd / raw]
+            for match in matches:
+                resolved = match.resolve()
+                if resolved not in seen:
+                    seen.add(resolved)
+                    fragments.append(match)
         if not fragments:
             raise CondaValueError(
                 "--merge matched no files; check the pattern and try again."

--- a/conda_workspaces/exceptions.py
+++ b/conda_workspaces/exceptions.py
@@ -204,6 +204,29 @@ class LockfileNotFoundError(CondaWorkspacesError):
         )
 
 
+class LockfileMergeError(CondaWorkspacesError):
+    """A set of ``conda.lock`` fragments cannot be merged into one file.
+
+    Raised by :func:`conda_workspaces.lockfile.merge_lockfiles` when the
+    caller-provided fragments disagree on metadata (schema version,
+    channel list for a shared environment) or overlap on an
+    ``(environment, platform)`` pair that would otherwise be written
+    twice.  The *reason* attribute carries the human-readable detail.
+    """
+
+    def __init__(self, reason: str, *, hints: list[str] | None = None) -> None:
+        self.reason = reason
+        super().__init__(
+            f"Cannot merge lockfile fragments: {reason}",
+            hints=hints
+            or [
+                "Regenerate the offending fragment with `conda workspace"
+                " lock --platform <subdir> --output conda.lock.<subdir>`"
+                " and re-run the merge.",
+            ],
+        )
+
+
 class LockfileStaleError(CondaWorkspacesError):
     """The lockfile is older than the workspace manifest."""
 

--- a/conda_workspaces/lockfile.py
+++ b/conda_workspaces/lockfile.py
@@ -40,6 +40,7 @@ exact URLs, bypassing the solver entirely.
 
 from __future__ import annotations
 
+import io
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -385,8 +386,6 @@ def merge_lockfiles(paths: Sequence[Path], ctx: WorkspaceContext) -> Path:
 
     Returns the path to the merged lockfile.
     """
-    import io
-
     from conda.common.serialize.yaml import dump as yaml_dump
 
     if not paths:

--- a/conda_workspaces/lockfile.py
+++ b/conda_workspaces/lockfile.py
@@ -46,10 +46,15 @@ from typing import TYPE_CHECKING
 
 from conda.plugins.types import EnvironmentSpecBase
 
-from .exceptions import AllTargetsUnsolvableError, LockfileNotFoundError, SolveError
+from .exceptions import (
+    AllTargetsUnsolvableError,
+    LockfileMergeError,
+    LockfileNotFoundError,
+    SolveError,
+)
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Callable, Iterable, Sequence
     from typing import Any, ClassVar, Final
 
     from conda.common.path import PathType
@@ -161,7 +166,13 @@ class CondaLockLoader(EnvironmentSpecBase):
 
         payload = dict(self._data)
         payload["version"] = 6
-        return _rattler_lock_v6_to_env(name=name, platform=platform, **payload)
+        env = _rattler_lock_v6_to_env(name=name, platform=platform, **payload)
+        # The rattler v6 helper does not populate ``Environment.name``
+        # on the returned object; re-exporters like
+        # :func:`.export.multiplatform_export` rely on it to group
+        # platforms under the right environment key, so restore it.
+        env.name = name
+        return env
 
     @property
     def env(self) -> Environment:
@@ -260,6 +271,7 @@ def generate_lockfile(
     progress: Callable[[str, str], None] | None = None,
     skip_unsolvable: bool = False,
     on_skip: Callable[[str, str, SolveError], None] | None = None,
+    output_path: Path | None = None,
 ) -> Path:
     """Generate a ``conda.lock`` by solving workspace environments.
 
@@ -281,6 +293,12 @@ def generate_lockfile(
     pairs; :class:`AllTargetsUnsolvableError` is raised only if every
     pair fails.  Non-solver errors (missing channel, invalid manifest,
     etc.) always abort.
+
+    When *output_path* is given, the lockfile is written there instead
+    of the default ``<workspace>/conda.lock``.  Matrix CI runners use
+    this to emit per-platform fragments
+    (e.g. ``conda.lock.linux-64``) that a coordinator job later stitches
+    back together with :func:`merge_lockfiles`.
 
     Returns the path to the generated lockfile.
     """
@@ -327,9 +345,158 @@ def generate_lockfile(
     if failures and not envs:
         raise AllTargetsUnsolvableError(failures)
 
-    path = lockfile_path(ctx)
+    path = output_path if output_path is not None else lockfile_path(ctx)
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(multiplatform_export(envs), encoding="utf-8")
     return path
+
+
+def merge_lockfiles(paths: Sequence[Path], ctx: WorkspaceContext) -> Path:
+    """Merge per-platform ``conda.lock`` fragments into a single lockfile.
+
+    Designed for CI matrix pipelines that split locking across runners:
+    each runner produces a fragment for one platform (typically via
+    ``conda workspace lock --platform <subdir> --output
+    conda.lock.<subdir>``), and a coordinator job stitches them back
+    into a single ``<workspace>/conda.lock`` with this function.
+
+    Every fragment must be a ``version: 1`` lockfile.  Fragments that
+    declare the same environment must agree on its ``channels`` list
+    entry-for-entry and in the same order.  Two fragments may not both
+    carry entries for the same ``(environment, platform)`` pair —
+    overlapping platforms indicate a misconfigured pipeline rather than
+    a legitimate merge.  Any violation raises
+    :class:`LockfileMergeError` and nothing is written.
+
+    The merge happens at the YAML layer — going through
+    :class:`CondaLockLoader` would force
+    :func:`conda_lockfiles.records_from_conda_urls.records_from_conda_urls`
+    to fetch every package to populate :class:`PackageRecord` objects,
+    which defeats the purpose of merging cached fragments.  We stitch
+    the dicts back together and hand them to conda's YAML dumper.
+
+    The output is byte-stable with a single-run
+    :func:`generate_lockfile` call over the same inputs: environments
+    are walked in first-seen order across fragments, platforms in
+    alphabetical order within each environment, and top-level
+    ``packages`` are emitted in the same order
+    :meth:`CondaLockLoader.compose` would produce (first encounter of
+    each URL wins, iterating env-by-env then platform-by-platform).
+
+    Returns the path to the merged lockfile.
+    """
+    import io
+
+    from conda.common.serialize.yaml import dump as yaml_dump
+
+    if not paths:
+        raise LockfileMergeError("no lockfile fragments were supplied")
+
+    merged = _compose_lockfile_dict(paths)
+
+    out_path = lockfile_path(ctx)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    buf = io.StringIO()
+    yaml_dump(merged, buf)
+    out_path.write_text(buf.getvalue(), encoding="utf-8")
+    return out_path
+
+
+def _compose_lockfile_dict(paths: Sequence[Path]) -> dict[str, Any]:
+    """Validate and fold every fragment in *paths* into a single lockfile dict.
+
+    Raises :class:`LockfileMergeError` on any validation failure.  The
+    returned dict shape matches what :meth:`CondaLockLoader.compose`
+    emits, guaranteeing byte-stable output once passed through the same
+    YAML dumper.
+    """
+    from conda_lockfiles.load_yaml import load_yaml
+
+    env_order: list[str] = []
+    env_channels: dict[str, list[dict[str, Any]]] = {}
+    env_platforms: dict[str, dict[str, list[dict[str, str]]]] = {}
+    seen_pairs: dict[tuple[str, str], Path] = {}
+    packages_by_url: dict[str, dict[str, Any]] = {}
+
+    for path in paths:
+        if not path.is_file():
+            raise LockfileMergeError(f"fragment '{path}' does not exist")
+        data = load_yaml(path)
+        version = data.get("version")
+        if version != LOCKFILE_VERSION:
+            raise LockfileMergeError(
+                f"fragment '{path}' has version {version!r}, "
+                f"expected {LOCKFILE_VERSION}"
+            )
+        for record in data.get("packages", []) or []:
+            url = record.get("url") or record.get("conda") or record.get("pypi")
+            if not url:
+                continue
+            packages_by_url.setdefault(url, record)
+
+        for env_name, env_data in (data.get("environments") or {}).items():
+            channels = list(env_data.get("channels") or [])
+            existing = env_channels.get(env_name)
+            if existing is None:
+                env_order.append(env_name)
+                env_channels[env_name] = channels
+                env_platforms[env_name] = {}
+            elif existing != channels:
+                raise LockfileMergeError(
+                    f"environment '{env_name}' channels differ between "
+                    f"fragments; '{path}' disagrees with an earlier fragment",
+                    hints=[
+                        "Every fragment must declare the same channel list"
+                        " (same entries, same order) for a shared environment.",
+                    ],
+                )
+            for platform, refs in (env_data.get("packages") or {}).items():
+                pair = (env_name, platform)
+                if pair in seen_pairs:
+                    raise LockfileMergeError(
+                        f"environment '{env_name}' on platform "
+                        f"'{platform}' is present in both "
+                        f"'{seen_pairs[pair]}' and '{path}'",
+                        hints=[
+                            "Each (environment, platform) pair must come"
+                            " from exactly one fragment.",
+                        ],
+                    )
+                seen_pairs[pair] = path
+                env_platforms[env_name][platform] = list(refs or [])
+
+    # Rebuild top-level ``packages`` in the same order
+    # :meth:`CondaLockLoader.compose` would produce for a single-run
+    # solve: iterate envs in first-seen order, platforms alphabetically,
+    # then each platform's refs (already sorted by package name by the
+    # producing fragment).  First occurrence of a URL wins.
+    merged_packages: list[dict[str, Any]] = []
+    emitted_urls: set[str] = set()
+    for env_name in env_order:
+        for platform in sorted(env_platforms[env_name]):
+            for ref in env_platforms[env_name][platform]:
+                url = ref.get("conda")
+                if not url or url in emitted_urls:
+                    continue
+                record = packages_by_url.get(url)
+                if record is not None:
+                    merged_packages.append(record)
+                    emitted_urls.add(url)
+
+    return {
+        "version": LOCKFILE_VERSION,
+        "environments": {
+            name: {
+                "channels": env_channels[name],
+                "packages": {
+                    platform: env_platforms[name][platform]
+                    for platform in sorted(env_platforms[name])
+                },
+            }
+            for name in env_order
+        },
+        "packages": merged_packages,
+    }
 
 
 def install_from_lockfile(ctx: WorkspaceContext, env_name: str) -> None:

--- a/conda_workspaces/lockfile.py
+++ b/conda_workspaces/lockfile.py
@@ -387,29 +387,10 @@ def merge_lockfiles(paths: Sequence[Path], ctx: WorkspaceContext) -> Path:
     Returns the path to the merged lockfile.
     """
     from conda.common.serialize.yaml import dump as yaml_dump
+    from conda_lockfiles.load_yaml import load_yaml
 
     if not paths:
         raise LockfileMergeError("no lockfile fragments were supplied")
-
-    merged = _compose_lockfile_dict(paths)
-
-    out_path = lockfile_path(ctx)
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    buf = io.StringIO()
-    yaml_dump(merged, buf)
-    out_path.write_text(buf.getvalue(), encoding="utf-8")
-    return out_path
-
-
-def _compose_lockfile_dict(paths: Sequence[Path]) -> dict[str, Any]:
-    """Validate and fold every fragment in *paths* into a single lockfile dict.
-
-    Raises :class:`LockfileMergeError` on any validation failure.  The
-    returned dict shape matches what :meth:`CondaLockLoader.compose`
-    emits, guaranteeing byte-stable output once passed through the same
-    YAML dumper.
-    """
-    from conda_lockfiles.load_yaml import load_yaml
 
     env_order: list[str] = []
     env_channels: dict[str, list[dict[str, Any]]] = {}
@@ -482,7 +463,7 @@ def _compose_lockfile_dict(paths: Sequence[Path]) -> dict[str, Any]:
                     merged_packages.append(record)
                     emitted_urls.add(url)
 
-    return {
+    merged = {
         "version": LOCKFILE_VERSION,
         "environments": {
             name: {
@@ -496,6 +477,13 @@ def _compose_lockfile_dict(paths: Sequence[Path]) -> dict[str, Any]:
         },
         "packages": merged_packages,
     }
+
+    out_path = lockfile_path(ctx)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    buf = io.StringIO()
+    yaml_dump(merged, buf)
+    out_path.write_text(buf.getvalue(), encoding="utf-8")
+    return out_path
 
 
 def install_from_lockfile(ctx: WorkspaceContext, env_name: str) -> None:

--- a/demos/README.md
+++ b/demos/README.md
@@ -11,6 +11,7 @@ Animated terminal demos recorded with [VHS](https://github.com/charmbracelet/vhs
 | `quickstart` | Init a workspace, add deps, install, list envs, run a command |
 | `lockfile` | Install, lock, clean, reinstall from lockfile |
 | `export` | Export manifests to environment.yml / environment.json / conda.lock via the plugin hook |
+| `ci-split` | Split locking across a CI matrix and merge fragments with `--merge` |
 | `multi-platform` | Cross-platform locking and the `--platform` flag |
 | `multi-env` | Multiple environments from one manifest |
 | `pixi-compat` | Use an existing pixi.toml with conda-workspaces |

--- a/demos/ci-split.tape
+++ b/demos/ci-split.tape
@@ -1,0 +1,58 @@
+Source demos/_settings.tape
+
+Output demos/ci-split.gif
+Output demos/ci-split.mp4
+
+Hide
+Type `eval "$(pixi shell-hook -s bash -e dev)"`
+Enter
+Wait /\)/
+Type `export PS1="$DEMO_PS1" && mkdir -p /tmp/.demo-home && echo 'PS1="$ "' > /tmp/.demo-home/.bash_profile && export HOME=/tmp/.demo-home`
+Enter
+Wait /\$/
+Type `FIXTURES=$(pwd)/demos/fixtures`
+Enter
+Wait /\$/
+Type "rm -rf /tmp/ci-split-demo && mkdir -p /tmp/ci-split-demo && cd /tmp/ci-split-demo"
+Enter
+Wait /\$/
+Type `cp "$FIXTURES/lockfile.toml" conda.toml`
+Enter
+Wait /\$/
+Type "clear"
+Enter
+Wait /\$/
+Show
+
+Type "# Each CI runner locks one platform into its own fragment file"
+Enter
+Sleep 500ms
+
+Type@80ms "conda workspace lock --platform linux-64 --output conda.lock.linux-64"
+Enter
+Wait /\$/
+Sleep 2s
+
+Type@80ms "conda workspace lock --platform osx-arm64 --output conda.lock.osx-arm64"
+Enter
+Wait /\$/
+Sleep 2s
+
+Type@80ms "ls conda.lock.*"
+Enter
+Wait /\$/
+Sleep 2s
+
+Type "# The coordinator stitches fragments into a single conda.lock — no solver"
+Enter
+Sleep 500ms
+
+Type@80ms "conda workspace lock --merge 'conda.lock.*'"
+Enter
+Wait /\$/
+Sleep 2s
+
+Type@80ms "head -15 conda.lock"
+Enter
+Wait /\$/
+Sleep 3s

--- a/docs/features.md
+++ b/docs/features.md
@@ -455,6 +455,35 @@ relative to the manifest — if the manifest has changed since the lockfile
 was generated, the install fails. Use `--frozen` to skip freshness
 checks entirely and install the lockfile as-is.
 
+### CI-split locking with `--merge`
+
+Solving every platform in one job becomes expensive as a workspace
+grows. `conda workspace lock` supports matrix pipelines that split
+solving across runners and stitch the fragments back together on a
+coordinator job:
+
+```bash
+# In a matrix job, per platform
+conda workspace lock --platform linux-64 --output conda.lock.linux-64
+conda workspace lock --platform osx-arm64 --output conda.lock.osx-arm64
+conda workspace lock --platform win-64 --output conda.lock.win-64
+
+# On the coordinator — no solver runs, fragments are combined in place
+conda workspace lock --merge "conda.lock.*"
+```
+
+`--output` writes the solved lockfile to the given path instead of the
+default `<workspace>/conda.lock`. It may be combined with `--platform`
+so each matrix runner emits exactly one `(env, platform)` slice.
+
+`--merge` loads every fragment, validates that they agree on schema
+version and on each shared environment's channel list, and rejects
+overlapping `(environment, platform)` pairs. On success the merged
+`conda.lock` is byte-stable with what a single-run
+`conda workspace lock` would produce for the same inputs. `--merge`
+is mutually exclusive with `--environment`, `--platform`,
+`--skip-unsolvable`, and `--output`.
+
 You can also point to a specific manifest with `--file` / `-f`:
 
 ```bash

--- a/tests/cli/workspace/test_lock.py
+++ b/tests/cli/workspace/test_lock.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 from conda.exceptions import CondaValueError
@@ -11,9 +11,6 @@ from conda_workspaces.cli.workspace.lock import execute_lock
 from conda_workspaces.exceptions import EnvironmentNotFoundError, PlatformError
 
 from ..conftest import make_args
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 _DEFAULTS = {
     "file": None,
@@ -243,8 +240,6 @@ def test_lock_merge_rejects_incompatible_flags(
     incompatible: dict,
 ) -> None:
     """``--merge`` is mutually exclusive with solver-side flags."""
-    from pathlib import Path
-
     monkeypatch.chdir(pixi_workspace)
     frag = pixi_workspace / "conda.lock.linux-64"
     frag.write_text("placeholder", encoding="utf-8")

--- a/tests/cli/workspace/test_lock.py
+++ b/tests/cli/workspace/test_lock.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from conda.exceptions import CondaValueError
 
-from conda_workspaces.cli.workspace.lock import execute_lock
+from conda_workspaces.cli.workspace.lock import _expand_merge_paths, execute_lock
 from conda_workspaces.exceptions import EnvironmentNotFoundError, PlatformError
 
 from ..conftest import make_args
@@ -19,6 +20,8 @@ _DEFAULTS = {
     "environment": None,
     "platform": None,
     "skip_unsolvable": False,
+    "merge": None,
+    "output": None,
 }
 
 
@@ -41,6 +44,7 @@ def capture_generate_lockfile(monkeypatch: pytest.MonkeyPatch, pixi_workspace: P
         progress=None,
         skip_unsolvable=False,
         on_skip=None,
+        output_path=None,
     ):
         calls.append(
             {
@@ -49,9 +53,10 @@ def capture_generate_lockfile(monkeypatch: pytest.MonkeyPatch, pixi_workspace: P
                 "progress": progress,
                 "skip_unsolvable": skip_unsolvable,
                 "on_skip": on_skip,
+                "output_path": output_path,
             }
         )
-        return pixi_workspace / "conda.lock"
+        return output_path or (pixi_workspace / "conda.lock")
 
     monkeypatch.setattr(
         "conda_workspaces.cli.workspace.lock.generate_lockfile", fake_generate
@@ -149,3 +154,104 @@ def test_lock_forwards_skip_unsolvable(
         assert callable(capture_generate_lockfile[0]["on_skip"])
     else:
         assert capture_generate_lockfile[0]["on_skip"] is None
+
+
+def test_lock_forwards_output_path(
+    pixi_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capture_generate_lockfile: list[dict],
+) -> None:
+    """``--output`` threads through to ``generate_lockfile(output_path=...)``."""
+    monkeypatch.chdir(pixi_workspace)
+    target = pixi_workspace / "conda.lock.linux-64"
+
+    result = execute_lock(make_args(_DEFAULTS, output=target))
+    assert result == 0
+    assert capture_generate_lockfile[0]["output_path"] == target
+
+
+def test_lock_merge_dispatches_to_merge_lockfiles(
+    pixi_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capture_generate_lockfile: list[dict],
+) -> None:
+    """``--merge`` bypasses the solver and calls ``merge_lockfiles``."""
+    monkeypatch.chdir(pixi_workspace)
+    frag1 = pixi_workspace / "conda.lock.linux-64"
+    frag2 = pixi_workspace / "conda.lock.osx-arm64"
+    frag1.write_text("placeholder", encoding="utf-8")
+    frag2.write_text("placeholder", encoding="utf-8")
+
+    seen_paths: list[list] = []
+
+    def fake_merge(paths, ctx):
+        seen_paths.append(list(paths))
+        return pixi_workspace / "conda.lock"
+
+    monkeypatch.setattr(
+        "conda_workspaces.cli.workspace.lock.merge_lockfiles", fake_merge
+    )
+
+    result = execute_lock(
+        make_args(_DEFAULTS, merge=[str(frag1), str(frag2)]),
+    )
+    assert result == 0
+    assert capture_generate_lockfile == []
+    assert len(seen_paths) == 1
+    resolved = {p.resolve() for p in seen_paths[0]}
+    assert resolved == {frag1.resolve(), frag2.resolve()}
+
+
+def test_lock_merge_glob_expansion(
+    pixi_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--merge 'conda.lock.*'`` globs fragments relative to cwd."""
+    monkeypatch.chdir(pixi_workspace)
+    (pixi_workspace / "conda.lock.linux-64").write_text("x", encoding="utf-8")
+    (pixi_workspace / "conda.lock.osx-arm64").write_text("x", encoding="utf-8")
+
+    paths = _expand_merge_paths(["conda.lock.*"])
+    names = sorted(p.name for p in paths)
+    assert names == ["conda.lock.linux-64", "conda.lock.osx-arm64"]
+
+
+@pytest.mark.parametrize(
+    "incompatible",
+    [
+        {"environment": "default"},
+        {"platform": ["linux-64"]},
+        {"skip_unsolvable": True},
+        {"output": "conda.lock.linux-64"},
+    ],
+    ids=["with-environment", "with-platform", "with-skip-unsolvable", "with-output"],
+)
+def test_lock_merge_rejects_incompatible_flags(
+    pixi_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    incompatible: dict,
+) -> None:
+    """``--merge`` is mutually exclusive with solver-side flags."""
+    from pathlib import Path
+
+    monkeypatch.chdir(pixi_workspace)
+    frag = pixi_workspace / "conda.lock.linux-64"
+    frag.write_text("placeholder", encoding="utf-8")
+    if "output" in incompatible:
+        incompatible = {"output": Path(str(incompatible["output"]))}
+
+    with pytest.raises(CondaValueError, match="--merge"):
+        execute_lock(
+            make_args(_DEFAULTS, merge=[str(frag)], **incompatible),
+        )
+
+
+def test_lock_merge_no_matches_raises(
+    pixi_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty glob match is a user error, not a silent no-op."""
+    monkeypatch.chdir(pixi_workspace)
+
+    with pytest.raises(CondaValueError, match="matched no files"):
+        execute_lock(make_args(_DEFAULTS, merge=["conda.lock.missing.*"]))

--- a/tests/cli/workspace/test_lock.py
+++ b/tests/cli/workspace/test_lock.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 from conda.exceptions import CondaValueError
 
-from conda_workspaces.cli.workspace.lock import _expand_merge_paths, execute_lock
+from conda_workspaces.cli.workspace.lock import execute_lock
 from conda_workspaces.exceptions import EnvironmentNotFoundError, PlatformError
 
 from ..conftest import make_args
@@ -211,8 +211,19 @@ def test_lock_merge_glob_expansion(
     (pixi_workspace / "conda.lock.linux-64").write_text("x", encoding="utf-8")
     (pixi_workspace / "conda.lock.osx-arm64").write_text("x", encoding="utf-8")
 
-    paths = _expand_merge_paths(["conda.lock.*"])
-    names = sorted(p.name for p in paths)
+    seen_paths: list[list] = []
+
+    def fake_merge(paths, ctx):
+        seen_paths.append(list(paths))
+        return pixi_workspace / "conda.lock"
+
+    monkeypatch.setattr(
+        "conda_workspaces.cli.workspace.lock.merge_lockfiles", fake_merge
+    )
+
+    assert execute_lock(make_args(_DEFAULTS, merge=["conda.lock.*"])) == 0
+    assert len(seen_paths) == 1
+    names = sorted(p.name for p in seen_paths[0])
     assert names == ["conda.lock.linux-64", "conda.lock.osx-arm64"]
 
 

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 from conda.base.context import context as conda_context
 from conda.models.match_spec import MatchSpec
+from conda_lockfiles.load_yaml import load_yaml
 from conda_lockfiles.rattler_lock.v6 import _record_to_dict
 
 from conda_workspaces.context import WorkspaceContext
@@ -742,32 +743,35 @@ def test_solve_for_platform_virtual_package_env(
     assert os.environ.get("CONDA_OVERRIDE_GLIBC") is None
 
 
-def _write_fragment(
-    ctx: WorkspaceContext,
-    resolved_envs,
-    platform: str,
-) -> Path:
-    """Run ``generate_lockfile`` for exactly one platform into a fragment."""
-    target = ctx.root / f"conda.lock.{platform}"
-    generate_lockfile(
-        ctx,
-        resolved_envs,
-        platforms=(platform,),
-        output_path=target,
-    )
-    # conda_lockfiles.load_yaml caches by path; fragment files are
-    # rewritten between tests, so evict any stale parse before callers
-    # re-read the same path.
-    from conda_lockfiles.load_yaml import load_yaml
+@pytest.fixture
+def write_fragment() -> Callable[[WorkspaceContext, dict, str], Path]:
+    """Factory that solves one platform into a ``conda.lock.<platform>`` fragment.
 
-    load_yaml.cache_clear()
-    return target
+    ``conda_lockfiles.load_yaml`` caches parsed YAML by path; fragment
+    files are rewritten between calls in the merge tests, so the
+    factory evicts the cache after every write to keep subsequent
+    reads fresh.
+    """
+
+    def _factory(ctx: WorkspaceContext, resolved_envs, platform: str) -> Path:
+        target = ctx.root / f"conda.lock.{platform}"
+        generate_lockfile(
+            ctx,
+            resolved_envs,
+            platforms=(platform,),
+            output_path=target,
+        )
+        load_yaml.cache_clear()
+        return target
+
+    return _factory
 
 
 def test_merge_lockfiles_byte_stable_with_single_run(
     workspace_ctx_factory: Callable[..., WorkspaceContext],
     fake_solver_factory,
     resolved_envs_factory,
+    write_fragment: Callable[[WorkspaceContext, dict, str], Path],
 ) -> None:
     """Merging per-platform fragments must match a single-run lockfile byte-for-byte."""
     ctx_single = workspace_ctx_factory(env_names=["default", "test"])
@@ -785,8 +789,8 @@ def test_merge_lockfiles_byte_stable_with_single_run(
         default=["linux-64", "osx-arm64"],
         test=["linux-64", "osx-arm64"],
     )
-    frag_linux = _write_fragment(ctx_split, resolved_envs_split, "linux-64")
-    frag_osx = _write_fragment(ctx_split, resolved_envs_split, "osx-arm64")
+    frag_linux = write_fragment(ctx_split, resolved_envs_split, "linux-64")
+    frag_osx = write_fragment(ctx_split, resolved_envs_split, "osx-arm64")
 
     # Delete any lockfile left behind by the fragment solves so the
     # merge writes into a clean slate.
@@ -835,11 +839,12 @@ def test_merge_lockfiles_channel_mismatch(
     workspace_ctx_factory: Callable[..., WorkspaceContext],
     fake_solver_factory,
     resolved_envs_factory,
+    write_fragment: Callable[[WorkspaceContext, dict, str], Path],
 ) -> None:
     ctx = workspace_ctx_factory(env_names=["default"])
     fake_solver_factory()
     resolved_envs = resolved_envs_factory(default=["linux-64"])
-    frag_a = _write_fragment(ctx, resolved_envs, "linux-64")
+    frag_a = write_fragment(ctx, resolved_envs, "linux-64")
 
     # Produce a second fragment with a different channel list by
     # tweaking the saved content directly.
@@ -853,8 +858,6 @@ def test_merge_lockfiles_channel_mismatch(
         )
     )
     frag_b.write_text(content, encoding="utf-8")
-    from conda_lockfiles.load_yaml import load_yaml
-
     load_yaml.cache_clear()
 
     with pytest.raises(LockfileMergeError, match="channels differ"):
@@ -865,16 +868,15 @@ def test_merge_lockfiles_duplicate_platform(
     workspace_ctx_factory: Callable[..., WorkspaceContext],
     fake_solver_factory,
     resolved_envs_factory,
+    write_fragment: Callable[[WorkspaceContext, dict, str], Path],
 ) -> None:
     ctx = workspace_ctx_factory(env_names=["default"])
     fake_solver_factory()
     resolved_envs = resolved_envs_factory(default=["linux-64"])
-    frag_a = _write_fragment(ctx, resolved_envs, "linux-64")
+    frag_a = write_fragment(ctx, resolved_envs, "linux-64")
 
     frag_b = ctx.root / "conda.lock.linux-64.dup"
     frag_b.write_text(frag_a.read_text(encoding="utf-8"), encoding="utf-8")
-    from conda_lockfiles.load_yaml import load_yaml
-
     load_yaml.cache_clear()
 
     with pytest.raises(LockfileMergeError, match="present in both"):

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -16,7 +16,11 @@ from conda.models.match_spec import MatchSpec
 from conda_lockfiles.rattler_lock.v6 import _record_to_dict
 
 from conda_workspaces.context import WorkspaceContext
-from conda_workspaces.exceptions import LockfileNotFoundError, SolveError
+from conda_workspaces.exceptions import (
+    LockfileMergeError,
+    LockfileNotFoundError,
+    SolveError,
+)
 from conda_workspaces.lockfile import (
     ALIASES,
     DEFAULT_FILENAMES,
@@ -27,6 +31,7 @@ from conda_workspaces.lockfile import (
     generate_lockfile,
     install_from_lockfile,
     lockfile_path,
+    merge_lockfiles,
 )
 from conda_workspaces.models import Channel, Environment, Feature, WorkspaceConfig
 from conda_workspaces.resolver import ResolvedEnvironment
@@ -735,3 +740,142 @@ def test_solve_for_platform_virtual_package_env(
     # After the solve, any baseline the context manager applied must
     # have been restored — nothing leaks into the surrounding process.
     assert os.environ.get("CONDA_OVERRIDE_GLIBC") is None
+
+
+def _write_fragment(
+    ctx: WorkspaceContext,
+    resolved_envs,
+    platform: str,
+) -> Path:
+    """Run ``generate_lockfile`` for exactly one platform into a fragment."""
+    target = ctx.root / f"conda.lock.{platform}"
+    generate_lockfile(
+        ctx,
+        resolved_envs,
+        platforms=(platform,),
+        output_path=target,
+    )
+    # conda_lockfiles.load_yaml caches by path; fragment files are
+    # rewritten between tests, so evict any stale parse before callers
+    # re-read the same path.
+    from conda_lockfiles.load_yaml import load_yaml
+
+    load_yaml.cache_clear()
+    return target
+
+
+def test_merge_lockfiles_byte_stable_with_single_run(
+    workspace_ctx_factory: Callable[..., WorkspaceContext],
+    fake_solver_factory,
+    resolved_envs_factory,
+) -> None:
+    """Merging per-platform fragments must match a single-run lockfile byte-for-byte."""
+    ctx_single = workspace_ctx_factory(env_names=["default", "test"])
+    fake_solver_factory()
+    resolved_envs = resolved_envs_factory(
+        default=["linux-64", "osx-arm64"],
+        test=["linux-64", "osx-arm64"],
+    )
+    single_path = generate_lockfile(ctx_single, resolved_envs)
+    single_content = single_path.read_text(encoding="utf-8")
+
+    ctx_split = workspace_ctx_factory(env_names=["default", "test"])
+    fake_solver_factory()
+    resolved_envs_split = resolved_envs_factory(
+        default=["linux-64", "osx-arm64"],
+        test=["linux-64", "osx-arm64"],
+    )
+    frag_linux = _write_fragment(ctx_split, resolved_envs_split, "linux-64")
+    frag_osx = _write_fragment(ctx_split, resolved_envs_split, "osx-arm64")
+
+    # Delete any lockfile left behind by the fragment solves so the
+    # merge writes into a clean slate.
+    merged_path = lockfile_path(ctx_split)
+    if merged_path.exists():
+        merged_path.unlink()
+
+    result = merge_lockfiles([frag_linux, frag_osx], ctx_split)
+    assert result == merged_path
+    assert merged_path.read_text(encoding="utf-8") == single_content
+
+
+def test_merge_lockfiles_rejects_empty_input(
+    workspace_ctx_factory: Callable[..., WorkspaceContext],
+) -> None:
+    """An empty fragment list is a user error."""
+    ctx = workspace_ctx_factory()
+    with pytest.raises(LockfileMergeError, match="no lockfile fragments"):
+        merge_lockfiles([], ctx)
+
+
+def test_merge_lockfiles_missing_file(
+    tmp_path: Path,
+    workspace_ctx_factory: Callable[..., WorkspaceContext],
+) -> None:
+    ctx = workspace_ctx_factory()
+    with pytest.raises(LockfileMergeError, match="does not exist"):
+        merge_lockfiles([tmp_path / "missing.lock"], ctx)
+
+
+def test_merge_lockfiles_rejects_wrong_version(
+    tmp_path: Path,
+    workspace_ctx_factory: Callable[..., WorkspaceContext],
+) -> None:
+    ctx = workspace_ctx_factory()
+    bad = tmp_path / "conda.lock.bad"
+    bad.write_text(
+        "version: 99\nenvironments: {}\npackages: []\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(LockfileMergeError, match="version"):
+        merge_lockfiles([bad], ctx)
+
+
+def test_merge_lockfiles_channel_mismatch(
+    workspace_ctx_factory: Callable[..., WorkspaceContext],
+    fake_solver_factory,
+    resolved_envs_factory,
+) -> None:
+    ctx = workspace_ctx_factory(env_names=["default"])
+    fake_solver_factory()
+    resolved_envs = resolved_envs_factory(default=["linux-64"])
+    frag_a = _write_fragment(ctx, resolved_envs, "linux-64")
+
+    # Produce a second fragment with a different channel list by
+    # tweaking the saved content directly.
+    frag_b = ctx.root / "conda.lock.osx-arm64"
+    content = (
+        frag_a.read_text(encoding="utf-8")
+        .replace("linux-64", "osx-arm64")
+        .replace(
+            "conda-forge",
+            "different-channel",
+        )
+    )
+    frag_b.write_text(content, encoding="utf-8")
+    from conda_lockfiles.load_yaml import load_yaml
+
+    load_yaml.cache_clear()
+
+    with pytest.raises(LockfileMergeError, match="channels differ"):
+        merge_lockfiles([frag_a, frag_b], ctx)
+
+
+def test_merge_lockfiles_duplicate_platform(
+    workspace_ctx_factory: Callable[..., WorkspaceContext],
+    fake_solver_factory,
+    resolved_envs_factory,
+) -> None:
+    ctx = workspace_ctx_factory(env_names=["default"])
+    fake_solver_factory()
+    resolved_envs = resolved_envs_factory(default=["linux-64"])
+    frag_a = _write_fragment(ctx, resolved_envs, "linux-64")
+
+    frag_b = ctx.root / "conda.lock.linux-64.dup"
+    frag_b.write_text(frag_a.read_text(encoding="utf-8"), encoding="utf-8")
+    from conda_lockfiles.load_yaml import load_yaml
+
+    load_yaml.cache_clear()
+
+    with pytest.raises(LockfileMergeError, match="present in both"):
+        merge_lockfiles([frag_a, frag_b], ctx)


### PR DESCRIPTION
## Summary

- `conda workspace lock` gained `--output <path>` and `--merge <glob>` so matrix CI pipelines can split solving across runners and stitch the fragments back into a single `conda.lock` without re-solving.
- Producer side: `--output` threads through to a new `output_path` kwarg on `generate_lockfile`; combine with `--platform` to emit per-platform fragments (e.g. `conda.lock.linux-64`).
- Consumer side: new `merge_lockfiles(paths, ctx)` helper plus `--merge` (repeatable, accepts globs). It validates schema version, per-env channel-list equality, and rejects overlapping `(env, platform)` pairs; failures raise the new `LockfileMergeError` and nothing is written. Merged output is byte-stable with a single-run lock for the same inputs.
- `--merge` is mutually exclusive with `--environment`, `--platform`, `--skip-unsolvable`, and `--output`.

Closes #34.

## Test plan

- [x] `pixi run -e test pytest` (800 passed)
- [x] `pixi run ruff check`
- [x] `pixi run ruff format --check`
- [x] New `test_merge_lockfiles_byte_stable_with_single_run` confirms fragment-merge output matches single-run output byte-for-byte
- [ ] `pixi run demos ci-split` to regenerate the gif/mp4 locally
- [ ] Try the end-to-end pipeline in a real GitHub Actions matrix