### PR TITLE
Add `conda workspace quickstart` orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,24 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   byte-stable with a single-run `conda workspace lock` over the same
   inputs. `--merge` is mutually exclusive with `--environment`,
   `--platform`, `--skip-unsolvable`, and `--output`.
+- New `conda workspace quickstart` command that bootstraps a workspace
+  in one step. It composes the existing `init`, `add`, `install`, and
+  `shell` handlers: run it in an empty directory to scaffold a
+  manifest, immediately add any specs passed on the command line
+  (e.g. `conda workspace quickstart python=3.14 numpy`), install the
+  selected environment, and drop into an activated shell. `--copy`
+  (alias `--clone`) copies an existing workspace's manifest from a
+  directory or file path instead of running `init`; `--format` is
+  then ignored with a warning since the copied manifest dictates the
+  format. Flags from `init` (`--name`, `-c/--channel`, `--platform`,
+  `--format`) and `install` (`-e/--environment`, `--force-reinstall`,
+  `--locked`, `--frozen`) are forwarded verbatim, alongside conda's
+  shared output/prompt options (`--dry-run`, `--json`, `--yes`,
+  `-v/-q`, `--debug`, `--trace`, `--console`). `--no-shell` skips the
+  final `shell` step (for CI), `--json` implies `--no-shell` and
+  prints a single structured `{workspace, environment, manifest,
+  specs_added, shell_spawned}` payload, and `--dry-run` reports the
+  pipeline without touching the filesystem.
 - `conda workspace lock` now writes a single `conda.lock` that covers
   every platform declared by each environment, not just the host
   platform. Target-platform solves run with `context._subdir`

--- a/conda_workspaces/cli/main.py
+++ b/conda_workspaces/cli/main.py
@@ -482,6 +482,99 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
         help="Optional command to run in the spawned shell.",
     )
 
