### PR TITLE
AGENTS.md: sync virtual_package_overrides names with PR #36

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,9 +102,9 @@
   `obj.foo(platform)` instead of `_foo(platform, obj.attr)`, tests
   instantiate the class directly instead of threading loose arguments,
   and the public surface stays discoverable. The canonical examples
-  are `ResolvedEnvironment.baseline_virtual_package_env` /
-  `scoped_solver_env` in `resolver.py` (moved out of `lockfile.py`
-  private helpers) and `ManifestParser.for_format` /
+  are `ResolvedEnvironment.virtual_package_overrides` /
+  `scoped_virtual_packages` in `resolver.py` (moved out of
+  `lockfile.py` private helpers) and `ManifestParser.for_format` /
   `resolve_source` / `copy_manifest` in `manifests/base.py` (moved
   out of `cli/workspace/quickstart.py` private helpers).
 


### PR DESCRIPTION
## Summary

Follow-up to #42. PR #36 renamed the `ResolvedEnvironment` helper pair from `baseline_virtual_package_env` / `scoped_solver_env` to `virtual_package_overrides` / `scoped_virtual_packages` before merging. The code-structure canonical example in `AGENTS.md` still referenced the old names; this PR syncs it with the live method names.

## Test plan

- [x] Markdown-only change; no code affected.