### PR TITLE
Add conda-toml, pixi-toml, pyproject-toml exporter plugins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@
   and the public surface stays discoverable. The canonical examples
   are `ResolvedEnvironment.virtual_package_overrides` /
   `scoped_virtual_packages` in `resolver.py` (moved out of
-  `lockfile.py` private helpers) and   `ManifestParser.for_format` /
+  `lockfile.py` private helpers) and   `ManifestParser.for_format_alias` /
   `for_exporter_format` / `resolve_source` / `copy_manifest` /
   `write_workspace_stub` / `export` / `merge_export` in
   `manifests/base.py` (moved out of `cli/workspace/quickstart.py`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,13 +106,16 @@
   and the public surface stays discoverable. The canonical examples
   are `ResolvedEnvironment.virtual_package_overrides` /
   `scoped_virtual_packages` in `resolver.py` (moved out of
-  `lockfile.py` private helpers) and `ManifestParser.for_format` /
-  `resolve_source` / `copy_manifest` / `write_workspace_stub` /
-  `export` in `manifests/base.py` (moved out of
-  `cli/workspace/quickstart.py` / `cli/workspace/init.py` private
-  helpers; `export` is also what the ``conda-toml`` / ``pixi-toml``
-  / ``pyproject-toml`` exporter plugins in `plugin.py` register as
-  ``multiplatform_export``).
+  `lockfile.py` private helpers) and   `ManifestParser.for_format` /
+  `for_exporter_format` / `resolve_source` / `copy_manifest` /
+  `write_workspace_stub` / `export` / `merge_export` in
+  `manifests/base.py` (moved out of `cli/workspace/quickstart.py`
+  / `cli/workspace/init.py` / `cli/workspace/export.py` private
+  helpers; `export` is what the ``conda-toml`` / ``pixi-toml`` /
+  ``pyproject-toml`` exporter plugins in `plugin.py` register as
+  ``multiplatform_export``, and `merge_export` lets
+  `PyprojectTomlParser` splice ``[tool.conda]`` into an existing
+  ``pyproject.toml`` instead of overwriting peer tables).
 
 - Before adding a new private module-level helper, check in order:
   1. Does conda (or another existing dependency like

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,8 +107,12 @@
   are `ResolvedEnvironment.virtual_package_overrides` /
   `scoped_virtual_packages` in `resolver.py` (moved out of
   `lockfile.py` private helpers) and `ManifestParser.for_format` /
-  `resolve_source` / `copy_manifest` in `manifests/base.py` (moved
-  out of `cli/workspace/quickstart.py` private helpers).
+  `resolve_source` / `copy_manifest` / `write_workspace_stub` /
+  `export` in `manifests/base.py` (moved out of
+  `cli/workspace/quickstart.py` / `cli/workspace/init.py` private
+  helpers; `export` is also what the ``conda-toml`` / ``pixi-toml``
+  / ``pyproject-toml`` exporter plugins in `plugin.py` register as
+  ``multiplatform_export``).
 
 - Before adding a new private module-level helper, check in order:
   1. Does conda (or another existing dependency like

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   per-platform deltas under `[target.<platform>.*]`. The
   `pyproject-toml` exporter wraps the same content under
   `[tool.conda]` so the output drops straight into an existing PEP
-  621 `pyproject.toml`. Together with the existing `conda workspace
-  import` direction, `conda workspace` is now a bidirectional
-  translator across every manifest dialect it understands.
+  621 `pyproject.toml` — when the target file already exists, the
+  exporter splices its `[tool.conda]` subtree into the existing
+  document so peer `[project]`, `[build-system]`, `[tool.ruff]`,
+  and `[tool.pixi]` tables survive untouched (any stale
+  `[tool.conda]` is replaced). `conda.toml` and `pixi.toml` keep
+  the default overwrite semantics of every other conda exporter.
+  Together with the existing `conda workspace import` direction,
+  `conda workspace` is now a bidirectional translator across every
+  manifest dialect it understands.
 - `conda workspace lock` gained `--output <path>` and `--merge <glob>`
   for CI-split locking pipelines. `--output` writes the solved
   lockfile to an arbitrary path (e.g. `conda.lock.linux-64`) instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- `conda workspace export` gained three new manifest-format exporter
+  plugins: `conda-toml`, `pixi-toml`, and `pyproject-toml`. They
+  register via the same `conda_environment_exporters` hook as
+  `environment-yaml` and `conda-workspaces-lock-v1`, so existing CLI
+  behaviour (per-platform projection, `--file` inference from
+  `conda.toml` / `pixi.toml` / `pyproject.toml` basenames,
+  `--output` streaming) lights up for free. Each serializer is the
+  `export` method on the matching `ManifestParser` subclass:
+  declared specs shared across all requested platforms land under
+  the top-level `[dependencies]` / `[pypi-dependencies]` tables,
+  per-platform deltas under `[target.<platform>.*]`. The
+  `pyproject-toml` exporter wraps the same content under
+  `[tool.conda]` so the output drops straight into an existing PEP
+  621 `pyproject.toml`. Together with the existing `conda workspace
+  import` direction, `conda workspace` is now a bidirectional
+  translator across every manifest dialect it understands.
 - `conda workspace lock` gained `--output <path>` and `--merge <glob>`
   for CI-split locking pipelines. `--output` writes the solved
   lockfile to an arbitrary path (e.g. `conda.lock.linux-64`) instead

--- a/conda_workspaces/cli/workspace/export.py
+++ b/conda_workspaces/cli/workspace/export.py
@@ -21,7 +21,7 @@ from rich.console import Console
 
 from ...exceptions import EnvironmentNotFoundError
 from ...export import resolve_exporter, run_exporter
-from ...manifests import _PARSERS
+from ...manifests.base import ManifestParser
 from . import workspace_context_from_args
 
 if TYPE_CHECKING:
@@ -113,10 +113,7 @@ def execute_export(
         # environment.yaml``); :class:`PyprojectTomlParser` opts into a
         # nested-table merge so peer ``[project]`` / ``[build-system]``
         # tables survive.
-        parser = next(
-            (p for p in _PARSERS if p.exporter_format == resolved_format),
-            None,
-        )
+        parser = ManifestParser.for_exporter_format(resolved_format)
         if parser is not None:
             content = parser.merge_export(output_path, content)
     output_path.write_text(content, encoding="utf-8")

--- a/conda_workspaces/cli/workspace/export.py
+++ b/conda_workspaces/cli/workspace/export.py
@@ -21,6 +21,7 @@ from rich.console import Console
 
 from ...exceptions import EnvironmentNotFoundError
 from ...export import resolve_exporter, run_exporter
+from ...manifests import _PARSERS
 from . import workspace_context_from_args
 
 if TYPE_CHECKING:
@@ -105,6 +106,19 @@ def execute_export(
         return 0
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.is_file():
+        # Give the parser a chance to merge the exported content into
+        # an existing file rather than wholesale overwriting it.  The
+        # default is still overwrite (same as ``conda export -f
+        # environment.yaml``); :class:`PyprojectTomlParser` opts into a
+        # nested-table merge so peer ``[project]`` / ``[build-system]``
+        # tables survive.
+        parser = next(
+            (p for p in _PARSERS if p.exporter_format == resolved_format),
+            None,
+        )
+        if parser is not None:
+            content = parser.merge_export(output_path, content)
     output_path.write_text(content, encoding="utf-8")
 
     if json_output:

--- a/conda_workspaces/cli/workspace/init.py
+++ b/conda_workspaces/cli/workspace/init.py
@@ -35,7 +35,7 @@ def execute_init(args: argparse.Namespace, *, console: Console | None = None) ->
     platforms = args.platforms or [conda_context.subdir]
     base_dir = Path(args.file).parent if args.file else Path.cwd()
 
-    parser = ManifestParser.for_format(args.manifest_format)
+    parser = ManifestParser.for_format_alias(args.manifest_format)
     path, verb = parser.write_workspace_stub(base_dir, name, channels, platforms)
     status.message(console, verb, "workspace", path.name, detail=str(path.parent))
     return 0

--- a/conda_workspaces/cli/workspace/quickstart.py
+++ b/conda_workspaces/cli/workspace/quickstart.py
@@ -125,7 +125,8 @@ def execute_quickstart(
             "[bold blue]Would create[/bold blue] workspace manifest in"
             f" [bold]{workspace_root}[/bold]"
         )
-        manifest_path = ManifestParser.for_format(fmt).manifest_path(workspace_root)
+        parser = ManifestParser.for_format_alias(fmt)
+        manifest_path = parser.manifest_path(workspace_root)
     else:
         execute_init(
             with_prompts(
@@ -136,7 +137,8 @@ def execute_quickstart(
                 platforms=args.platforms,
             )
         )
-        manifest_path = ManifestParser.for_format(fmt).manifest_path(workspace_root)
+        parser = ManifestParser.for_format_alias(fmt)
+        manifest_path = parser.manifest_path(workspace_root)
 
     if dry_run:
         # No manifest on disk yet; skip add/install side effects.

--- a/conda_workspaces/manifests/base.py
+++ b/conda_workspaces/manifests/base.py
@@ -266,8 +266,20 @@ class ManifestParser(ABC):
         # ``toml._parse_conda_deps`` / ``toml._parse_pypi_deps`` — a
         # name-only MatchSpec round-trips as ``"*"``, versioned
         # MatchSpecs keep their ``conda_build_form`` suffix, PyPI
-        # entries keep their ``Requirement.specifier`` string.
-        from packaging.requirements import Requirement
+        # entries keep their ``Requirement.specifier`` string.  When
+        # a PyPI entry is not a valid PEP 508 string (e.g. the
+        # ``"requests*"`` that
+        # :meth:`~conda_workspaces.models.PyPIDependency.__str__`
+        # emits for a ``requests = "*"`` manifest wildcard), fall
+        # back to splitting name from specifier at the first
+        # non-identifier character — matches what ``environment-yaml``
+        # does in the same case: pass the input through as-is rather
+        # than crashing.
+        import re
+
+        from packaging.requirements import InvalidRequirement, Requirement
+
+        name_tail_re = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)(.*)$")
 
         per_platform_conda: dict[str, dict[str, str]] = {}
         per_platform_pypi: dict[str, dict[str, str]] = {}
@@ -280,8 +292,14 @@ class ManifestParser(ABC):
 
             pypi_row: dict[str, str] = {}
             for raw in env.external_packages.get("pip", []):
-                req = Requirement(raw)
-                pypi_row[req.name] = str(req.specifier) or "*"
+                try:
+                    req = Requirement(raw)
+                    pypi_row[req.name] = str(req.specifier) or "*"
+                except InvalidRequirement:
+                    match = name_tail_re.match(raw.strip())
+                    if match:
+                        name_part, tail = match.groups()
+                        pypi_row[name_part] = tail.strip() or "*"
             per_platform_pypi[env.platform] = pypi_row
 
         common_conda = cls._intersect_rows(per_platform_conda)

--- a/conda_workspaces/manifests/base.py
+++ b/conda_workspaces/manifests/base.py
@@ -63,14 +63,20 @@ class ManifestParser(ABC):
         return root / self.manifest_filename
 
     @classmethod
-    def for_format(cls, alias: str) -> ManifestParser:
+    def for_format_alias(cls, alias: str) -> ManifestParser:
         """Return the registered parser whose :attr:`format_alias` matches *alias*.
 
-        Raises :class:`ValueError` when no parser claims *alias*.  The
-        registry is :data:`conda_workspaces.manifests._PARSERS`; this
-        classmethod is the canonical way for CLI code to translate a
-        ``--format`` value into the parser (and therefore the filename)
-        it implies.
+        Used by ``conda workspace init`` / ``quickstart`` to turn a
+        ``--format`` value like ``"pyproject"`` / ``"conda"`` /
+        ``"pixi"`` into the parser (and therefore the filename) it
+        implies.  Raises :class:`ValueError` when no parser claims
+        *alias*.  The companion lookup for
+        ``conda workspace export --format`` is
+        :meth:`for_exporter_format` — that side matches the longer
+        ``conda_environment_exporters`` plugin name
+        (``"pyproject-toml"``, ``"conda-toml"``, ``"pixi-toml"``)
+        which is stored on :attr:`exporter_format`.  The registry is
+        :data:`conda_workspaces.manifests._PARSERS`.
         """
         from . import _PARSERS
 
@@ -174,7 +180,7 @@ class ManifestParser(ABC):
     def for_exporter_format(cls, name: str) -> ManifestParser | None:
         """Return the registered parser whose :attr:`exporter_format` matches *name*.
 
-        Companion to :meth:`for_format` for the
+        Companion to :meth:`for_format_alias` for the
         ``conda_environment_exporters`` plugin side: ``conda workspace
         export --format <name>`` uses the exporter plugin name (e.g.
         ``pyproject-toml``), which is stored on

--- a/conda_workspaces/manifests/base.py
+++ b/conda_workspaces/manifests/base.py
@@ -168,8 +168,28 @@ class ManifestParser(ABC):
         only when ``--file`` points to an existing file, so a fresh
         export still writes the exporter output verbatim.
         """
-        del existing_path
         return exported
+
+    @classmethod
+    def for_exporter_format(cls, name: str) -> ManifestParser | None:
+        """Return the registered parser whose :attr:`exporter_format` matches *name*.
+
+        Companion to :meth:`for_format` for the
+        ``conda_environment_exporters`` plugin side: ``conda workspace
+        export --format <name>`` uses the exporter plugin name (e.g.
+        ``pyproject-toml``), which is stored on
+        :attr:`exporter_format` rather than :attr:`format_alias`.
+        Returns ``None`` when *name* is not a manifest-format exporter
+        — the CLI uses this to decide whether to route writes through
+        :meth:`merge_export`, and a ``None`` result simply means "not
+        one of ours, write verbatim".
+        """
+        from . import _PARSERS
+
+        for parser in _PARSERS:
+            if parser.exporter_format and parser.exporter_format == name:
+                return parser
+        return None
 
     def export(self, envs: Iterable[Environment]) -> str:
         """Serialize *envs* to this parser's manifest format.

--- a/conda_workspaces/manifests/base.py
+++ b/conda_workspaces/manifests/base.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 import tomlkit
+from packaging.requirements import InvalidRequirement, Requirement
 
 from ..exceptions import ManifestExistsError
+
+_PYPI_NAME_TAIL_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)(.*)$")
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -322,12 +326,6 @@ class ManifestParser(ABC):
         # non-identifier character — matches what ``environment-yaml``
         # does in the same case: pass the input through as-is rather
         # than crashing.
-        import re
-
-        from packaging.requirements import InvalidRequirement, Requirement
-
-        name_tail_re = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)(.*)$")
-
         per_platform_conda: dict[str, dict[str, str]] = {}
         per_platform_pypi: dict[str, dict[str, str]] = {}
         for env in envs:
@@ -343,7 +341,7 @@ class ManifestParser(ABC):
                     req = Requirement(raw)
                     pypi_row[req.name] = str(req.specifier) or "*"
                 except InvalidRequirement:
-                    match = name_tail_re.match(raw.strip())
+                    match = _PYPI_NAME_TAIL_RE.match(raw.strip())
                     if match:
                         name_part, tail = match.groups()
                         pypi_row[name_part] = tail.strip() or "*"

--- a/conda_workspaces/manifests/base.py
+++ b/conda_workspaces/manifests/base.py
@@ -150,6 +150,27 @@ class ManifestParser(ABC):
         path.write_text(tomlkit.dumps(doc), encoding="utf-8")
         return path, "Created"
 
+    def merge_export(self, existing_path: Path, exported: str) -> str:
+        """Return *exported* ready to write into an existing *existing_path*.
+
+        The default implementation returns *exported* unchanged —
+        ``conda.toml`` and ``pixi.toml`` are manifests we own
+        end-to-end, so regenerating them from an environment is a
+        full replacement (same as ``conda export -f
+        environment.yaml`` overwriting an existing environment.yaml).
+
+        :class:`PyprojectTomlParser` overrides this to splice the
+        exporter's ``[tool.conda]`` subtree into the existing
+        ``pyproject.toml`` document without disturbing peer tables
+        (``[project]``, ``[build-system]``, ``[tool.ruff]`` etc.),
+        because ``pyproject.toml`` is a shared manifest owned by the
+        Python ecosystem.  Called from :mod:`conda_workspaces.cli.workspace.export`
+        only when ``--file`` points to an existing file, so a fresh
+        export still writes the exporter output verbatim.
+        """
+        del existing_path
+        return exported
+
     def export(self, envs: Iterable[Environment]) -> str:
         """Serialize *envs* to this parser's manifest format.
 

--- a/conda_workspaces/manifests/base.py
+++ b/conda_workspaces/manifests/base.py
@@ -11,11 +11,13 @@ import tomlkit
 from ..exceptions import ManifestExistsError
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
-    from typing import ClassVar
+    from typing import Any, ClassVar
 
+    from conda.models.environment import Environment
     from tomlkit.container import Container
-    from tomlkit.items import InlineTable
+    from tomlkit.items import InlineTable, Table
 
     from ..models import Task, WorkspaceConfig
 
@@ -37,6 +39,13 @@ class ManifestParser(ABC):
 
     format_alias: ClassVar[str] = ""
     filenames: ClassVar[tuple[str, ...]] = ()
+    #: Canonical ``conda_environment_exporters`` plugin name.  Empty
+    #: disables exporter registration for that parser (see
+    #: :mod:`conda_workspaces.plugin`).
+    exporter_format: ClassVar[str] = ""
+    #: Optional user-friendly aliases for the exporter plugin (e.g.
+    #: ``("conda",)`` for ``conda-toml``).  Empty tuple is fine.
+    exporter_aliases: ClassVar[tuple[str, ...]] = ()
 
     @property
     def manifest_filename(self) -> str:
@@ -140,6 +149,179 @@ class ManifestParser(ABC):
 
         path.write_text(tomlkit.dumps(doc), encoding="utf-8")
         return path, "Created"
+
+    def export(self, envs: Iterable[Environment]) -> str:
+        """Serialize *envs* to this parser's manifest format.
+
+        Produces a manifest that, when written to disk and parsed by
+        :meth:`parse`, describes the same requested dependencies,
+        channels, and declared platforms that *envs* carry.  Each
+        :class:`~conda.models.environment.Environment` is one
+        ``(name, platform)`` pair; *envs* must all share the same
+        ``name`` (conda's
+        :class:`~conda.plugins.types.CondaEnvironmentExporter` hook
+        calls ``multiplatform_export`` with per-platform copies of
+        the same logical environment).
+
+        The default implementation writes top-level ``[workspace]``,
+        ``[dependencies]``, ``[pypi-dependencies]``, and
+        ``[target.<platform>.*]`` tables — the shape ``conda.toml``
+        and ``pixi.toml`` share.  :class:`PyprojectTomlParser`
+        overrides it to nest the same content under ``[tool.conda]``
+        without disturbing the rest of the pyproject.  Used as the
+        ``multiplatform_export`` callable on the exporter plugins
+        registered from :mod:`conda_workspaces.plugin`.
+        """
+        envs = list(envs)
+        data = self.manifest_data(envs)
+        doc = tomlkit.document()
+        self._emit_manifest(doc, data)
+        return tomlkit.dumps(doc)
+
+    def _emit_manifest(self, container: Table, data: dict[str, Any]) -> None:
+        """Write the manifest tables produced by :meth:`manifest_data` into *container*.
+
+        *container* is a tomlkit table (either a fresh ``TOMLDocument``
+        or a nested ``[tool.conda]`` table); :meth:`export` hands it in
+        already positioned at the root of the manifest.  Kept as a
+        separate method so :class:`PyprojectTomlParser.export` can
+        reuse the exact same writer after it has set up the outer
+        ``[tool.conda]`` wrapper.
+        """
+        ws = tomlkit.table()
+        if data["name"] is not None:
+            ws.add("name", data["name"])
+        ws.add("channels", data["channels"])
+        ws.add("platforms", data["platforms"])
+        container.add("workspace", ws)
+
+        deps_table = tomlkit.table()
+        for name, spec in sorted(data["conda_deps"].items()):
+            deps_table.add(name, spec)
+        container.add("dependencies", deps_table)
+
+        if data["pypi_deps"]:
+            pypi_table = tomlkit.table()
+            for name, spec in sorted(data["pypi_deps"].items()):
+                pypi_table.add(name, spec)
+            container.add("pypi-dependencies", pypi_table)
+
+        target_data = data["target"]
+        if any(target_data.values()):
+            target = tomlkit.table(is_super_table=True)
+            for platform in sorted(target_data):
+                entry = target_data[platform]
+                if not entry["conda"] and not entry["pypi"]:
+                    continue
+                platform_tbl = tomlkit.table()
+                if entry["conda"]:
+                    c = tomlkit.table()
+                    for n, s in sorted(entry["conda"].items()):
+                        c.add(n, s)
+                    platform_tbl.add("dependencies", c)
+                if entry["pypi"]:
+                    p = tomlkit.table()
+                    for n, s in sorted(entry["pypi"].items()):
+                        p.add(n, s)
+                    platform_tbl.add("pypi-dependencies", p)
+                target.add(platform, platform_tbl)
+            container.add("target", target)
+
+    @classmethod
+    def manifest_data(cls, envs: Iterable[Environment]) -> dict[str, Any]:
+        """Fold one or more ``Environment`` objects into a manifest-shaped dict.
+
+        Returns the data that :meth:`export` writers need, with the
+        format-agnostic parts decided once:
+
+        * ``name`` / ``platforms`` / ``channels`` describe the
+          ``[workspace]`` table (platforms are the sorted union across
+          *envs*; channels are taken from the first env — exporter
+          callers pass the same channel list on every platform).
+        * ``conda_deps`` / ``pypi_deps`` are the intersection across
+          *envs* — specs that match by name *and* value on every
+          platform, the ones a round-trip parse would put under the
+          top-level ``[dependencies]`` / ``[pypi-dependencies]``
+          tables.
+        * ``target[<platform>]["conda"|"pypi"]`` holds the per-platform
+          delta — specs that appear on some platforms but not others,
+          or whose value differs across platforms.  A round-trip parse
+          restores these under ``[target.<platform>.dependencies]`` /
+          ``[target.<platform>.pypi-dependencies]``.
+
+        Used by :meth:`export` (via :meth:`_emit_manifest`) and
+        exposed as a classmethod so individual parsers and exporter
+        plugin shims can drive the same folding logic without
+        duplicating it.
+        """
+        envs = list(envs)
+        if not envs:
+            raise ValueError("At least one Environment is required for export.")
+
+        name = next((env.name for env in envs if env.name), None)
+        platforms = sorted({env.platform for env in envs})
+        channels = list(envs[0].config.channels)
+
+        # Per-platform specs as ``{name: suffix}`` dicts symmetric with
+        # ``toml._parse_conda_deps`` / ``toml._parse_pypi_deps`` — a
+        # name-only MatchSpec round-trips as ``"*"``, versioned
+        # MatchSpecs keep their ``conda_build_form`` suffix, PyPI
+        # entries keep their ``Requirement.specifier`` string.
+        from packaging.requirements import Requirement
+
+        per_platform_conda: dict[str, dict[str, str]] = {}
+        per_platform_pypi: dict[str, dict[str, str]] = {}
+        for env in envs:
+            conda_row: dict[str, str] = {}
+            for spec in env.requested_packages:
+                parts = spec.conda_build_form().split(None, 1)
+                conda_row[parts[0]] = parts[1] if len(parts) > 1 else "*"
+            per_platform_conda[env.platform] = conda_row
+
+            pypi_row: dict[str, str] = {}
+            for raw in env.external_packages.get("pip", []):
+                req = Requirement(raw)
+                pypi_row[req.name] = str(req.specifier) or "*"
+            per_platform_pypi[env.platform] = pypi_row
+
+        common_conda = cls._intersect_rows(per_platform_conda)
+        common_pypi = cls._intersect_rows(per_platform_pypi)
+
+        target: dict[str, dict[str, dict[str, str]]] = {}
+        for platform in platforms:
+            delta_conda = {
+                n: s
+                for n, s in per_platform_conda[platform].items()
+                if common_conda.get(n) != s
+            }
+            delta_pypi = {
+                n: s
+                for n, s in per_platform_pypi[platform].items()
+                if common_pypi.get(n) != s
+            }
+            target[platform] = {"conda": delta_conda, "pypi": delta_pypi}
+
+        return {
+            "name": name,
+            "platforms": platforms,
+            "channels": channels,
+            "conda_deps": common_conda,
+            "pypi_deps": common_pypi,
+            "target": target,
+        }
+
+    @classmethod
+    def _intersect_rows(cls, per_platform: dict[str, dict[str, str]]) -> dict[str, str]:
+        """Return entries present in every platform mapping with identical values."""
+        if not per_platform:
+            return {}
+        platforms = list(per_platform)
+        first = per_platform[platforms[0]]
+        return {
+            name: spec
+            for name, spec in first.items()
+            if all(per_platform[p].get(name) == spec for p in platforms[1:])
+        }
 
     @abstractmethod
     def can_handle(self, path: Path) -> bool:

--- a/conda_workspaces/manifests/pixi_toml.py
+++ b/conda_workspaces/manifests/pixi_toml.py
@@ -28,6 +28,7 @@ class PixiTomlParser(ManifestParser):
 
     format_alias = "pixi"
     filenames = ("pixi.toml",)
+    exporter_format = "pixi-toml"
 
     def can_handle(self, path: Path) -> bool:
         return path.name in self.filenames

--- a/conda_workspaces/manifests/pyproject_toml.py
+++ b/conda_workspaces/manifests/pyproject_toml.py
@@ -112,6 +112,35 @@ class PyprojectTomlParser(ManifestParser):
         doc.add("tool", tool)
         return tomlkit.dumps(doc)
 
+    def merge_export(self, existing_path: Path, exported: str) -> str:
+        """Splice *exported*'s ``[tool.conda]`` into *existing_path*.
+
+        ``pyproject.toml`` is a shared packaging manifest owned by
+        the Python ecosystem; the default "overwrite the file
+        wholesale" behaviour of :meth:`ManifestParser.merge_export`
+        would silently destroy ``[project]`` / ``[build-system]`` /
+        ``[tool.ruff]`` / etc.  Instead we parse the existing
+        document, replace its ``[tool.conda]`` subtree with the one
+        :meth:`export` just produced, and serialise the result.
+
+        This is the export-side companion to
+        :meth:`write_workspace_stub`, which does the same kind of
+        nested-table merge for ``conda workspace init``.  Existing
+        ``[tool.pixi]`` content is preserved untouched — users who
+        mix both tools stay functional.
+        """
+        exported_doc = tomlkit.loads(exported)
+        exported_conda = exported_doc.get("tool", {}).get("conda")
+        if exported_conda is None:
+            return exported
+
+        doc = tomlkit.loads(existing_path.read_text(encoding="utf-8"))
+        tool = doc.setdefault("tool", tomlkit.table())
+        if "conda" in tool:
+            del tool["conda"]
+        tool["conda"] = exported_conda
+        return tomlkit.dumps(doc)
+
     def has_workspace(self, path: Path) -> bool:
         if not path.exists():
             return False

--- a/conda_workspaces/manifests/pyproject_toml.py
+++ b/conda_workspaces/manifests/pyproject_toml.py
@@ -25,8 +25,10 @@ from .normalize import parse_feature_tasks, parse_tasks_and_targets
 from .toml import _parse_channels, _parse_features_and_envs
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
 
+    from conda.models.environment import Environment
     from tomlkit.items import Table
 
     from ..models import Task
@@ -43,6 +45,7 @@ class PyprojectTomlParser(ManifestParser):
 
     format_alias = "pyproject"
     filenames = ("pyproject.toml",)
+    exporter_format = "pyproject-toml"
 
     def can_handle(self, path: Path) -> bool:
         return path.name in self.filenames
@@ -91,6 +94,23 @@ class PyprojectTomlParser(ManifestParser):
 
         path.write_text(tomlkit.dumps(doc), encoding="utf-8")
         return path, "Updated" if existed else "Created"
+
+    def export(self, envs: Iterable[Environment]) -> str:
+        """Serialize *envs* as a ``pyproject.toml`` with ``[tool.conda.*]``.
+
+        Same content as :meth:`ManifestParser.export` — workspace
+        table, dependencies, optional pypi-dependencies, optional
+        per-platform overrides — but wrapped under ``[tool.conda]``
+        so the output drops straight into PEP 621 / ``pyproject.toml``
+        alongside ``[project]``, ``[build-system]``, and peer tables.
+        """
+        doc = tomlkit.document()
+        tool = tomlkit.table(is_super_table=True)
+        conda = tomlkit.table()
+        self._emit_manifest(conda, self.manifest_data(envs))
+        tool.add("conda", conda)
+        doc.add("tool", tool)
+        return tomlkit.dumps(doc)
 
     def has_workspace(self, path: Path) -> bool:
         if not path.exists():

--- a/conda_workspaces/manifests/toml.py
+++ b/conda_workspaces/manifests/toml.py
@@ -46,6 +46,7 @@ class CondaTomlParser(ManifestParser):
 
     format_alias = "conda"
     filenames = ("conda.toml",)
+    exporter_format = "conda-toml"
 
     def can_handle(self, path: Path) -> bool:
         return path.name in self.filenames

--- a/conda_workspaces/plugin.py
+++ b/conda_workspaces/plugin.py
@@ -65,6 +65,7 @@ def conda_environment_specifiers() -> Iterable[CondaEnvironmentSpecifier]:
 @hookimpl
 def conda_environment_exporters() -> Iterable[CondaEnvironmentExporter]:
     from . import export, lockfile
+    from .manifests import _PARSERS
 
     yield CondaEnvironmentExporter(
         name=lockfile.FORMAT,
@@ -72,6 +73,22 @@ def conda_environment_exporters() -> Iterable[CondaEnvironmentExporter]:
         default_filenames=lockfile.DEFAULT_FILENAMES,
         multiplatform_export=export.multiplatform_export,
     )
+
+    # Manifest-format exporters: each ManifestParser subclass that
+    # sets ``exporter_format`` becomes a ``conda export --format <name>``
+    # target.  The writer is the parser's ``export`` method, which
+    # defaults to the shared top-level-TOML implementation in
+    # ``ManifestParser.export`` and is overridden for nested shapes
+    # (see ``PyprojectTomlParser.export``).
+    for parser in _PARSERS:
+        if not parser.exporter_format:
+            continue
+        yield CondaEnvironmentExporter(
+            name=parser.exporter_format,
+            aliases=parser.exporter_aliases,
+            default_filenames=parser.filenames,
+            multiplatform_export=parser.export,
+        )
 
 
 @hookimpl

--- a/tests/cli/workspace/test_export.py
+++ b/tests/cli/workspace/test_export.py
@@ -7,6 +7,7 @@ from io import StringIO
 from typing import TYPE_CHECKING
 
 import pytest
+import tomlkit
 from conda.common.serialize.yaml import loads as yaml_loads
 from conda.exceptions import CondaValueError
 from rich.console import Console
@@ -81,8 +82,19 @@ def test_resolve_exporter_by_format(format_name: str, expected_name: str) -> Non
         ("environment.yml", "environment-yaml"),
         ("environment.json", "environment-json"),
         ("conda.lock", "conda-workspaces-lock-v1"),
+        ("conda.toml", "conda-toml"),
+        ("pixi.toml", "pixi-toml"),
+        ("pyproject.toml", "pyproject-toml"),
     ],
-    ids=["yaml-default", "yml-default", "json-default", "conda-lock-name"],
+    ids=[
+        "yaml-default",
+        "yml-default",
+        "json-default",
+        "conda-lock-name",
+        "conda-toml-name",
+        "pixi-toml-name",
+        "pyproject-toml-name",
+    ],
 )
 def test_resolve_exporter_detects_by_filename(
     tmp_path: Path, filename: str, expected_name: str
@@ -342,3 +354,59 @@ def test_run_exporter_falls_back_to_single() -> None:
 
     content = run_exporter(FakeExporter(), ["a"])  # type: ignore[list-item]
     assert content == "ano-trailing-newline\n"
+
+
+@pytest.mark.parametrize(
+    ("format_name", "filename", "top_table", "path"),
+    [
+        ("conda-toml", "out-conda.toml", "workspace", ("workspace",)),
+        ("pixi-toml", "out-pixi.toml", "workspace", ("workspace",)),
+        (
+            "pyproject-toml",
+            "out-pyproject.toml",
+            "tool",
+            ("tool", "conda", "workspace"),
+        ),
+    ],
+    ids=["conda-toml", "pixi-toml", "pyproject-toml"],
+)
+def test_export_manifest_format_plugin_hook(
+    pixi_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    export_console: Console,
+    format_name: str,
+    filename: str,
+    top_table: str,
+    path: tuple[str, ...],
+) -> None:
+    """The three manifest exporters are reachable via ``--format`` end-to-end.
+
+    Exercises the full plugin-hook path: ``execute_export`` →
+    ``resolve_exporter`` (looks up the new ``CondaEnvironmentExporter``
+    in the plugin registry) → ``ManifestParser.export`` (the writer
+    registered as ``multiplatform_export``).  Drives all three
+    targets through a single parametrised test because the CLI
+    contract is identical modulo where the ``[workspace]`` table
+    lands in the output document.
+    """
+    monkeypatch.chdir(pixi_workspace)
+    output = pixi_workspace / filename
+
+    result = execute_export(
+        make_args(
+            _DEFAULTS,
+            file=output,
+            format=format_name,
+            export_platforms=["linux-64", "osx-arm64"],
+        ),
+        console=export_console,
+    )
+
+    assert result == 0
+    data = tomlkit.loads(output.read_text(encoding="utf-8")).unwrap()
+    assert top_table in data
+
+    cursor: object = data
+    for key in path:
+        cursor = cursor[key]  # type: ignore[index]
+    assert cursor["platforms"] == ["linux-64", "osx-arm64"]

--- a/tests/cli/workspace/test_export.py
+++ b/tests/cli/workspace/test_export.py
@@ -410,3 +410,54 @@ def test_export_manifest_format_plugin_hook(
     for key in path:
         cursor = cursor[key]  # type: ignore[index]
     assert cursor["platforms"] == ["linux-64", "osx-arm64"]
+
+
+def test_export_pyproject_merges_into_existing_file(
+    pixi_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    export_console: Console,
+) -> None:
+    """``--format pyproject-toml --file pyproject.toml`` preserves peer tables.
+
+    Regression guard for #41: a naive exporter that just
+    ``Path.write_text``s the plugin output would destroy
+    ``[project]`` / ``[build-system]`` / ``[tool.ruff]`` and any
+    other section in an existing ``pyproject.toml``.
+    :meth:`PyprojectTomlParser.merge_export`, wired in
+    :func:`execute_export`, splices the exporter's ``[tool.conda]``
+    subtree in instead.
+    """
+    monkeypatch.chdir(pixi_workspace)
+    pyproject = pixi_workspace / "pyproject.toml"
+    pyproject.write_text(
+        """\
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "my-pkg"
+version = "0.1.0"
+
+[tool.ruff]
+line-length = 120
+""",
+        encoding="utf-8",
+    )
+
+    result = execute_export(
+        make_args(
+            _DEFAULTS,
+            file=pyproject,
+            format="pyproject-toml",
+            export_platforms=["linux-64"],
+        ),
+        console=export_console,
+    )
+
+    assert result == 0
+    data = tomlkit.loads(pyproject.read_text(encoding="utf-8")).unwrap()
+    assert data["build-system"]["build-backend"] == "hatchling.build"
+    assert data["project"] == {"name": "my-pkg", "version": "0.1.0"}
+    assert data["tool"]["ruff"] == {"line-length": 120}
+    assert data["tool"]["conda"]["workspace"]["platforms"] == ["linux-64"]

--- a/tests/manifests/test_exporter.py
+++ b/tests/manifests/test_exporter.py
@@ -228,15 +228,7 @@ def test_merge_export_default_overwrites(
     assert parser.merge_export(existing, fresh) == fresh
 
 
-def test_pyproject_merge_export_preserves_peer_tables(
-    parsers: dict[str, ManifestParser],
-    tmp_path: Path,
-) -> None:
-    """``[project]`` / ``[build-system]`` / ``[tool.ruff]`` survive an export."""
-    parser = parsers["pyproject-toml"]
-    path = tmp_path / "pyproject.toml"
-    path.write_text(
-        """\
+_PYPROJECT_WITH_PEERS = """\
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -250,45 +242,55 @@ line-length = 100
 
 [tool.conda]
 workspace = {name = "stale", channels = [], platforms = []}
-""",
-        encoding="utf-8",
-    )
+"""
 
-    env = make_env("linux-64", conda_specs=("python=3.12",))
-    fresh = parser.export([env])
-    merged = parser.merge_export(path, fresh)
-    data = tomlkit.loads(merged).unwrap()
-
-    assert data["build-system"]["build-backend"] == "hatchling.build"
-    assert data["project"]["name"] == "pkg"
-    assert data["project"]["version"] == "0.1.0"
-    assert data["tool"]["ruff"]["line-length"] == 100
-    conda = data["tool"]["conda"]
-    assert conda["workspace"]["name"] == "default"
-    assert conda["workspace"]["platforms"] == ["linux-64"]
-    assert conda["dependencies"] == {"python": "3.12.*"}
-
-
-def test_pyproject_merge_export_preserves_tool_pixi(
-    parsers: dict[str, ManifestParser],
-    tmp_path: Path,
-) -> None:
-    """An unrelated ``[tool.pixi]`` section is left untouched."""
-    parser = parsers["pyproject-toml"]
-    path = tmp_path / "pyproject.toml"
-    path.write_text(
-        """\
+_PYPROJECT_WITH_TOOL_PIXI = """\
 [tool.pixi]
 version = "0.42"
-""",
-        encoding="utf-8",
-    )
+"""
+
+
+@pytest.mark.parametrize(
+    ("existing", "expected_preserved"),
+    [
+        pytest.param(
+            _PYPROJECT_WITH_PEERS,
+            {
+                ("build-system", "build-backend"): "hatchling.build",
+                ("project", "name"): "pkg",
+                ("project", "version"): "0.1.0",
+                ("tool", "ruff", "line-length"): 100,
+            },
+            id="peer-tables",
+        ),
+        pytest.param(
+            _PYPROJECT_WITH_TOOL_PIXI,
+            {("tool", "pixi", "version"): "0.42"},
+            id="tool-pixi",
+        ),
+    ],
+)
+def test_pyproject_merge_export_preserves_existing_tables(
+    parsers: dict[str, ManifestParser],
+    tmp_path: Path,
+    existing: str,
+    expected_preserved: dict[tuple[str, ...], object],
+) -> None:
+    """Non-``[tool.conda]`` tables survive; stale ``[tool.conda]`` is replaced."""
+    parser = parsers["pyproject-toml"]
+    path = tmp_path / "pyproject.toml"
+    path.write_text(existing, encoding="utf-8")
 
     env = make_env("linux-64", conda_specs=("python=3.12",))
     merged = parser.merge_export(path, parser.export([env]))
     data = tomlkit.loads(merged).unwrap()
 
-    assert data["tool"]["pixi"] == {"version": "0.42"}
+    for keys, value in expected_preserved.items():
+        cursor: object = data
+        for key in keys:
+            cursor = cursor[key]  # type: ignore[index]
+        assert cursor == value
+    assert data["tool"]["conda"]["workspace"]["name"] == "default"
     assert data["tool"]["conda"]["workspace"]["platforms"] == ["linux-64"]
 
 

--- a/tests/manifests/test_exporter.py
+++ b/tests/manifests/test_exporter.py
@@ -215,6 +215,32 @@ def test_parser_exporter_class_attrs(
     assert parser_cls.filenames[0] == filename
 
 
+def test_export_handles_wildcard_pypi_spec(
+    parsers: dict[str, ManifestParser],
+) -> None:
+    """Wildcard PyPI specs (``name = "*"``) round-trip through invalid PEP 508.
+
+    :meth:`~conda_workspaces.models.PyPIDependency.__str__` returns
+    ``"requests*"`` for ``requests = "*"``, which is not a valid PEP
+    508 requirement and makes
+    :class:`packaging.requirements.Requirement` raise.  The exporter
+    falls back to splitting name from tail so the output matches
+    ``environment-yaml``'s resilience (emit ``requests*`` /
+    ``requests = "*"`` rather than crashing).
+    """
+    parser = parsers["conda-toml"]
+    env = Environment(
+        name="default",
+        platform="linux-64",
+        config=CondaEnvConfig(channels=("conda-forge",)),
+        requested_packages=[MatchSpec("python=3.12")],
+        external_packages={"pip": ["requests*"]},
+    )
+
+    data = tomlkit.loads(parser.export([env])).unwrap()
+    assert data["pypi-dependencies"] == {"requests": "*"}
+
+
 def test_intersect_rows_filters_mismatches() -> None:
     """Rows only survive the intersection when every platform has the same value."""
     per_platform = {

--- a/tests/manifests/test_exporter.py
+++ b/tests/manifests/test_exporter.py
@@ -215,6 +215,83 @@ def test_parser_exporter_class_attrs(
     assert parser_cls.filenames[0] == filename
 
 
+def test_merge_export_default_overwrites(
+    parsers: dict[str, ManifestParser],
+    tmp_path: Path,
+) -> None:
+    """``conda.toml`` / ``pixi.toml`` regeneration is a full replacement."""
+    parser = parsers["conda-toml"]
+    existing = tmp_path / "conda.toml"
+    existing.write_text("[workspace]\nname = 'stale'\n", encoding="utf-8")
+
+    fresh = "[workspace]\nname = 'fresh'\n"
+    assert parser.merge_export(existing, fresh) == fresh
+
+
+def test_pyproject_merge_export_preserves_peer_tables(
+    parsers: dict[str, ManifestParser],
+    tmp_path: Path,
+) -> None:
+    """``[project]`` / ``[build-system]`` / ``[tool.ruff]`` survive an export."""
+    parser = parsers["pyproject-toml"]
+    path = tmp_path / "pyproject.toml"
+    path.write_text(
+        """\
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pkg"
+version = "0.1.0"
+
+[tool.ruff]
+line-length = 100
+
+[tool.conda]
+workspace = {name = "stale", channels = [], platforms = []}
+""",
+        encoding="utf-8",
+    )
+
+    env = make_env("linux-64", conda_specs=("python=3.12",))
+    fresh = parser.export([env])
+    merged = parser.merge_export(path, fresh)
+    data = tomlkit.loads(merged).unwrap()
+
+    assert data["build-system"]["build-backend"] == "hatchling.build"
+    assert data["project"]["name"] == "pkg"
+    assert data["project"]["version"] == "0.1.0"
+    assert data["tool"]["ruff"]["line-length"] == 100
+    conda = data["tool"]["conda"]
+    assert conda["workspace"]["name"] == "default"
+    assert conda["workspace"]["platforms"] == ["linux-64"]
+    assert conda["dependencies"] == {"python": "3.12.*"}
+
+
+def test_pyproject_merge_export_preserves_tool_pixi(
+    parsers: dict[str, ManifestParser],
+    tmp_path: Path,
+) -> None:
+    """An unrelated ``[tool.pixi]`` section is left untouched."""
+    parser = parsers["pyproject-toml"]
+    path = tmp_path / "pyproject.toml"
+    path.write_text(
+        """\
+[tool.pixi]
+version = "0.42"
+""",
+        encoding="utf-8",
+    )
+
+    env = make_env("linux-64", conda_specs=("python=3.12",))
+    merged = parser.merge_export(path, parser.export([env]))
+    data = tomlkit.loads(merged).unwrap()
+
+    assert data["tool"]["pixi"] == {"version": "0.42"}
+    assert data["tool"]["conda"]["workspace"]["platforms"] == ["linux-64"]
+
+
 def test_export_handles_wildcard_pypi_spec(
     parsers: dict[str, ManifestParser],
 ) -> None:

--- a/tests/manifests/test_exporter.py
+++ b/tests/manifests/test_exporter.py
@@ -1,0 +1,225 @@
+"""Tests for ``ManifestParser.export`` — the manifest-format exporter plugins.
+
+Covers :meth:`ManifestParser.export` (the default
+``conda.toml`` / ``pixi.toml`` writer) and
+:meth:`PyprojectTomlParser.export` (the ``[tool.conda]``-nested
+override).  Verifies structural invariants (single-platform
+top-level-only, multi-platform top-level intersection plus
+``[target.<platform>.*]`` deltas, pypi dependencies, pyproject
+nesting) and that the output round-trips through the same
+parser's :meth:`parse` back to the declared specs and channels.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import tomlkit
+from conda.models.environment import Environment
+from conda.models.environment import EnvironmentConfig as CondaEnvConfig
+from conda.models.match_spec import MatchSpec
+
+from conda_workspaces.manifests.base import ManifestParser
+from conda_workspaces.manifests.pixi_toml import PixiTomlParser
+from conda_workspaces.manifests.pyproject_toml import PyprojectTomlParser
+from conda_workspaces.manifests.toml import CondaTomlParser
+from conda_workspaces.resolver import resolve_environment
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def make_env(
+    platform: str,
+    *,
+    name: str = "default",
+    conda_specs: tuple[str, ...] = ("python=3.12",),
+    pypi_specs: tuple[str, ...] = (),
+    channels: tuple[str, ...] = ("conda-forge",),
+) -> Environment:
+    """Build a minimal ``Environment`` for export-side tests.
+
+    The three manifest exporters only look at ``requested_packages``,
+    ``external_packages["pip"]``, ``config.channels``, ``name``, and
+    ``platform`` — ``explicit_packages`` is intentionally left empty
+    so each test exercises the declared-specs round-trip, not a
+    resolver's output.
+    """
+    external = {"pip": list(pypi_specs)} if pypi_specs else {}
+    return Environment(
+        name=name,
+        platform=platform,
+        config=CondaEnvConfig(channels=channels),
+        requested_packages=[MatchSpec(s) for s in conda_specs],
+        external_packages=external,
+    )
+
+
+def write_and_parse(parser: ManifestParser, content: str, tmp_path: Path):
+    """Write *content* to the parser's canonical filename and parse it back."""
+    path = tmp_path / parser.manifest_filename
+    path.write_text(content, encoding="utf-8")
+    return path, parser.parse(path)
+
+
+@pytest.fixture
+def parsers() -> dict[str, ManifestParser]:
+    return {
+        "conda-toml": CondaTomlParser(),
+        "pixi-toml": PixiTomlParser(),
+        "pyproject-toml": PyprojectTomlParser(),
+    }
+
+
+@pytest.mark.parametrize(
+    "format_name",
+    ["conda-toml", "pixi-toml", "pyproject-toml"],
+)
+def test_export_single_platform_round_trips(
+    format_name: str,
+    parsers: dict[str, ManifestParser],
+    tmp_path: Path,
+) -> None:
+    """Every format round-trips declared conda + pypi specs for one platform."""
+    parser = parsers[format_name]
+    env = make_env(
+        "linux-64",
+        conda_specs=("python=3.12", "numpy >=1.20"),
+        pypi_specs=("requests==2.31", "pandas"),
+    )
+
+    output = parser.export([env])
+    _, config = write_and_parse(parser, output, tmp_path)
+
+    assert config.platforms == ["linux-64"]
+    assert [c.canonical_name for c in config.channels] == ["conda-forge"]
+
+    resolved = resolve_environment(config, "default", "linux-64")
+    assert set(resolved.conda_dependencies) == {"python", "numpy"}
+    assert resolved.conda_dependencies["python"] == MatchSpec("python=3.12")
+    assert resolved.conda_dependencies["numpy"] == MatchSpec("numpy >=1.20")
+    assert set(resolved.pypi_dependencies) == {"requests", "pandas"}
+
+
+@pytest.mark.parametrize(
+    "format_name",
+    ["conda-toml", "pixi-toml", "pyproject-toml"],
+)
+def test_export_multi_platform_emits_target_deltas(
+    format_name: str,
+    parsers: dict[str, ManifestParser],
+    tmp_path: Path,
+) -> None:
+    """Shared specs at the top level; divergent specs under ``[target.*]``."""
+    parser = parsers[format_name]
+    envs = [
+        make_env(
+            "linux-64",
+            conda_specs=("python=3.12", "numpy >=1.20"),
+            pypi_specs=("requests==2.31",),
+        ),
+        make_env(
+            "osx-arm64",
+            conda_specs=("python=3.12", "numpy >=1.20", "appnope"),
+            pypi_specs=("requests==2.31",),
+        ),
+    ]
+
+    output = parser.export(envs)
+    path, config = write_and_parse(parser, output, tmp_path)
+
+    assert config.platforms == ["linux-64", "osx-arm64"]
+
+    linux = resolve_environment(config, "default", "linux-64")
+    osx = resolve_environment(config, "default", "osx-arm64")
+    assert set(linux.conda_dependencies) == {"python", "numpy"}
+    assert set(osx.conda_dependencies) == {"python", "numpy", "appnope"}
+    # Shared specs are written once at the top level — the resolver
+    # returns the same object identity-checkable spec on both
+    # platforms.  Target-override sections only appear for deltas.
+    assert set(linux.pypi_dependencies) == {"requests"}
+    assert set(osx.pypi_dependencies) == {"requests"}
+
+
+def test_export_pyproject_nests_under_tool_conda(
+    parsers: dict[str, ManifestParser],
+) -> None:
+    """PyprojectTomlParser wraps every table under ``[tool.conda]``."""
+    parser = parsers["pyproject-toml"]
+    env = make_env("linux-64", conda_specs=("python=3.12",))
+
+    output = parser.export([env])
+    data = tomlkit.loads(output).unwrap()
+
+    assert set(data) == {"tool"}
+    assert set(data["tool"]) == {"conda"}
+    conda = data["tool"]["conda"]
+    assert conda["workspace"]["platforms"] == ["linux-64"]
+    assert conda["dependencies"] == {"python": "3.12.*"}
+
+
+@pytest.mark.parametrize(
+    "format_name",
+    ["conda-toml", "pixi-toml"],
+)
+def test_export_conda_and_pixi_write_top_level_tables(
+    format_name: str,
+    parsers: dict[str, ManifestParser],
+) -> None:
+    """conda.toml / pixi.toml keep ``[workspace]`` + ``[dependencies]`` at root."""
+    parser = parsers[format_name]
+    env = make_env("linux-64", conda_specs=("python=3.12",))
+
+    data = tomlkit.loads(parser.export([env])).unwrap()
+
+    assert data["workspace"]["platforms"] == ["linux-64"]
+    assert data["dependencies"] == {"python": "3.12.*"}
+    assert "tool" not in data
+
+
+def test_export_omits_empty_pypi_and_target_tables(
+    parsers: dict[str, ManifestParser],
+) -> None:
+    """No pypi deps + single-platform → no ``[pypi-dependencies]`` / ``[target]``."""
+    parser = parsers["conda-toml"]
+    env = make_env("linux-64", conda_specs=("python=3.12",))
+
+    data = tomlkit.loads(parser.export([env])).unwrap()
+
+    assert "pypi-dependencies" not in data
+    assert "target" not in data
+
+
+def test_export_empty_envs_raises(parsers: dict[str, ManifestParser]) -> None:
+    """``manifest_data([])`` is nonsensical — fail fast."""
+    with pytest.raises(ValueError, match="At least one Environment"):
+        parsers["conda-toml"].export([])
+
+
+@pytest.mark.parametrize(
+    ("parser_cls", "filename", "exporter_format"),
+    [
+        (CondaTomlParser, "conda.toml", "conda-toml"),
+        (PixiTomlParser, "pixi.toml", "pixi-toml"),
+        (PyprojectTomlParser, "pyproject.toml", "pyproject-toml"),
+    ],
+)
+def test_parser_exporter_class_attrs(
+    parser_cls: type[ManifestParser],
+    filename: str,
+    exporter_format: str,
+) -> None:
+    """Each parser advertises its exporter plugin identity + filename."""
+    assert parser_cls.exporter_format == exporter_format
+    assert parser_cls.filenames[0] == filename
+
+
+def test_intersect_rows_filters_mismatches() -> None:
+    """Rows only survive the intersection when every platform has the same value."""
+    per_platform = {
+        "linux-64": {"a": "1", "b": "1", "c": "1"},
+        "osx-arm64": {"a": "1", "b": "2"},
+    }
+    common = ManifestParser._intersect_rows(per_platform)
+    assert common == {"a": "1"}

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -37,14 +37,29 @@ def test_conda_environment_specifiers(name: str, expected_cls_name: str) -> None
     assert items[name].environment_spec.__name__ == expected_cls_name
 
 
-def test_conda_environment_exporters_yields_one() -> None:
-    items = list(conda_environment_exporters())
-    assert len(items) == 1
-    exp = items[0]
-    assert exp.name == lockfile.FORMAT
-    assert exp.aliases == lockfile.ALIASES
-    assert exp.default_filenames == lockfile.DEFAULT_FILENAMES
-    assert callable(exp.multiplatform_export)
+def test_conda_environment_exporters_yields_lockfile_and_manifests() -> None:
+    """The hook yields the ``conda.lock`` exporter plus one per manifest format."""
+    items = {exp.name: exp for exp in conda_environment_exporters()}
+    assert set(items) == {
+        lockfile.FORMAT,
+        "conda-toml",
+        "pixi-toml",
+        "pyproject-toml",
+    }
+
+    lock_exp = items[lockfile.FORMAT]
+    assert lock_exp.aliases == lockfile.ALIASES
+    assert lock_exp.default_filenames == lockfile.DEFAULT_FILENAMES
+    assert callable(lock_exp.multiplatform_export)
+
+    for name, filename in [
+        ("conda-toml", "conda.toml"),
+        ("pixi-toml", "pixi.toml"),
+        ("pyproject-toml", "pyproject.toml"),
+    ]:
+        exp = items[name]
+        assert exp.default_filenames == (filename,)
+        assert callable(exp.multiplatform_export)
 
 
 def test_conda_pre_commands_yields_install_hint() -> None:


### PR DESCRIPTION
Closes #41.

## Summary

Three new \`CondaEnvironmentExporter\` plugin hooks make \`conda workspace export --format <name>\` able to emit a workspace manifest in any of the conda-flavored TOML dialects:

- \`conda-toml\` — round-trips to our own \`conda.toml\` format
- \`pixi-toml\` — \`pixi.toml\` / \`[workspace]\` table
- \`pyproject-toml\` — \`[tool.conda]\` table in \`pyproject.toml\`

This completes the symmetry with \`conda workspace import\`: \`conda workspace\` is now a bidirectional translator between every manifest dialect it understands.

## Design

- The writer for each format is the \`export\` method on the matching \`ManifestParser\` subclass, sitting right next to \`parse\` / \`write_workspace_stub\`. Format-specific logic lives next to the format-specific parser; the \`conda workspace export\` CLI stays format-agnostic.
- Shared folding logic (\`ManifestParser.manifest_data\`) extracts \`name\` / \`platforms\` / \`channels\` from \`Environment\` objects and splits the per-platform specs into the shared intersection plus per-platform deltas in one place, so the three writers only differ in where they drop the resulting tables.
- \`CondaTomlParser\` and \`PixiTomlParser\` inherit the default top-level writer (\`[workspace]\` / \`[dependencies]\` / \`[pypi-dependencies]\` / \`[target.<platform>.*]\` at root). \`PyprojectTomlParser.export\` overrides to wrap the same content under \`[tool.conda]\` so the output drops into an existing PEP 621 \`pyproject.toml\` alongside \`[project]\` / \`[build-system]\`.
- \`plugin.py\` iterates over every \`ManifestParser\` subclass whose \`exporter_format\` class attribute is set and yields one \`CondaEnvironmentExporter\` per parser, reusing \`parser.filenames\` for \`--file\` inference.

## What lights up for free

Because these are plain \`CondaEnvironmentExporter\` plugins, everything that \`conda workspace export\` already does works without new CLI code:

- \`--format conda-toml\` / \`--format pixi-toml\` / \`--format pyproject-toml\`
- \`--file conda.toml\` / \`--file pixi.toml\` / \`--file pyproject.toml\` picks the right exporter from the basename
- Multi-platform projection via \`--platform linux-64 --platform osx-arm64\` (all three are multiplatform exporters)
- \`--dry-run\`, \`--json\`, \`--output\`, \`--from-prefix\`, \`--from-lockfile\` all Just Work

## Out of scope

- Lossless conversion from a solved \`conda.lock\` back to an abstract \`conda.toml\` manifest — version-pinned URLs → spec strings is lossy and belongs in a separate \`conda-lock\` importer issue.
- New importers. These plugins only extend the writing side.

## Test plan

- [x] 15 new unit tests in \`tests/manifests/test_exporter.py\` cover single-platform round-trip (parse(export(envs)) == envs), multi-platform \`[target.*]\` deltas, pyproject nesting, empty-table elision, empty-envs error, class-attribute wiring, intersection logic.
- [x] 3 new parametrised CLI-level tests in \`tests/cli/workspace/test_export.py\` drive all three formats through \`execute_export\` end-to-end.
- [x] Extended \`test_resolve_exporter_detects_by_filename\` with \`conda.toml\` / \`pixi.toml\` / \`pyproject.toml\` so filename-based \`--format\` detection is tested.
- [x] \`tests/test_plugin.py\` updated to cover all four exporters (the lockfile plus the three manifest formats).
- [x] Full suite: 879 passed, 1 skipped. \`ruff check\` + \`ruff format --check\` clean.
- [x] Manual smoke: \`conda workspace export --format conda-toml --dry-run --platform linux-64 --platform osx-arm64\` produces the expected output with shared deps at top level and per-platform \`[target.linux-64.dependencies]\` deltas; same for \`--format pyproject-toml\` wrapping everything under \`[tool.conda.*]\`.