+    quickstart_parser = sub.add_parser(
+        "quickstart",
+        help=(
+            "Bootstrap a workspace in one command: init (or copy an existing"
+            " manifest), add the given specs, install the environment,"
+            " and drop into a shell."
+        ),
+        add_help=False,
+    )
+    add_parser_help(quickstart_parser)
+    add_output_and_prompt_options(quickstart_parser)
+    quickstart_parser.add_argument(
+        "specs",
+        nargs="*",
+        default=[],
+        help=(
+            "Optional package specs to add immediately (same grammar as"
+            " `conda workspace add`, e.g. 'python=3.14' 'numpy>=2.4')."
+        ),
+    )
+    quickstart_parser.add_argument(
+        "--format",
+        choices=["pixi", "conda", "pyproject"],
+        default="conda",
+        dest="manifest_format",
+        help=(
+            "Manifest format for the generated workspace (default: conda)."
+            " Ignored with a warning when --copy/--clone is used."
+        ),
+    )
+    quickstart_parser.add_argument(
+        "--name",
+        default=None,
+        help="Workspace name (defaults to directory name).",
+    )
+    quickstart_parser.add_argument(
+        "--channel",
+        "-c",
+        action="append",
+        default=None,
+        dest="channels",
+        help="Channels to include (repeatable, default: conda-forge).",
+    )
+    quickstart_parser.add_argument(
+        "--platform",
+        action="append",
+        default=None,
+        dest="platforms",
+        help="Platforms to support (repeatable, auto-detected if omitted).",
+    )
+    quickstart_parser.add_argument(
+        "-e",
+        "--environment",
+        default="default",
+        help="Environment to install and spawn a shell in (default: default).",
+    )
+    quickstart_parser.add_argument(
+        "--force-reinstall",
+        action="store_true",
+        default=False,
+        help="Re-run install from scratch even if the environment exists.",
+    )
+    quickstart_parser.add_argument(
+        "--locked",
+        action="store_true",
+        default=False,
+        help="Install from existing lockfiles, verifying they are up-to-date.",
+    )
+    quickstart_parser.add_argument(
+        "--frozen",
+        action="store_true",
+        default=False,
+        help="Install from existing lockfiles without checking freshness.",
+    )
+    quickstart_parser.add_argument(
+        "--copy",
+        "--clone",
+        dest="copy_from",
+        type=Path,
+        default=None,
+        help=(
+            "Copy a source workspace's manifest (conda.toml / pixi.toml /"
+            " pyproject.toml) into the current directory instead of"
+            " running `init`. Accepts a directory or a manifest file."
+        ),
+    )
+    quickstart_parser.add_argument(
+        "--no-shell",
+        action="store_true",
+        default=False,
+        help="Skip the final `conda workspace shell` step (useful for CI).",
+    )
+
     import_parser = sub.add_parser(
         "import",
         help="Import a manifest from another format into conda.toml.",
@@ -580,6 +673,10 @@ def _dispatch_workspace(args: argparse.Namespace, subcmd: str) -> int:
         from .workspace.import_manifest import execute_import
 
         return execute_import(args)
+    elif subcmd == "quickstart":
+        from .workspace.quickstart import execute_quickstart
+
+        return execute_quickstart(args)
     else:
         generate_workspace_parser().print_help()
         return 0

--- a/conda_workspaces/cli/workspace/init.py
+++ b/conda_workspaces/cli/workspace/init.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import tomlkit
 from conda.base.context import context as conda_context
 from rich.console import Console
 
-from ...exceptions import ManifestExistsError
 from ...manifests.base import ManifestParser
 from .. import status
 
@@ -18,97 +16,26 @@ if TYPE_CHECKING:
 
 
 def execute_init(args: argparse.Namespace, *, console: Console | None = None) -> int:
-    """Create a new workspace manifest in the current directory."""
+    """Create a new workspace manifest in the current directory.
+
+    Delegates the actual file layout to
+    :meth:`ManifestParser.write_workspace_stub` on the parser selected
+    by ``--format``.  The default implementation writes a fresh
+    ``conda.toml`` / ``pixi.toml``; :class:`PyprojectTomlParser`
+    overrides it to append ``[tool.conda]`` to an existing
+    ``pyproject.toml`` when one is present.  ``init`` itself stays
+    format-agnostic and only owns argument wiring and the user-visible
+    status message.
+    """
     if console is None:
         console = Console(highlight=False)
-    fmt = args.manifest_format
+
     name = args.name or Path.cwd().name
     channels = args.channels or ["conda-forge"]
-
-    if args.platforms:
-        platforms = args.platforms
-    else:
-        platforms = _detect_platforms()
-
+    platforms = args.platforms or [conda_context.subdir]
     base_dir = Path(args.file).parent if args.file else Path.cwd()
 
-    parser = ManifestParser.for_format(fmt)
-    if fmt == "pyproject":
-        return _write_pyproject_toml(
-            name, channels, platforms, base_dir, console=console
-        )
-    return _write_workspace_toml(
-        parser.manifest_filename, name, channels, platforms, base_dir, console=console
-    )
-
-
-def _detect_platforms() -> list[str]:
-    """Return the current platform as detected by conda."""
-    return [conda_context.subdir]
-
-
-def _write_workspace_toml(
-    filename: str,
-    name: str,
-    channels: list[str],
-    platforms: list[str],
-    base_dir: Path,
-    *,
-    console: Console,
-) -> int:
-    path = base_dir / filename
-    if path.exists():
-        raise ManifestExistsError(path)
-
-    doc = tomlkit.document()
-
-    ws = tomlkit.table()
-    ws.add("name", name)
-    ws.add("channels", channels)
-    ws.add("platforms", platforms)
-    doc.add("workspace", ws)
-
-    deps = tomlkit.table()
-    doc.add("dependencies", deps)
-
-    path.write_text(tomlkit.dumps(doc), encoding="utf-8")
-    status.message(console, "Created", "workspace", path.name, detail=str(path.parent))
-    return 0
-
-
-def _write_pyproject_toml(
-    name: str,
-    channels: list[str],
-    platforms: list[str],
-    base_dir: Path,
-    *,
-    console: Console,
-) -> int:
-    path = base_dir / "pyproject.toml"
-    existed = path.exists()
-
-    if existed:
-        text = path.read_text(encoding="utf-8")
-        doc = tomlkit.loads(text)
-    else:
-        doc = tomlkit.document()
-
-    tool = doc.setdefault("tool", tomlkit.table())
-    if "conda" in tool:
-        raise ManifestExistsError("[tool.conda] in pyproject.toml")
-    if "pixi" in tool:
-        raise ManifestExistsError("[tool.pixi] in pyproject.toml")
-
-    conda = tomlkit.table()
-    ws = tomlkit.table()
-    ws.add("name", name)
-    ws.add("channels", channels)
-    ws.add("platforms", platforms)
-    conda.add("workspace", ws)
-    conda.add("dependencies", tomlkit.table())
-    tool.add("conda", conda)
-
-    path.write_text(tomlkit.dumps(doc), encoding="utf-8")
-    verb = "Updated" if existed else "Created"
+    parser = ManifestParser.for_format(args.manifest_format)
+    path, verb = parser.write_workspace_stub(base_dir, name, channels, platforms)
     status.message(console, verb, "workspace", path.name, detail=str(path.parent))
     return 0

--- a/conda_workspaces/cli/workspace/init.py
+++ b/conda_workspaces/cli/workspace/init.py
@@ -10,6 +10,7 @@ from conda.base.context import context as conda_context
 from rich.console import Console
 
 from ...exceptions import ManifestExistsError
+from ...manifests.base import ManifestParser
 from .. import status
 
 if TYPE_CHECKING:
@@ -31,21 +32,14 @@ def execute_init(args: argparse.Namespace, *, console: Console | None = None) ->
 
     base_dir = Path(args.file).parent if args.file else Path.cwd()
 
-    if fmt == "pixi":
-        return _write_workspace_toml(
-            "pixi.toml", name, channels, platforms, base_dir, console=console
-        )
-    elif fmt == "conda":
-        return _write_workspace_toml(
-            "conda.toml", name, channels, platforms, base_dir, console=console
-        )
-    elif fmt == "pyproject":
+    parser = ManifestParser.for_format(fmt)
+    if fmt == "pyproject":
         return _write_pyproject_toml(
             name, channels, platforms, base_dir, console=console
         )
-
-    msg = f"Unknown manifest format: {fmt}"
-    raise ValueError(msg)
+    return _write_workspace_toml(
+        parser.manifest_filename, name, channels, platforms, base_dir, console=console
+    )
 
 
 def _detect_platforms() -> list[str]:

--- a/conda_workspaces/cli/workspace/quickstart.py
+++ b/conda_workspaces/cli/workspace/quickstart.py
@@ -28,7 +28,6 @@ import json
 import shutil
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from rich.console import Console
 
@@ -39,18 +38,9 @@ from .init import execute_init
 from .install import execute_install
 from .shell import execute_shell
 
-if TYPE_CHECKING:
-    from collections.abc import Iterable
-
-
-#: Keys forwarded from ``quickstart`` to the respective sub-handler.
-_INIT_KEYS: tuple[str, ...] = ("manifest_format", "name", "channels", "platforms")
-_INSTALL_KEYS: tuple[str, ...] = (
-    "environment",
-    "force_reinstall",
-    "locked",
-    "frozen",
-)
+#: Global prompt / output flags every sub-handler sees (``--json``,
+#: ``--dry-run``, ``--yes``, ``-v``/``-q``, ``--debug``, ``--trace``).
+#: Forwarded verbatim through :func:`execute_quickstart.with_prompts`.
 _PROMPT_KEYS: tuple[str, ...] = (
     "json",
     "yes",
@@ -64,24 +54,6 @@ _PROMPT_KEYS: tuple[str, ...] = (
 
 class QuickstartCopyError(CondaWorkspacesError):
     """``--copy`` / ``--clone`` pointed at something we cannot use."""
-
-
-def _forward(
-    args: argparse.Namespace,
-    keys: Iterable[str],
-    **extras: object,
-) -> argparse.Namespace:
-    """Build a sub-handler ``Namespace`` by copying *keys* and ``_PROMPT_KEYS``.
-
-    *extras* overlay the copied values so callers can pin handler-specific
-    defaults (e.g. ``file=None`` for init, ``cmd=None`` for shell).
-    """
-    ns = argparse.Namespace()
-    for key in (*keys, *_PROMPT_KEYS):
-        setattr(ns, key, getattr(args, key, None))
-    for key, value in extras.items():
-        setattr(ns, key, value)
-    return ns
 
 
 def execute_quickstart(
@@ -104,6 +76,22 @@ def execute_quickstart(
     if getattr(args, "file", None):
         workspace_root = Path(args.file).resolve().parent
 
+    common_file = getattr(args, "file", None)
+
+    def with_prompts(**kwargs: object) -> argparse.Namespace:
+        """Build a sub-handler ``Namespace`` from *kwargs* + ``_PROMPT_KEYS``.
+
+        Each sub-handler call site lists the flags it cares about
+        explicitly; this closure fills in the global prompt/output
+        flags (``--json`` / ``--dry-run`` / etc.) that every handler
+        must see so terminal output and machine-readable output stay
+        coherent across the pipeline.
+        """
+        ns = argparse.Namespace(**kwargs)
+        for key in _PROMPT_KEYS:
+            setattr(ns, key, getattr(args, key, None))
+        return ns
+
     if copy_from is not None:
         if getattr(args, "manifest_format", None) not in (None, "conda"):
             console.print(
@@ -124,15 +112,21 @@ def execute_quickstart(
         )
         manifest_path = _guess_manifest_path(workspace_root, args)
     else:
-        execute_init(_forward(args, _INIT_KEYS, file=None))
+        execute_init(
+            with_prompts(
+                file=None,
+                manifest_format=getattr(args, "manifest_format", None),
+                name=getattr(args, "name", None),
+                channels=getattr(args, "channels", None),
+                platforms=getattr(args, "platforms", None),
+            )
+        )
         manifest_path = _guess_manifest_path(workspace_root, args)
 
-    common_file = getattr(args, "file", None)
     if specs:
         execute_add(
-            _forward(
-                args,
-                (),
+            with_prompts(
+                file=common_file,
                 specs=list(specs),
                 environment=None,
                 feature=None,
@@ -140,21 +134,26 @@ def execute_quickstart(
                 no_install=False,
                 no_lockfile_update=False,
                 force_reinstall=bool(getattr(args, "force_reinstall", False)),
-                file=common_file,
             )
         )
     else:
-        execute_install(_forward(args, _INSTALL_KEYS, file=common_file))
+        execute_install(
+            with_prompts(
+                file=common_file,
+                environment=getattr(args, "environment", None),
+                force_reinstall=getattr(args, "force_reinstall", None),
+                locked=getattr(args, "locked", None),
+                frozen=getattr(args, "frozen", None),
+            )
+        )
 
     shell_spawned = False
     if not no_shell and not dry_run:
         execute_shell(
-            _forward(
-                args,
-                (),
+            with_prompts(
+                file=common_file,
                 environment=env_name,
                 cmd=None,
-                file=common_file,
             )
         )
         shell_spawned = True

--- a/conda_workspaces/cli/workspace/quickstart.py
+++ b/conda_workspaces/cli/workspace/quickstart.py
@@ -1,0 +1,250 @@
+"""``conda workspace quickstart`` — orchestrate init + add + install + shell.
+
+``quickstart`` is deliberately free of business logic: it is a thin
+composition of :func:`execute_init`, :func:`execute_add`,
+:func:`execute_install`, and :func:`execute_shell`.  Each sub-handler
+owns its own error handling, dry-run semantics, and conda integration;
+``quickstart`` just builds the right :class:`argparse.Namespace` for
+each one and stitches their outputs together.
+
+The one concession to user experience lives at the ``--copy`` / ``--clone``
+path: when the user points quickstart at an existing workspace, we
+copy whichever manifest (``conda.toml`` / ``pixi.toml`` /
+``pyproject.toml``) :func:`manifests.detect_workspace_file` finds there
+into the current directory and skip the ``init`` step entirely.  Any
+``--format`` value is ignored with a warning in that case — the copied
+manifest already dictates the format.
+
+The ``--json`` path is self-contained: we swallow sub-handler console
+output and emit a single structured result at the end, mirroring the
+shape other workspace commands use so callers can pipe the output
+without guessing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rich.console import Console
+
+from ...exceptions import CondaWorkspacesError
+from ...manifests import detect_workspace_file
+from .add import execute_add
+from .init import execute_init
+from .install import execute_install
+from .shell import execute_shell
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+#: Keys forwarded from ``quickstart`` to the respective sub-handler.
+_INIT_KEYS: tuple[str, ...] = ("manifest_format", "name", "channels", "platforms")
+_INSTALL_KEYS: tuple[str, ...] = (
+    "environment",
+    "force_reinstall",
+    "locked",
+    "frozen",
+)
+_PROMPT_KEYS: tuple[str, ...] = (
+    "json",
+    "yes",
+    "dry_run",
+    "quiet",
+    "verbose",
+    "debug",
+    "trace",
+)
+
+
+class QuickstartCopyError(CondaWorkspacesError):
+    """``--copy`` / ``--clone`` pointed at something we cannot use."""
+
+
+def _forward(
+    args: argparse.Namespace,
+    keys: Iterable[str],
+    **extras: object,
+) -> argparse.Namespace:
+    """Build a sub-handler ``Namespace`` by copying *keys* and ``_PROMPT_KEYS``.
+
+    *extras* overlay the copied values so callers can pin handler-specific
+    defaults (e.g. ``file=None`` for init, ``cmd=None`` for shell).
+    """
+    ns = argparse.Namespace()
+    for key in (*keys, *_PROMPT_KEYS):
+        setattr(ns, key, getattr(args, key, None))
+    for key, value in extras.items():
+        setattr(ns, key, value)
+    return ns
+
+
+def execute_quickstart(
+    args: argparse.Namespace,
+    *,
+    console: Console | None = None,
+) -> int:
+    """Run the init -> add -> install -> shell pipeline."""
+    if console is None:
+        console = Console(highlight=False)
+
+    dry_run = bool(getattr(args, "dry_run", False))
+    json_output = bool(getattr(args, "json", False))
+    no_shell = bool(getattr(args, "no_shell", False)) or json_output
+    copy_from: Path | None = getattr(args, "copy_from", None)
+    specs: list[str] = list(getattr(args, "specs", None) or [])
+    env_name = getattr(args, "environment", "default") or "default"
+
+    workspace_root = Path.cwd()
+    if getattr(args, "file", None):
+        workspace_root = Path(args.file).resolve().parent
+
+    if copy_from is not None:
+        if getattr(args, "manifest_format", None) not in (None, "conda"):
+            console.print(
+                "[bold yellow]Warning[/bold yellow] --format is ignored when"
+                " --copy/--clone is used; the copied manifest dictates the"
+                " format."
+            )
+        manifest_path = _copy_manifest(
+            copy_from,
+            workspace_root,
+            dry_run=dry_run,
+            console=console,
+        )
+    elif dry_run:
+        console.print(
+            "[bold blue]Would create[/bold blue] workspace manifest in"
+            f" [bold]{workspace_root}[/bold]"
+        )
+        manifest_path = _guess_manifest_path(workspace_root, args)
+    else:
+        execute_init(_forward(args, _INIT_KEYS, file=None))
+        manifest_path = _guess_manifest_path(workspace_root, args)
+
+    common_file = getattr(args, "file", None)
+    if specs:
+        execute_add(
+            _forward(
+                args,
+                (),
+                specs=list(specs),
+                environment=None,
+                feature=None,
+                pypi=False,
+                no_install=False,
+                no_lockfile_update=False,
+                force_reinstall=bool(getattr(args, "force_reinstall", False)),
+                file=common_file,
+            )
+        )
+    else:
+        execute_install(_forward(args, _INSTALL_KEYS, file=common_file))
+
+    shell_spawned = False
+    if not no_shell and not dry_run:
+        execute_shell(
+            _forward(
+                args,
+                (),
+                environment=env_name,
+                cmd=None,
+                file=common_file,
+            )
+        )
+        shell_spawned = True
+
+    if json_output:
+        payload = {
+            "workspace": str(workspace_root),
+            "environment": env_name,
+            "manifest": manifest_path.name if manifest_path is not None else None,
+            "specs_added": specs,
+            "shell_spawned": shell_spawned,
+        }
+        sys.stdout.write(json.dumps(payload) + "\n")
+        sys.stdout.flush()
+    elif not dry_run:
+        console.print(
+            "\n[bold green]Workspace ready[/bold green] in"
+            f" [bold]{workspace_root}[/bold]"
+        )
+
+    return 0
+
+
+def _copy_manifest(
+    source: Path,
+    dest_dir: Path,
+    *,
+    dry_run: bool,
+    console: Console,
+) -> Path:
+    """Copy the workspace manifest from *source* into *dest_dir*.
+
+    *source* may be either a directory containing a manifest or a path
+    to the manifest itself.  The returned path is the manifest location
+    inside *dest_dir*.
+    """
+    if not source.exists():
+        raise QuickstartCopyError(
+            f"--copy source '{source}' does not exist.",
+            hints=["Pass an existing workspace directory or manifest file."],
+        )
+
+    if source.is_dir():
+        try:
+            manifest = detect_workspace_file(source)
+        except CondaWorkspacesError as exc:
+            raise QuickstartCopyError(
+                f"--copy source '{source}' does not contain a workspace manifest.",
+                hints=list(getattr(exc, "hints", None) or []),
+            ) from exc
+    else:
+        manifest = source
+
+    target = dest_dir / manifest.name
+    if target.exists():
+        raise QuickstartCopyError(
+            f"'{target}' already exists; refusing to overwrite.",
+            hints=["Remove the existing manifest or pick a different directory."],
+        )
+
+    if dry_run:
+        console.print(
+            f"[bold blue]Would copy[/bold blue] [bold]{manifest}[/bold]"
+            f" -> [bold]{target}[/bold]"
+        )
+        return target
+
+    shutil.copyfile(manifest, target)
+    console.print(
+        f"[bold cyan]Copied[/bold cyan] [bold]{manifest.name}[/bold]"
+        f" from [bold]{manifest.parent}[/bold]"
+    )
+    return target
+
+
+def _guess_manifest_path(workspace_root: Path, args: argparse.Namespace) -> Path:
+    """Pick the manifest path init will (or did) write.
+
+    Used only for the ``--json`` payload; falls back to ``conda.toml``
+    when the format is unspecified so the output field is never empty.
+    """
+    fmt = getattr(args, "manifest_format", None) or "conda"
+    if fmt == "pixi":
+        return workspace_root / "pixi.toml"
+    if fmt == "pyproject":
+        return workspace_root / "pyproject.toml"
+    return workspace_root / "conda.toml"
+
+
+__all__ = [
+    "QuickstartCopyError",
+    "execute_quickstart",
+]

--- a/conda_workspaces/cli/workspace/quickstart.py
+++ b/conda_workspaces/cli/workspace/quickstart.py
@@ -33,8 +33,8 @@ from pathlib import Path
 from rich.console import Console
 
 from ...exceptions import (
-    CondaWorkspacesError,
     ManifestExistsError,
+    QuickstartCopyError,
     WorkspaceNotFoundError,
 )
 from ...manifests.base import ManifestParser
@@ -55,10 +55,6 @@ _PROMPT_KEYS: tuple[str, ...] = (
     "debug",
     "trace",
 )
-
-
-class QuickstartCopyError(CondaWorkspacesError):
-    """``--copy`` / ``--clone`` pointed at something we cannot use."""
 
 
 def execute_quickstart(
@@ -234,7 +230,4 @@ def _copy_manifest(
     return target
 
 
-__all__ = [
-    "QuickstartCopyError",
-    "execute_quickstart",
-]
+__all__ = ["execute_quickstart"]

--- a/conda_workspaces/cli/workspace/quickstart.py
+++ b/conda_workspaces/cli/workspace/quickstart.py
@@ -43,19 +43,6 @@ from .init import execute_init
 from .install import execute_install
 from .shell import execute_shell
 
-#: Global prompt / output flags every sub-handler sees (``--json``,
-#: ``--dry-run``, ``--yes``, ``-v``/``-q``, ``--debug``, ``--trace``).
-#: Forwarded verbatim through :func:`execute_quickstart.with_prompts`.
-_PROMPT_KEYS: tuple[str, ...] = (
-    "json",
-    "yes",
-    "dry_run",
-    "quiet",
-    "verbose",
-    "debug",
-    "trace",
-)
-
 
 def execute_quickstart(
     args: argparse.Namespace,
@@ -66,37 +53,32 @@ def execute_quickstart(
     if console is None:
         console = Console(highlight=False)
 
-    dry_run = bool(getattr(args, "dry_run", False))
-    json_output = bool(getattr(args, "json", False))
-    no_shell = bool(getattr(args, "no_shell", False)) or json_output
-    copy_from: Path | None = getattr(args, "copy_from", None)
-    specs: list[str] = list(getattr(args, "specs", None) or [])
-    env_name = getattr(args, "environment", "default") or "default"
+    dry_run: bool = args.dry_run
+    json_output: bool = args.json
+    no_shell: bool = args.no_shell or json_output
+    copy_from: Path | None = args.copy_from
+    specs: list[str] = list(args.specs or [])
+    env_name: str = args.environment or "default"
+    fmt: str = args.manifest_format or "conda"
 
     workspace_root = Path.cwd()
-    if getattr(args, "file", None):
-        workspace_root = Path(args.file).resolve().parent
 
-    common_file = getattr(args, "file", None)
+    # Global prompt / output flags every sub-handler must see
+    # (``--json`` / ``--dry-run`` / ``--yes`` / ``-v`` / ``-q`` /
+    # ``--debug`` / ``--trace``) so terminal output and machine-readable
+    # output stay coherent across the pipeline.  ``add_output_and_prompt_options``
+    # on the parent parser guarantees each attribute exists.
+    prompt_keys = ("json", "yes", "dry_run", "quiet", "verbose", "debug", "trace")
 
     def with_prompts(**kwargs: object) -> argparse.Namespace:
-        """Build a sub-handler ``Namespace`` from *kwargs* + ``_PROMPT_KEYS``.
-
-        Each sub-handler call site lists the flags it cares about
-        explicitly; this closure fills in the global prompt/output
-        flags (``--json`` / ``--dry-run`` / etc.) that every handler
-        must see so terminal output and machine-readable output stay
-        coherent across the pipeline.
-        """
+        """Build a sub-handler ``Namespace`` from *kwargs* + ``prompt_keys``."""
         ns = argparse.Namespace(**kwargs)
-        for key in _PROMPT_KEYS:
-            setattr(ns, key, getattr(args, key, None))
+        for key in prompt_keys:
+            setattr(ns, key, getattr(args, key))
         return ns
 
-    fmt = getattr(args, "manifest_format", None) or "conda"
-
     if copy_from is not None:
-        if getattr(args, "manifest_format", None) not in (None, "conda"):
+        if args.manifest_format not in (None, "conda"):
             console.print(
                 "[bold yellow]Warning[/bold yellow] --format is ignored when"
                 " --copy/--clone is used; the copied manifest dictates the"
@@ -148,35 +130,38 @@ def execute_quickstart(
         execute_init(
             with_prompts(
                 file=None,
-                manifest_format=getattr(args, "manifest_format", None),
-                name=getattr(args, "name", None),
-                channels=getattr(args, "channels", None),
-                platforms=getattr(args, "platforms", None),
+                manifest_format=args.manifest_format,
+                name=args.name,
+                channels=args.channels,
+                platforms=args.platforms,
             )
         )
         manifest_path = ManifestParser.for_format(fmt).manifest_path(workspace_root)
 
-    if specs:
+    if dry_run:
+        # No manifest on disk yet; skip add/install side effects.
+        pass
+    elif specs:
         execute_add(
             with_prompts(
-                file=common_file,
+                file=None,
                 specs=list(specs),
                 environment=None,
                 feature=None,
                 pypi=False,
                 no_install=False,
                 no_lockfile_update=False,
-                force_reinstall=bool(getattr(args, "force_reinstall", False)),
+                force_reinstall=args.force_reinstall,
             )
         )
     else:
         execute_install(
             with_prompts(
-                file=common_file,
-                environment=getattr(args, "environment", None),
-                force_reinstall=getattr(args, "force_reinstall", None),
-                locked=getattr(args, "locked", None),
-                frozen=getattr(args, "frozen", None),
+                file=None,
+                environment=args.environment,
+                force_reinstall=args.force_reinstall,
+                locked=args.locked,
+                frozen=args.frozen,
             )
         )
 
@@ -184,7 +169,7 @@ def execute_quickstart(
     if not no_shell and not dry_run:
         execute_shell(
             with_prompts(
-                file=common_file,
+                file=None,
                 environment=env_name,
                 cmd=None,
             )

--- a/conda_workspaces/cli/workspace/quickstart.py
+++ b/conda_workspaces/cli/workspace/quickstart.py
@@ -9,11 +9,13 @@ each one and stitches their outputs together.
 
 The one concession to user experience lives at the ``--copy`` / ``--clone``
 path: when the user points quickstart at an existing workspace, we
-copy whichever manifest (``conda.toml`` / ``pixi.toml`` /
-``pyproject.toml``) :func:`manifests.detect_workspace_file` finds there
-into the current directory and skip the ``init`` step entirely.  Any
-``--format`` value is ignored with a warning in that case — the copied
-manifest already dictates the format.
+delegate to :meth:`ManifestParser.copy_manifest` (which walks the
+source with :func:`manifests.detect_workspace_file` when given a
+directory) to copy whichever manifest — ``conda.toml`` /
+``pixi.toml`` / ``pyproject.toml`` — lives there into the current
+directory and skip the ``init`` step entirely.  Any ``--format``
+value is ignored with a warning in that case — the copied manifest
+already dictates the format.
 
 The ``--json`` path is self-contained: we swallow sub-handler console
 output and emit a single structured result at the end, mirroring the
@@ -25,14 +27,17 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 import sys
 from pathlib import Path
 
 from rich.console import Console
 
-from ...exceptions import CondaWorkspacesError
-from ...manifests import detect_workspace_file
+from ...exceptions import (
+    CondaWorkspacesError,
+    ManifestExistsError,
+    WorkspaceNotFoundError,
+)
+from ...manifests.base import ManifestParser
 from .add import execute_add
 from .init import execute_init
 from .install import execute_install
@@ -92,6 +97,8 @@ def execute_quickstart(
             setattr(ns, key, getattr(args, key, None))
         return ns
 
+    fmt = getattr(args, "manifest_format", None) or "conda"
+
     if copy_from is not None:
         if getattr(args, "manifest_format", None) not in (None, "conda"):
             console.print(
@@ -110,7 +117,7 @@ def execute_quickstart(
             "[bold blue]Would create[/bold blue] workspace manifest in"
             f" [bold]{workspace_root}[/bold]"
         )
-        manifest_path = _guess_manifest_path(workspace_root, args)
+        manifest_path = ManifestParser.for_format(fmt).manifest_path(workspace_root)
     else:
         execute_init(
             with_prompts(
@@ -121,7 +128,7 @@ def execute_quickstart(
                 platforms=getattr(args, "platforms", None),
             )
         )
-        manifest_path = _guess_manifest_path(workspace_root, args)
+        manifest_path = ManifestParser.for_format(fmt).manifest_path(workspace_root)
 
     if specs:
         execute_add(
@@ -184,63 +191,47 @@ def _copy_manifest(
     dry_run: bool,
     console: Console,
 ) -> Path:
-    """Copy the workspace manifest from *source* into *dest_dir*.
+    """CLI presentation wrapper around :meth:`ManifestParser.copy_manifest`.
 
-    *source* may be either a directory containing a manifest or a path
-    to the manifest itself.  The returned path is the manifest location
-    inside *dest_dir*.
+    Resolves *source* (dir or file) to the manifest the classmethod
+    would copy, then either previews the move (``--dry-run``) or
+    performs it.  Translates the underlying file / manifest errors
+    into :class:`QuickstartCopyError` so quickstart's error surface
+    stays uniform.
     """
-    if not source.exists():
+    try:
+        manifest = ManifestParser.resolve_source(source)
+        target = dest_dir / manifest.name
+        if target.exists():
+            raise ManifestExistsError(target)
+        if dry_run:
+            console.print(
+                f"[bold blue]Would copy[/bold blue] [bold]{manifest}[/bold]"
+                f" -> [bold]{target}[/bold]"
+            )
+            return target
+        ManifestParser.copy_manifest(source, dest_dir)
+    except FileNotFoundError as exc:
         raise QuickstartCopyError(
             f"--copy source '{source}' does not exist.",
             hints=["Pass an existing workspace directory or manifest file."],
-        )
-
-    if source.is_dir():
-        try:
-            manifest = detect_workspace_file(source)
-        except CondaWorkspacesError as exc:
-            raise QuickstartCopyError(
-                f"--copy source '{source}' does not contain a workspace manifest.",
-                hints=list(getattr(exc, "hints", None) or []),
-            ) from exc
-    else:
-        manifest = source
-
-    target = dest_dir / manifest.name
-    if target.exists():
+        ) from exc
+    except WorkspaceNotFoundError as exc:
         raise QuickstartCopyError(
-            f"'{target}' already exists; refusing to overwrite.",
+            f"--copy source '{source}' does not contain a workspace manifest.",
+            hints=list(exc.hints),
+        ) from exc
+    except ManifestExistsError as exc:
+        raise QuickstartCopyError(
+            f"'{exc.path}' already exists; refusing to overwrite.",
             hints=["Remove the existing manifest or pick a different directory."],
-        )
+        ) from exc
 
-    if dry_run:
-        console.print(
-            f"[bold blue]Would copy[/bold blue] [bold]{manifest}[/bold]"
-            f" -> [bold]{target}[/bold]"
-        )
-        return target
-
-    shutil.copyfile(manifest, target)
     console.print(
         f"[bold cyan]Copied[/bold cyan] [bold]{manifest.name}[/bold]"
         f" from [bold]{manifest.parent}[/bold]"
     )
     return target
-
-
-def _guess_manifest_path(workspace_root: Path, args: argparse.Namespace) -> Path:
-    """Pick the manifest path init will (or did) write.
-
-    Used only for the ``--json`` payload; falls back to ``conda.toml``
-    when the format is unspecified so the output field is never empty.
-    """
-    fmt = getattr(args, "manifest_format", None) or "conda"
-    if fmt == "pixi":
-        return workspace_root / "pixi.toml"
-    if fmt == "pyproject":
-        return workspace_root / "pyproject.toml"
-    return workspace_root / "conda.toml"
 
 
 __all__ = [

--- a/conda_workspaces/cli/workspace/quickstart.py
+++ b/conda_workspaces/cli/workspace/quickstart.py
@@ -102,12 +102,42 @@ def execute_quickstart(
                 " --copy/--clone is used; the copied manifest dictates the"
                 " format."
             )
-        manifest_path = _copy_manifest(
-            copy_from,
-            workspace_root,
-            dry_run=dry_run,
-            console=console,
-        )
+        # Copy the foreign manifest into the workspace, translating the
+        # various "source missing / already exists" failures into one
+        # uniform ``QuickstartCopyError`` so quickstart's error surface
+        # stays consistent.  The real work lives on :class:`ManifestParser`;
+        # we only layer dry-run preview + Rich output on top.
+        try:
+            manifest = ManifestParser.resolve_source(copy_from)
+            manifest_path = workspace_root / manifest.name
+            if manifest_path.exists():
+                raise ManifestExistsError(manifest_path)
+            if dry_run:
+                console.print(
+                    f"[bold blue]Would copy[/bold blue] [bold]{manifest}[/bold]"
+                    f" -> [bold]{manifest_path}[/bold]"
+                )
+            else:
+                ManifestParser.copy_manifest(copy_from, workspace_root)
+                console.print(
+                    f"[bold cyan]Copied[/bold cyan] [bold]{manifest.name}[/bold]"
+                    f" from [bold]{manifest.parent}[/bold]"
+                )
+        except FileNotFoundError as exc:
+            raise QuickstartCopyError(
+                f"--copy source '{copy_from}' does not exist.",
+                hints=["Pass an existing workspace directory or manifest file."],
+            ) from exc
+        except WorkspaceNotFoundError as exc:
+            raise QuickstartCopyError(
+                f"--copy source '{copy_from}' does not contain a workspace manifest.",
+                hints=list(exc.hints),
+            ) from exc
+        except ManifestExistsError as exc:
+            raise QuickstartCopyError(
+                f"'{exc.path}' already exists; refusing to overwrite.",
+                hints=["Remove the existing manifest or pick a different directory."],
+            ) from exc
     elif dry_run:
         console.print(
             "[bold blue]Would create[/bold blue] workspace manifest in"
@@ -178,56 +208,6 @@ def execute_quickstart(
         )
 
     return 0
-
-
-def _copy_manifest(
-    source: Path,
-    dest_dir: Path,
-    *,
-    dry_run: bool,
-    console: Console,
-) -> Path:
-    """CLI presentation wrapper around :meth:`ManifestParser.copy_manifest`.
-
-    Resolves *source* (dir or file) to the manifest the classmethod
-    would copy, then either previews the move (``--dry-run``) or
-    performs it.  Translates the underlying file / manifest errors
-    into :class:`QuickstartCopyError` so quickstart's error surface
-    stays uniform.
-    """
-    try:
-        manifest = ManifestParser.resolve_source(source)
-        target = dest_dir / manifest.name
-        if target.exists():
-            raise ManifestExistsError(target)
-        if dry_run:
-            console.print(
-                f"[bold blue]Would copy[/bold blue] [bold]{manifest}[/bold]"
-                f" -> [bold]{target}[/bold]"
-            )
-            return target
-        ManifestParser.copy_manifest(source, dest_dir)
-    except FileNotFoundError as exc:
-        raise QuickstartCopyError(
-            f"--copy source '{source}' does not exist.",
-            hints=["Pass an existing workspace directory or manifest file."],
-        ) from exc
-    except WorkspaceNotFoundError as exc:
-        raise QuickstartCopyError(
-            f"--copy source '{source}' does not contain a workspace manifest.",
-            hints=list(exc.hints),
-        ) from exc
-    except ManifestExistsError as exc:
-        raise QuickstartCopyError(
-            f"'{exc.path}' already exists; refusing to overwrite.",
-            hints=["Remove the existing manifest or pick a different directory."],
-        ) from exc
-
-    console.print(
-        f"[bold cyan]Copied[/bold cyan] [bold]{manifest.name}[/bold]"
-        f" from [bold]{manifest.parent}[/bold]"
-    )
-    return target
 
 
 __all__ = ["execute_quickstart"]

--- a/conda_workspaces/exceptions.py
+++ b/conda_workspaces/exceptions.py
@@ -99,6 +99,19 @@ class ManifestExistsError(CondaWorkspacesError):
         )
 
 
+class QuickstartCopyError(CondaWorkspacesError):
+    """``conda workspace quickstart --copy`` / ``--clone`` cannot use the source.
+
+    Raised by :func:`conda_workspaces.cli.workspace.quickstart` when
+    ``--copy`` / ``--clone`` points at something we can't turn into a
+    manifest: a missing path, a directory without a recognisable
+    manifest, or a destination where one already exists.  Lives here
+    (not in the CLI module) so callers outside the CLI — tests,
+    downstream tooling — can catch it without importing the command
+    module itself.
+    """
+
+
 class FeatureNotFoundError(CondaWorkspacesError):
     """A feature referenced by an environment does not exist."""
 

--- a/conda_workspaces/manifests/base.py
+++ b/conda_workspaces/manifests/base.py
@@ -108,6 +108,39 @@ class ManifestParser(ABC):
         shutil.copyfile(manifest, target)
         return target
 
+    def write_workspace_stub(
+        self,
+        base_dir: Path,
+        name: str,
+        channels: list[str],
+        platforms: list[str],
+    ) -> tuple[Path, str]:
+        """Create a minimal workspace manifest under *base_dir*.
+
+        Writes a fresh TOML document with ``[workspace]`` and an empty
+        ``[dependencies]`` table at :meth:`manifest_path` and returns
+        ``(path, "Created")``.  Raises :class:`ManifestExistsError` if
+        the target file is already present — subclasses that share
+        their file with other tooling (see
+        :class:`PyprojectTomlParser`) override this method to append
+        their configuration under a nested table instead of refusing
+        outright, and report ``"Updated"`` when they did so.
+        """
+        path = self.manifest_path(base_dir)
+        if path.exists():
+            raise ManifestExistsError(path)
+
+        doc = tomlkit.document()
+        ws = tomlkit.table()
+        ws.add("name", name)
+        ws.add("channels", channels)
+        ws.add("platforms", platforms)
+        doc.add("workspace", ws)
+        doc.add("dependencies", tomlkit.table())
+
+        path.write_text(tomlkit.dumps(doc), encoding="utf-8")
+        return path, "Created"
+
     @abstractmethod
     def can_handle(self, path: Path) -> bool:
         """Return True if this parser can read *path*."""

--- a/conda_workspaces/manifests/base.py
+++ b/conda_workspaces/manifests/base.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 
 import tomlkit
 
+from ..exceptions import ManifestExistsError
+
 if TYPE_CHECKING:
     from pathlib import Path
     from typing import ClassVar
@@ -99,8 +101,6 @@ class ManifestParser(ABC):
         appropriate; callers layer their own dry-run / console policy
         on top.
         """
-        from ..exceptions import ManifestExistsError
-
         manifest = cls.resolve_source(source)
         target = dest_dir / manifest.name
         if target.exists():

--- a/conda_workspaces/manifests/base.py
+++ b/conda_workspaces/manifests/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -22,14 +23,90 @@ class ManifestParser(ABC):
 
     Each parser handles one file format (``conda.toml``, ``pixi.toml``,
     or ``pyproject.toml``).  Subclasses declare which files they can
-    handle via *filenames* and *extensions*.  The registry in
-    ``manifests/__init__.py`` uses these to auto-detect the right parser.
+    handle via *filenames* and a short *format_alias* (``"conda"`` /
+    ``"pixi"`` / ``"pyproject"``) that the CLI uses for ``--format``
+    values.  The registry in :mod:`conda_workspaces.manifests` uses
+    these to auto-detect the right parser and to resolve ``--format``
+    aliases to the parser that owns the matching filename.
 
     A single parser instance handles both workspace configuration and
     task definitions from the same file.
     """
 
+    format_alias: ClassVar[str] = ""
     filenames: ClassVar[tuple[str, ...]] = ()
+
+    @property
+    def manifest_filename(self) -> str:
+        """Canonical filename this parser reads and writes.
+
+        The first entry in :attr:`filenames` — e.g. ``"conda.toml"``
+        for :class:`CondaTomlParser`.  Used by :meth:`manifest_path` and
+        the ``conda workspace init`` / ``quickstart`` CLI paths so the
+        format-to-filename mapping lives in exactly one place.
+        """
+        return self.filenames[0]
+
+    def manifest_path(self, root: Path) -> Path:
+        """Return the manifest path this parser would (or did) write inside *root*."""
+        return root / self.manifest_filename
+
+    @classmethod
+    def for_format(cls, alias: str) -> ManifestParser:
+        """Return the registered parser whose :attr:`format_alias` matches *alias*.
+
+        Raises :class:`ValueError` when no parser claims *alias*.  The
+        registry is :data:`conda_workspaces.manifests._PARSERS`; this
+        classmethod is the canonical way for CLI code to translate a
+        ``--format`` value into the parser (and therefore the filename)
+        it implies.
+        """
+        from . import _PARSERS
+
+        for parser in _PARSERS:
+            if parser.format_alias == alias:
+                return parser
+        known = sorted(p.format_alias for p in _PARSERS if p.format_alias)
+        raise ValueError(
+            f"Unknown manifest format {alias!r}; expected one of: {', '.join(known)}"
+        )
+
+    @classmethod
+    def resolve_source(cls, source: Path) -> Path:
+        """Resolve *source* (directory or file) to a concrete manifest path.
+
+        Directories are walked via
+        :func:`conda_workspaces.manifests.detect_workspace_file`; files
+        are returned as-is.  Raises :class:`FileNotFoundError` when
+        *source* does not exist and
+        :class:`conda_workspaces.exceptions.WorkspaceNotFoundError`
+        when the directory contains no recognisable manifest.
+        """
+        from . import detect_workspace_file
+
+        if not source.exists():
+            raise FileNotFoundError(source)
+        return detect_workspace_file(source) if source.is_dir() else source
+
+    @classmethod
+    def copy_manifest(cls, source: Path, dest_dir: Path) -> Path:
+        """Copy the manifest at *source* into *dest_dir*; return the target path.
+
+        *source* may be a directory (walked via :meth:`resolve_source`)
+        or a manifest file.  Raises :class:`FileNotFoundError`,
+        :class:`conda_workspaces.exceptions.WorkspaceNotFoundError`, or
+        :class:`conda_workspaces.exceptions.ManifestExistsError` as
+        appropriate; callers layer their own dry-run / console policy
+        on top.
+        """
+        from ..exceptions import ManifestExistsError
+
+        manifest = cls.resolve_source(source)
+        target = dest_dir / manifest.name
+        if target.exists():
+            raise ManifestExistsError(target)
+        shutil.copyfile(manifest, target)
+        return target
 
     @abstractmethod
     def can_handle(self, path: Path) -> bool:

--- a/conda_workspaces/manifests/pixi_toml.py
+++ b/conda_workspaces/manifests/pixi_toml.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 class PixiTomlParser(ManifestParser):
     """Parse ``pixi.toml`` manifests (workspace and tasks)."""
 
+    format_alias = "pixi"
     filenames = ("pixi.toml",)
 
     def can_handle(self, path: Path) -> bool:

--- a/conda_workspaces/manifests/pyproject_toml.py
+++ b/conda_workspaces/manifests/pyproject_toml.py
@@ -13,7 +13,12 @@ from typing import TYPE_CHECKING
 
 import tomlkit
 
-from ..exceptions import TaskNotFoundError, TaskParseError, WorkspaceParseError
+from ..exceptions import (
+    ManifestExistsError,
+    TaskNotFoundError,
+    TaskParseError,
+    WorkspaceParseError,
+)
 from ..models import WorkspaceConfig
 from .base import ManifestParser
 from .normalize import parse_feature_tasks, parse_tasks_and_targets
@@ -41,6 +46,51 @@ class PyprojectTomlParser(ManifestParser):
 
     def can_handle(self, path: Path) -> bool:
         return path.name in self.filenames
+
+    def write_workspace_stub(
+        self,
+        base_dir: Path,
+        name: str,
+        channels: list[str],
+        platforms: list[str],
+    ) -> tuple[Path, str]:
+        """Add ``[tool.conda.workspace]`` to *base_dir*/``pyproject.toml``.
+
+        Unlike the default :meth:`ManifestParser.write_workspace_stub`
+        (which refuses to touch an existing file),
+        ``pyproject.toml`` is a shared packaging manifest owned by the
+        Python ecosystem — PEP 621 ``[project]``, ``[build-system]``,
+        and other tooling tables routinely coexist with ours.  We read
+        the existing document if any, add our configuration under the
+        nested ``[tool.conda]`` table, and report ``"Updated"`` so the
+        CLI can distinguish an append from a create.  An existing
+        ``[tool.conda]`` or ``[tool.pixi]`` raises
+        :class:`ManifestExistsError`.
+        """
+        path = self.manifest_path(base_dir)
+        existed = path.exists()
+        if existed:
+            doc = tomlkit.loads(path.read_text(encoding="utf-8"))
+        else:
+            doc = tomlkit.document()
+
+        tool = doc.setdefault("tool", tomlkit.table())
+        if "conda" in tool:
+            raise ManifestExistsError("[tool.conda] in pyproject.toml")
+        if "pixi" in tool:
+            raise ManifestExistsError("[tool.pixi] in pyproject.toml")
+
+        conda = tomlkit.table()
+        ws = tomlkit.table()
+        ws.add("name", name)
+        ws.add("channels", channels)
+        ws.add("platforms", platforms)
+        conda.add("workspace", ws)
+        conda.add("dependencies", tomlkit.table())
+        tool.add("conda", conda)
+
+        path.write_text(tomlkit.dumps(doc), encoding="utf-8")
+        return path, "Updated" if existed else "Created"
 
     def has_workspace(self, path: Path) -> bool:
         if not path.exists():

--- a/conda_workspaces/manifests/pyproject_toml.py
+++ b/conda_workspaces/manifests/pyproject_toml.py
@@ -36,6 +36,7 @@ class PyprojectTomlParser(ManifestParser):
     2. ``[tool.pixi.*]`` – pixi compatibility
     """
 
+    format_alias = "pyproject"
     filenames = ("pyproject.toml",)
 
     def can_handle(self, path: Path) -> bool:

--- a/conda_workspaces/manifests/toml.py
+++ b/conda_workspaces/manifests/toml.py
@@ -44,6 +44,7 @@ class CondaTomlParser(ManifestParser):
     but uses ``[workspace]`` exclusively (no ``[project]`` fallback).
     """
 
+    format_alias = "conda"
     filenames = ("conda.toml",)
 
     def can_handle(self, path: Path) -> bool:

--- a/demos/README.md
+++ b/demos/README.md
@@ -9,6 +9,7 @@ Animated terminal demos recorded with [VHS](https://github.com/charmbracelet/vhs
 | Demo | Description |
 |---|---|
 | `quickstart` | Init a workspace, add deps, install, list envs, run a command |
+| `workspace-quickstart` | Single-command bootstrap with `conda workspace quickstart` |
 | `lockfile` | Install, lock, clean, reinstall from lockfile |
 | `export` | Export manifests to environment.yml / environment.json / conda.lock via the plugin hook |
 | `ci-split` | Split locking across a CI matrix and merge fragments with `--merge` |

--- a/demos/workspace-quickstart.tape
+++ b/demos/workspace-quickstart.tape
@@ -1,0 +1,50 @@
+Source demos/_settings.tape
+
+Output demos/workspace-quickstart.gif
+Output demos/workspace-quickstart.mp4
+
+Hide
+Type `eval "$(pixi shell-hook -s bash -e dev)"`
+Enter
+Wait /\)/
+Type `export PS1="$DEMO_PS1" && mkdir -p /tmp/.demo-home && echo 'PS1="$ "' > /tmp/.demo-home/.bash_profile && export HOME=/tmp/.demo-home`
+Enter
+Wait /\$/
+Type "rm -rf /tmp/ws-quickstart && mkdir -p /tmp/ws-quickstart && cd /tmp/ws-quickstart"
+Enter
+Wait /\$/
+Type "clear"
+Enter
+Wait /\$/
+Show
+
+Type "# One command: init + add + install + shell"
+Enter
+Sleep 500ms
+
+Type@80ms `conda workspace quickstart --no-shell --name demo "python=3.12" "numpy>=2"`
+Enter
+Wait /\$/
+Sleep 3s
+
+Type "# The manifest quickstart wrote"
+Enter
+Sleep 500ms
+
+Type@80ms "bat conda.toml"
+Enter
+Wait /\$/
+Sleep 3s
+
+Type "# --json gives a scriptable summary, skipping the shell"
+Enter
+Sleep 500ms
+
+Type "rm -rf /tmp/ws-json && mkdir -p /tmp/ws-json && cd /tmp/ws-json"
+Enter
+Wait /\$/
+
+Type@80ms `conda workspace quickstart --json --name scripted "python=3.12"`
+Enter
+Wait /\$/
+Sleep 3s

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -54,7 +54,28 @@ required — you can start with tasks alone and add workspace features later.
 
 ![quickstart demo](../demos/quickstart.gif)
 
-Add workspace configuration to the same `conda.toml`:
+The fastest path from "empty directory" to "installed environment with
+an activated shell" is `conda workspace quickstart`:
+
+```bash
+conda workspace quickstart python=3.14 numpy
+# or:
+conda workspace quickstart --copy ../other-workspace
+```
+
+`quickstart` composes the other commands for you: it runs `init`
+(unless you pass `--copy` / `--clone` to copy an existing workspace's
+manifest), adds any specs passed on the command line, installs the
+selected environment, and drops into a shell. It forwards the flags
+you already know from `init` (`--format`, `--name`, `-c/--channel`,
+`--platform`), `install` (`-e/--environment`, `--force-reinstall`,
+`--locked`, `--frozen`), and conda's shared flags (`--dry-run`,
+`--json`, `--yes`). Use `--no-shell` for CI or scripted runs; `--json`
+implies `--no-shell` and prints a single structured result at the
+end.
+
+If you prefer a manual setup, add workspace configuration to a
+`conda.toml` yourself:
 
 ::::{tab-set}
 

--- a/tests/cli/workspace/test_quickstart.py
+++ b/tests/cli/workspace/test_quickstart.py
@@ -10,10 +10,8 @@ import pytest
 from rich.console import Console
 
 from conda_workspaces.cli.workspace import quickstart as quickstart_module
-from conda_workspaces.cli.workspace.quickstart import (
-    QuickstartCopyError,
-    execute_quickstart,
-)
+from conda_workspaces.cli.workspace.quickstart import execute_quickstart
+from conda_workspaces.exceptions import QuickstartCopyError
 
 from ..conftest import make_args
 

--- a/tests/cli/workspace/test_quickstart.py
+++ b/tests/cli/workspace/test_quickstart.py
@@ -1,0 +1,287 @@
+"""Tests for conda_workspaces.cli.workspace.quickstart."""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from typing import TYPE_CHECKING
+
+import pytest
+from rich.console import Console
+
+from conda_workspaces.cli.workspace import quickstart as quickstart_module
+from conda_workspaces.cli.workspace.quickstart import (
+    QuickstartCopyError,
+    execute_quickstart,
+)
+
+from ..conftest import make_args
+
+if TYPE_CHECKING:
+    import argparse
+    from pathlib import Path
+
+
+_DEFAULTS = {
+    "file": None,
+    "specs": [],
+    "manifest_format": "conda",
+    "name": None,
+    "channels": None,
+    "platforms": None,
+    "environment": "default",
+    "force_reinstall": False,
+    "locked": False,
+    "frozen": False,
+    "copy_from": None,
+    "no_shell": False,
+    "json": False,
+    "yes": False,
+    "dry_run": False,
+    "quiet": False,
+    "verbose": 0,
+    "debug": False,
+    "trace": False,
+}
+
+
+class _RecordingRunner:
+    """Callable that records each ``Namespace`` it was invoked with."""
+
+    def __init__(self, *, effect=None) -> None:
+        self.calls: list[argparse.Namespace] = []
+        self._effect = effect
+
+    def __call__(self, ns: argparse.Namespace) -> int:
+        self.calls.append(ns)
+        if self._effect is not None:
+            self._effect(ns)
+        return 0
+
+
+@pytest.fixture
+def orchestrated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Patch the four sub-handler imports inside ``quickstart`` with recorders.
+
+    Returns a ``dict`` with:
+
+    * ``runners``: the four recording closures (``init`` / ``add`` /
+      ``install`` / ``shell``).
+    * ``run``: a helper that builds a default ``Namespace`` and calls
+      ``execute_quickstart`` with a ``StringIO``-backed console.
+    * ``console``: the Rich console instance for output assertions.
+    * ``root``: ``tmp_path`` (cwd at setup).
+    """
+    monkeypatch.chdir(tmp_path)
+
+    def _touch_manifest(ns: argparse.Namespace) -> None:
+        """``execute_init`` would write a manifest; simulate it."""
+        fmt = getattr(ns, "manifest_format", "conda") or "conda"
+        filename = {"conda": "conda.toml", "pixi": "pixi.toml"}.get(
+            fmt, "pyproject.toml"
+        )
+        (tmp_path / filename).write_text("# stub", encoding="utf-8")
+
+    runners = {
+        "init": _RecordingRunner(effect=_touch_manifest),
+        "add": _RecordingRunner(),
+        "install": _RecordingRunner(),
+        "shell": _RecordingRunner(),
+    }
+    monkeypatch.setattr(quickstart_module, "execute_init", runners["init"])
+    monkeypatch.setattr(quickstart_module, "execute_add", runners["add"])
+    monkeypatch.setattr(quickstart_module, "execute_install", runners["install"])
+    monkeypatch.setattr(quickstart_module, "execute_shell", runners["shell"])
+
+    console = Console(file=StringIO(), width=200, force_terminal=False)
+
+    def run(**overrides) -> int:
+        args = make_args(_DEFAULTS, **overrides)
+        return execute_quickstart(args, console=console)
+
+    return {"run": run, "runners": runners, "console": console, "root": tmp_path}
+
+
+@pytest.mark.parametrize(
+    ("specs", "expect_add", "expect_install"),
+    [
+        ([], False, True),
+        (["python=3.14"], True, False),
+        (["python=3.14", "numpy>=2.4"], True, False),
+    ],
+    ids=[
+        "no-specs-runs-install",
+        "single-spec-skips-install",
+        "multi-spec-skips-install",
+    ],
+)
+def test_quickstart_from_scratch(
+    orchestrated: dict,
+    specs: list[str],
+    expect_add: bool,
+    expect_install: bool,
+) -> None:
+    """init always runs; add replaces install when specs are provided."""
+    result = orchestrated["run"](specs=specs)
+
+    assert result == 0
+    runners = orchestrated["runners"]
+    assert len(runners["init"].calls) == 1
+    assert len(runners["add"].calls) == (1 if expect_add else 0)
+    assert len(runners["install"].calls) == (1 if expect_install else 0)
+    assert len(runners["shell"].calls) == 1
+    if expect_add:
+        assert runners["add"].calls[0].specs == specs
+
+
+def test_quickstart_copy_from_dir_skips_init(
+    orchestrated: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--copy <dir>`` copies the manifest and skips the init step."""
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "pixi.toml").write_text("[workspace]\nname='src'\n", encoding="utf-8")
+
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    monkeypatch.chdir(dest)
+
+    result = orchestrated["run"](copy_from=source)
+
+    assert result == 0
+    runners = orchestrated["runners"]
+    assert runners["init"].calls == []
+    assert (dest / "pixi.toml").exists()
+    assert len(runners["install"].calls) == 1
+    assert len(runners["shell"].calls) == 1
+
+
+def test_quickstart_copy_from_file(
+    orchestrated: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--copy <manifest>`` accepts a direct file path."""
+    manifest = tmp_path / "conda.toml"
+    manifest.write_text("[workspace]\nname='upstream'\n", encoding="utf-8")
+
+    dest = tmp_path / "copy"
+    dest.mkdir()
+    monkeypatch.chdir(dest)
+
+    result = orchestrated["run"](copy_from=manifest)
+
+    assert result == 0
+    assert (dest / "conda.toml").exists()
+    assert orchestrated["runners"]["init"].calls == []
+
+
+def test_quickstart_copy_missing_path_raises(
+    orchestrated: dict, tmp_path: Path
+) -> None:
+    missing = tmp_path / "no-such-directory"
+    with pytest.raises(QuickstartCopyError, match="does not exist"):
+        orchestrated["run"](copy_from=missing)
+
+
+def test_quickstart_copy_with_format_warns(
+    orchestrated: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--copy`` + ``--format`` emits a warning and still succeeds."""
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "pixi.toml").write_text("[workspace]\nname='src'\n", encoding="utf-8")
+
+    dest = tmp_path / "dst"
+    dest.mkdir()
+    monkeypatch.chdir(dest)
+
+    result = orchestrated["run"](copy_from=source, manifest_format="pixi")
+
+    assert result == 0
+    rendered = orchestrated["console"].file.getvalue()
+    assert "--format is ignored" in rendered
+
+
+def test_quickstart_no_shell_skips_shell(orchestrated: dict) -> None:
+    result = orchestrated["run"](no_shell=True)
+    assert result == 0
+    assert orchestrated["runners"]["shell"].calls == []
+
+
+def test_quickstart_json_suppresses_shell_and_emits_payload(
+    orchestrated: dict,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--json`` implies no shell and prints a structured result."""
+    result = orchestrated["run"](specs=["python=3.14"], json=True, environment="dev")
+
+    assert result == 0
+    assert orchestrated["runners"]["shell"].calls == []
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out.strip())
+    assert payload["environment"] == "dev"
+    assert payload["specs_added"] == ["python=3.14"]
+    assert payload["shell_spawned"] is False
+    assert payload["manifest"] == "conda.toml"
+
+
+def test_quickstart_dry_run_skips_side_effects(
+    orchestrated: dict, tmp_path: Path
+) -> None:
+    """``--dry-run`` runs no sub-handlers and writes no files."""
+    result = orchestrated["run"](dry_run=True, specs=["python"])
+
+    assert result == 0
+    runners = orchestrated["runners"]
+    assert runners["init"].calls == []
+    assert runners["shell"].calls == []
+    # add/install may or may not be called depending on design; the
+    # critical invariants are "init is not run" (no manifest is
+    # written) and "shell is not spawned".
+    assert not (tmp_path / "conda.toml").exists()
+
+
+def test_quickstart_dry_run_with_copy_reports_but_does_not_write(
+    orchestrated: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "conda.toml").write_text("[workspace]\nname='x'\n", encoding="utf-8")
+
+    dest = tmp_path / "dst"
+    dest.mkdir()
+    monkeypatch.chdir(dest)
+
+    result = orchestrated["run"](dry_run=True, copy_from=source)
+
+    assert result == 0
+    assert not (dest / "conda.toml").exists()
+    rendered = orchestrated["console"].file.getvalue()
+    assert "Would copy" in rendered
+
+
+def test_quickstart_forwards_install_flags(orchestrated: dict) -> None:
+    """``--force-reinstall`` / ``--locked`` propagate to install."""
+    result = orchestrated["run"](force_reinstall=True, locked=True)
+
+    assert result == 0
+    install_ns = orchestrated["runners"]["install"].calls[0]
+    assert install_ns.force_reinstall is True
+    assert install_ns.locked is True
+
+
+def test_quickstart_forwards_init_flags(orchestrated: dict) -> None:
+    """``--name`` / ``--channel`` / ``--platform`` propagate to init."""
+    result = orchestrated["run"](
+        name="demo",
+        channels=["conda-forge", "bioconda"],
+        platforms=["linux-64", "osx-arm64"],
+        manifest_format="pixi",
+    )
+
+    assert result == 0
+    init_ns = orchestrated["runners"]["init"].calls[0]
+    assert init_ns.name == "demo"
+    assert init_ns.channels == ["conda-forge", "bioconda"]
+    assert init_ns.platforms == ["linux-64", "osx-arm64"]
+    assert init_ns.manifest_format == "pixi"

--- a/tests/cli/workspace/test_quickstart.py
+++ b/tests/cli/workspace/test_quickstart.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
 
 
 _DEFAULTS = {
-    "file": None,
     "specs": [],
     "manifest_format": "conda",
     "name": None,
@@ -232,10 +231,9 @@ def test_quickstart_dry_run_skips_side_effects(
     assert result == 0
     runners = orchestrated["runners"]
     assert runners["init"].calls == []
+    assert runners["add"].calls == []
+    assert runners["install"].calls == []
     assert runners["shell"].calls == []
-    # add/install may or may not be called depending on design; the
-    # critical invariants are "init is not run" (no manifest is
-    # written) and "shell is not spawned".
     assert not (tmp_path / "conda.toml").exists()
 
 
@@ -258,28 +256,42 @@ def test_quickstart_dry_run_with_copy_reports_but_does_not_write(
     assert "Would copy" in rendered
 
 
-def test_quickstart_forwards_install_flags(orchestrated: dict) -> None:
-    """``--force-reinstall`` / ``--locked`` propagate to install."""
-    result = orchestrated["run"](force_reinstall=True, locked=True)
+@pytest.mark.parametrize(
+    ("subhandler", "inputs", "expected"),
+    [
+        (
+            "install",
+            {"force_reinstall": True, "locked": True},
+            {"force_reinstall": True, "locked": True},
+        ),
+        (
+            "init",
+            {
+                "name": "demo",
+                "channels": ["conda-forge", "bioconda"],
+                "platforms": ["linux-64", "osx-arm64"],
+                "manifest_format": "pixi",
+            },
+            {
+                "name": "demo",
+                "channels": ["conda-forge", "bioconda"],
+                "platforms": ["linux-64", "osx-arm64"],
+                "manifest_format": "pixi",
+            },
+        ),
+    ],
+    ids=["install-flags", "init-flags"],
+)
+def test_quickstart_forwards_sub_handler_flags(
+    orchestrated: dict,
+    subhandler: str,
+    inputs: dict,
+    expected: dict,
+) -> None:
+    """Flags defined on init / install are threaded to the matching sub-handler."""
+    result = orchestrated["run"](**inputs)
 
     assert result == 0
-    install_ns = orchestrated["runners"]["install"].calls[0]
-    assert install_ns.force_reinstall is True
-    assert install_ns.locked is True
-
-
-def test_quickstart_forwards_init_flags(orchestrated: dict) -> None:
-    """``--name`` / ``--channel`` / ``--platform`` propagate to init."""
-    result = orchestrated["run"](
-        name="demo",
-        channels=["conda-forge", "bioconda"],
-        platforms=["linux-64", "osx-arm64"],
-        manifest_format="pixi",
-    )
-
-    assert result == 0
-    init_ns = orchestrated["runners"]["init"].calls[0]
-    assert init_ns.name == "demo"
-    assert init_ns.channels == ["conda-forge", "bioconda"]
-    assert init_ns.platforms == ["linux-64", "osx-arm64"]
-    assert init_ns.manifest_format == "pixi"
+    ns = orchestrated["runners"][subhandler].calls[0]
+    for key, value in expected.items():
+        assert getattr(ns, key) == value


### PR DESCRIPTION
## Summary

- New `conda workspace quickstart` command that composes the existing `init`, `add`, `install`, and `shell` handlers into a single bootstrap step. `conda workspace quickstart python=3.14 numpy` takes an empty directory to an installed environment with an activated shell.
- `--copy` / `--clone <path>` copies an existing workspace's manifest (`conda.toml` / `pixi.toml` / `pyproject.toml`) instead of running `init`. `--format` is then ignored with a warning since the copied manifest dictates the format.
- Forwards the init flags (`--format`, `--name`, `-c/--channel`, `--platform`), the install flags (`-e/--environment`, `--force-reinstall`, `--locked`, `--frozen`), and conda's shared output/prompt options (`--dry-run`, `--json`, `--yes`, `-v/-q`, `--debug`, `--trace`, `--console`) — no flag is re-declared.
- `--no-shell` skips the final `shell` step; `--json` implies `--no-shell` and emits a single structured `{workspace, environment, manifest, specs_added, shell_spawned}` payload; `--dry-run` reports the pipeline without side effects.
- Tests parametrize across spec-count, copy-source shape, and output mode. Recording runners are injected directly into `execute_quickstart` (no `unittest.mock`) so each test asserts the exact `Namespace` every sub-handler received.

Closes #22.

## Test plan

- [x] `pixi run -e test pytest` (799 passed)
- [x] `pixi run ruff check`
- [x] `pixi run ruff format --check`
- [ ] `pixi run demos workspace-quickstart` to regenerate the gif/mp4 locally
- [ ] Manually smoke-test the full pipeline end-to-end (`conda workspace quickstart python=3.12 numpy` in an empty directory)