### PR TITLE
Fix --json handling across workspace subcommands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,53 @@
   `conda_settings`, `conda_pre_commands`) and the
   `[project.entry-points.conda]` entry point.
 
+## `--json` contract
+
+- `--json` is an **output format**, not a behaviour switch. It belongs
+  on subcommands whose job is to produce data worth serializing
+  (queries, state dumps, structured result envelopes). Side-effect
+  subcommands — ones whose job is to mutate the workspace, drop into
+  a shell, or exec another process — must not advertise `--json`,
+  because they have nothing meaningful to emit and a noisy
+  human-readable stream on stdout would break a caller's JSON parser.
+
+- Which workspace / task subcommands emit structured JSON today, and
+  which don't:
+
+  | Emits JSON (use `add_output_and_prompt_options`)         | Side-effect only (use `_accept_json_silently`)          |
+  |----------------------------------------------------------|---------------------------------------------------------|
+  | `info`, `list`, `envs`, `export`, `quickstart`,          | `init`, `activate`, `run`, `shell`                      |
+  | `install`, `lock`, `add`, `remove`, `clean`, `import`,   |                                                         |
+  | `task run`, `task list`, `task add`, `task remove`,      |                                                         |
+  | `task export`                                            |                                                         |
+
+  When a side-effect subcommand grows a genuinely structured result
+  (e.g. ``init`` could emit ``{"manifest": "...", "format": "..."}``),
+  promote it to the left column — switch from `_accept_json_silently`
+  to `add_output_and_prompt_options` and teach the handler to honour
+  the flag.
+
+- Subcommands in the right column still have to **tolerate** `--json`.
+  Scripts and CI wrappers pass `--json` globally, and argparse-level
+  crashes with ``unrecognized arguments: --json`` are a worse UX than
+  silent acceptance. Call `_accept_json_silently(parser)` (in
+  ``cli/main.py``) on those parsers; it mirrors conda's own
+  pre-parser trick (``conda/cli/conda_argparse.py`` registers
+  ``--json`` with ``help=SUPPRESS`` on the pre-parser so every
+  top-level command tolerates the flag). The handler produces no
+  output on ``--json`` and relies on the exit code for status.
+
+- Orchestrator subcommands that call other subcommands (`quickstart`,
+  any future composite) own the JSON surface themselves: they emit
+  one structured payload on stdout at the end, and route every
+  nested handler through a silent Rich `Console` so the sub-handler's
+  status lines land in a throwaway buffer instead of corrupting the
+  payload. Do not propagate `--json` into the sub-handler's
+  ``Namespace`` — the nested handlers stay in human-output mode, and
+  the orchestrator silences their ``Console`` instead. See
+  ``execute_quickstart`` in ``cli/workspace/quickstart.py`` for the
+  canonical pattern.
+
 ## Parser search order
 
 - The parser registry searches for workspace manifests in this order:

--- a/conda_workspaces/cli/main.py
+++ b/conda_workspaces/cli/main.py
@@ -6,6 +6,7 @@ Argparse configuration and dispatch for both subcommands.
 from __future__ import annotations
 
 import argparse
+from argparse import SUPPRESS
 from pathlib import Path
 
 from conda.base.context import context as conda_context
@@ -14,7 +15,34 @@ from conda.cli.helpers import (
     add_output_and_prompt_options,
     add_parser_help,
 )
+from conda.common.constants import NULL
 from conda.exceptions import CondaError, CondaSystemExit, DryRunExit
+
+
+def _accept_json_silently(parser: argparse.ArgumentParser) -> None:
+    """Accept ``--json`` on a side-effect subcommand without advertising it.
+
+    Mirrors conda's own pre-parser trick (``conda/cli/conda_argparse.py``
+    registers ``--json`` with ``help=SUPPRESS`` on the pre-parser, so
+    every top-level conda command tolerates the flag). Our subcommands
+    that do not have structured output to emit — ``init``, ``activate``,
+    ``run``, ``shell`` — still get piped by scripts and CI wrappers that
+    set ``--json`` globally; crashing with ``unrecognized arguments:
+    --json`` is the wrong UX. This helper lets those commands silently
+    accept the flag, produce no output on ``--json`` (so the caller's
+    JSON parser still sees a clean stream on stdout), and rely on the
+    exit code for status.
+
+    Only register ``--json`` via this helper on commands that do **not**
+    call :func:`add_output_and_prompt_options`; otherwise argparse
+    raises ``ArgumentError: conflicting option string``.
+    """
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        default=NULL,
+        help=SUPPRESS,
+    )
 
 
 def _handle_error(exc: CondaError) -> int:
@@ -66,6 +94,7 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
         add_help=False,
     )
     add_parser_help(init_parser)
+    _accept_json_silently(init_parser)
     init_parser.add_argument(
         "--format",
         choices=["pixi", "conda", "pyproject"],
@@ -439,6 +468,7 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
         add_help=False,
     )
     add_parser_help(activate_parser)
+    _accept_json_silently(activate_parser)
     activate_parser.add_argument(
         "-e",
         "--environment",
@@ -452,6 +482,7 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
         add_help=False,
     )
     add_parser_help(run_parser)
+    _accept_json_silently(run_parser)
     run_parser.add_argument(
         "-e",
         "--environment",
@@ -470,6 +501,7 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
         add_help=False,
     )
     add_parser_help(shell_parser)
+    _accept_json_silently(shell_parser)
     shell_parser.add_argument(
         "-e",
         "--environment",

--- a/conda_workspaces/cli/task/run.py
+++ b/conda_workspaces/cli/task/run.py
@@ -125,7 +125,7 @@ def execute_run(args: argparse.Namespace, *, console: Console | None = None) -> 
 
     dry_run = getattr(args, "dry_run", False)
     quiet = getattr(args, "quiet", False)
-    verbose = getattr(args, "verbose", 0) or 0
+    verbose = getattr(args, "verbosity", 0) or 0
     user_env = getattr(args, "environment", None)
     conda_prefix = _env_prefix_or_none(args)
 

--- a/conda_workspaces/cli/workspace/init.py
+++ b/conda_workspaces/cli/workspace/init.py
@@ -37,5 +37,11 @@ def execute_init(args: argparse.Namespace, *, console: Console | None = None) ->
 
     parser = ManifestParser.for_format_alias(args.manifest_format)
     path, verb = parser.write_workspace_stub(base_dir, name, channels, platforms)
-    status.message(console, verb, "workspace", path.name, detail=str(path.parent))
+    # ``init`` has no structured output of its own, but a caller that
+    # passes ``--json`` (accepted silently by ``_accept_json_silently``
+    # in ``cli/main.py``) is piping stdout through a JSON parser — the
+    # Rich status line would corrupt that. See the "--json contract"
+    # section in ``AGENTS.md``.
+    if not conda_context.json:
+        status.message(console, verb, "workspace", path.name, detail=str(path.parent))
     return 0

--- a/conda_workspaces/cli/workspace/quickstart.py
+++ b/conda_workspaces/cli/workspace/quickstart.py
@@ -26,6 +26,7 @@ without guessing.
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import sys
 from pathlib import Path
@@ -56,6 +57,22 @@ def execute_quickstart(
     dry_run: bool = args.dry_run
     json_output: bool = args.json
     no_shell: bool = args.no_shell or json_output
+
+    # --json promises a single JSON object on stdout and nothing else.
+    # ``execute_init`` / ``execute_add`` / ``execute_install`` are
+    # unaware of ``--json`` — they emit Rich status lines via
+    # :mod:`conda_workspaces.cli.status` unconditionally — so under
+    # ``--json`` we hand them (and every ``console.print`` call
+    # inside quickstart itself) a throwaway Console whose output
+    # goes to an in-memory buffer.  Only the final ``json.dumps``
+    # write at the end of this function reaches real stdout.
+    if json_output:
+        console = Console(
+            file=io.StringIO(),
+            highlight=False,
+            force_terminal=False,
+            no_color=True,
+        )
     copy_from: Path | None = args.copy_from
     specs: list[str] = list(args.specs or [])
     env_name: str = args.environment or "default"
@@ -64,11 +81,16 @@ def execute_quickstart(
     workspace_root = Path.cwd()
 
     # Global prompt / output flags every sub-handler must see
-    # (``--json`` / ``--dry-run`` / ``--yes`` / ``-v`` / ``-q`` /
-    # ``--debug`` / ``--trace``) so terminal output and machine-readable
-    # output stay coherent across the pipeline.  ``add_output_and_prompt_options``
-    # on the parent parser guarantees each attribute exists.
-    prompt_keys = ("json", "yes", "dry_run", "quiet", "verbosity", "debug", "trace")
+    # (``--dry-run`` / ``--yes`` / ``-v`` / ``-q`` / ``--debug`` /
+    # ``--trace``) so terminal output stays coherent across the
+    # pipeline.  ``--json`` is deliberately not forwarded: quickstart
+    # owns the JSON surface (one structured payload on stdout at the
+    # end of this function), and sub-handlers stay in human-output
+    # mode — we just hand them a silent ``Console`` above so their
+    # Rich status lines land in a throwaway buffer instead of
+    # corrupting the payload.  ``add_output_and_prompt_options`` on
+    # the parent parser guarantees each remaining attribute exists.
+    prompt_keys = ("yes", "dry_run", "quiet", "verbosity", "debug", "trace")
 
     def with_prompts(**kwargs: object) -> argparse.Namespace:
         """Build a sub-handler ``Namespace`` from *kwargs* + ``prompt_keys``."""
@@ -135,7 +157,8 @@ def execute_quickstart(
                 name=args.name,
                 channels=args.channels,
                 platforms=args.platforms,
-            )
+            ),
+            console=console,
         )
         parser = ManifestParser.for_format_alias(fmt)
         manifest_path = parser.manifest_path(workspace_root)
@@ -154,7 +177,8 @@ def execute_quickstart(
                 no_install=False,
                 no_lockfile_update=False,
                 force_reinstall=args.force_reinstall,
-            )
+            ),
+            console=console,
         )
     else:
         execute_install(
@@ -164,7 +188,8 @@ def execute_quickstart(
                 force_reinstall=args.force_reinstall,
                 locked=args.locked,
                 frozen=args.frozen,
-            )
+            ),
+            console=console,
         )
 
     shell_spawned = False

--- a/conda_workspaces/cli/workspace/quickstart.py
+++ b/conda_workspaces/cli/workspace/quickstart.py
@@ -68,7 +68,7 @@ def execute_quickstart(
     # ``--debug`` / ``--trace``) so terminal output and machine-readable
     # output stay coherent across the pipeline.  ``add_output_and_prompt_options``
     # on the parent parser guarantees each attribute exists.
-    prompt_keys = ("json", "yes", "dry_run", "quiet", "verbose", "debug", "trace")
+    prompt_keys = ("json", "yes", "dry_run", "quiet", "verbosity", "debug", "trace")
 
     def with_prompts(**kwargs: object) -> argparse.Namespace:
         """Build a sub-handler ``Namespace`` from *kwargs* + ``prompt_keys``."""

--- a/tests/cli/task/test_add.py
+++ b/tests/cli/task/test_add.py
@@ -31,7 +31,7 @@ def test_add_task(tmp_path, capsys, dry_run, expect_file_exists):
         description="A new task" if not dry_run else None,
         dry_run=dry_run,
         quiet=False,
-        verbose=0,
+        verbosity=0,
         json=False,
     )
     result = execute_add(args)
@@ -57,7 +57,7 @@ def test_add_task_auto_detect_creates_default_file(tmp_path, monkeypatch, capsys
         description=None,
         dry_run=False,
         quiet=False,
-        verbose=0,
+        verbosity=0,
         json=False,
     )
     result = execute_add(args)

--- a/tests/cli/task/test_export.py
+++ b/tests/cli/task/test_export.py
@@ -23,7 +23,7 @@ def _export_args(file: Path, output: Path | None = None) -> argparse.Namespace:
         file=file,
         output=output,
         quiet=False,
-        verbose=0,
+        verbosity=0,
         json=False,
         dry_run=False,
     )

--- a/tests/cli/task/test_list.py
+++ b/tests/cli/task/test_list.py
@@ -23,7 +23,7 @@ def _make_console() -> tuple[Console, io.StringIO]:
 
 def _list_args(file: Path, *, use_json: bool = False) -> argparse.Namespace:
     return argparse.Namespace(
-        file=file, json=use_json, quiet=False, verbose=0, dry_run=False
+        file=file, json=use_json, quiet=False, verbosity=0, dry_run=False
     )
 
 

--- a/tests/cli/task/test_remove.py
+++ b/tests/cli/task/test_remove.py
@@ -23,7 +23,7 @@ def _remove_args(
         task_name=task_name,
         dry_run=dry_run,
         quiet=False,
-        verbose=0,
+        verbosity=0,
         json=False,
     )
 

--- a/tests/cli/task/test_run.py
+++ b/tests/cli/task/test_run.py
@@ -24,7 +24,7 @@ def _run_args(
         skip_deps=False,
         dry_run=False,
         quiet=False,
-        verbose=0,
+        verbosity=0,
         clean_env=False,
         cwd=None,
         environment=None,
@@ -278,7 +278,7 @@ def test_execute_run_dep_chain_verbose(tmp_path, capsys, fake_shell):
         '[tasks.build]\ncmd = "echo build"\ndepends-on = ["setup"]\n'
     )
 
-    result = execute_run(_run_args(task_file, task_name="build", verbose=1))
+    result = execute_run(_run_args(task_file, task_name="build", verbosity=1))
 
     assert result == 0
     output = capsys.readouterr().out
@@ -296,7 +296,7 @@ def test_execute_run_verbose_with_io(tmp_path, capsys, fake_shell, monkeypatch):
     )
 
     monkeypatch.setattr(run_mod, "is_cached", lambda *a, **kw: False)
-    result = execute_run(_run_args(task_file, task_name="build", verbose=1))
+    result = execute_run(_run_args(task_file, task_name="build", verbosity=1))
 
     assert result == 0
     output = capsys.readouterr().out

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -237,6 +237,30 @@ def test_shell_accepts_environment_flag() -> None:
 
 
 @pytest.mark.parametrize(
+    "argv",
+    [
+        ["init", "--json"],
+        ["activate", "--json"],
+        ["run", "--json", "--", "echo", "hi"],
+        ["shell", "--json"],
+    ],
+    ids=["init", "activate", "run", "shell"],
+)
+def test_side_effect_subcommands_accept_json_silently(argv: list[str]) -> None:
+    """Side-effect subcommands must tolerate ``--json`` without argparse errors.
+
+    These subcommands register ``--json`` with ``help=SUPPRESS`` via
+    :func:`_accept_json_silently` because they have no structured output
+    to emit, but CI wrappers still pass ``--json`` globally; crashing
+    with ``unrecognized arguments: --json`` is the wrong UX. See the
+    ``--json contract`` section in ``AGENTS.md``.
+    """
+    parser = generate_workspace_parser()
+    parsed = parser.parse_args(argv)
+    assert parsed.subcmd == argv[0]
+
+
+@pytest.mark.parametrize(
     "args, expected_attr, expected_value",
     [
         (["run", "test"], "task_name", "test"),

--- a/tests/cli/workspace/test_init.py
+++ b/tests/cli/workspace/test_init.py
@@ -152,6 +152,36 @@ def test_init_default_name_from_dir(
     assert doc["workspace"]["name"] == tmp_path.name
 
 
+def test_init_silent_on_stdout_under_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``init --json`` must not print Rich status to stdout.
+
+    ``init`` has no structured JSON payload, but a caller that passes
+    ``--json`` (accepted silently via ``_accept_json_silently`` in
+    ``cli/main.py``) is piping stdout through a JSON parser. Leaking
+    the "Created ..." status line would corrupt that stream. See the
+    ``--json contract`` section in ``AGENTS.md``.
+    """
+    from conda_workspaces.cli.workspace import init as init_module
+
+    class _JsonContext:
+        json = True
+
+    monkeypatch.setattr(init_module, "conda_context", _JsonContext())
+    monkeypatch.chdir(tmp_path)
+    args = make_args(_DEFAULTS, manifest_format="conda", name="quiet")
+
+    result = execute_init(args)
+
+    assert result == 0
+    assert (tmp_path / "conda.toml").exists()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
 def test_init_default_channels(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     args = make_args(_DEFAULTS, manifest_format="pixi", name="ch-test", channels=None)

--- a/tests/cli/workspace/test_quickstart.py
+++ b/tests/cli/workspace/test_quickstart.py
@@ -36,7 +36,7 @@ _DEFAULTS = {
     "yes": False,
     "dry_run": False,
     "quiet": False,
-    "verbose": 0,
+    "verbosity": 0,
     "debug": False,
     "trace": False,
 }

--- a/tests/cli/workspace/test_quickstart.py
+++ b/tests/cli/workspace/test_quickstart.py
@@ -43,16 +43,27 @@ _DEFAULTS = {
 
 
 class _RecordingRunner:
-    """Callable that records each ``Namespace`` it was invoked with."""
+    """Callable that records each ``Namespace`` (and optional ``console``) it saw.
+
+    Mirrors the ``execute_X(args, *, console=None)`` signature the real
+    workspace sub-handlers expose, so tests can assert both the args
+    ``quickstart`` forwards *and* the ``Console`` it routed output
+    through (used to guard against ``--json`` leaking sub-handler
+    Rich output onto real stdout).
+    """
 
     def __init__(self, *, effect=None) -> None:
         self.calls: list[argparse.Namespace] = []
+        self.consoles: list[Console | None] = []
         self._effect = effect
 
-    def __call__(self, ns: argparse.Namespace) -> int:
+    def __call__(
+        self, ns: argparse.Namespace, *, console: Console | None = None
+    ) -> int:
         self.calls.append(ns)
+        self.consoles.append(console)
         if self._effect is not None:
-            self._effect(ns)
+            self._effect(ns, console=console)
         return 0
 
 
@@ -71,8 +82,11 @@ def orchestrated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     """
     monkeypatch.chdir(tmp_path)
 
-    def _touch_manifest(ns: argparse.Namespace) -> None:
+    def _touch_manifest(
+        ns: argparse.Namespace, *, console: Console | None = None
+    ) -> None:
         """``execute_init`` would write a manifest; simulate it."""
+        del console
         fmt = getattr(ns, "manifest_format", "conda") or "conda"
         filename = {"conda": "conda.toml", "pixi": "pixi.toml"}.get(
             fmt, "pyproject.toml"
@@ -220,6 +234,56 @@ def test_quickstart_json_suppresses_shell_and_emits_payload(
     assert payload["specs_added"] == ["python=3.14"]
     assert payload["shell_spawned"] is False
     assert payload["manifest"] == "conda.toml"
+
+
+def test_quickstart_json_does_not_forward_flag_to_subhandlers(
+    orchestrated: dict,
+) -> None:
+    """``--json`` is owned by quickstart; sub-handlers never see it.
+
+    Quickstart silences their Rich output via a throwaway Console
+    instead of asking them to honour ``--json`` themselves, so
+    neither ``init`` nor ``add`` / ``install`` should observe the
+    attribute on the ``Namespace`` they receive.
+    """
+    orchestrated["run"](specs=["python=3.14"], json=True)
+
+    for name in ("init", "add"):
+        ns = orchestrated["runners"][name].calls[0]
+        assert not hasattr(ns, "json"), (
+            f"execute_{name} unexpectedly received --json; quickstart"
+            " should own the JSON surface and keep sub-handlers in"
+            " human-output mode"
+        )
+
+
+def test_quickstart_json_routes_subhandlers_through_silent_console(
+    orchestrated: dict,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Rich output from sub-handlers must not leak onto stdout under --json.
+
+    Simulates the real sub-handlers by having the fake ``init`` /
+    ``add`` runners print status lines through the ``Console`` they
+    receive; under ``--json`` that console must be a StringIO-backed
+    sink, so stdout only carries the final JSON payload.
+    """
+
+    def _noisy(ns, *, console):  # type: ignore[no-untyped-def]
+        del ns
+        if console is not None:
+            console.print("[bold cyan]Created[/bold cyan] workspace stub")
+
+    orchestrated["runners"]["init"]._effect = _noisy
+    orchestrated["runners"]["add"]._effect = _noisy
+
+    orchestrated["run"](specs=["python=3.14"], json=True)
+
+    captured = capsys.readouterr()
+    lines = [line for line in captured.out.splitlines() if line]
+    assert len(lines) == 1, f"expected a single JSON line on stdout, got: {lines!r}"
+    payload = json.loads(lines[0])
+    assert payload["specs_added"] == ["python=3.14"]
 
 
 def test_quickstart_dry_run_skips_side_effects(


### PR DESCRIPTION
## Summary

Three related `--json` fixes that surfaced while recording the 0.4.0 demos:

- `conda workspace quickstart` crashed on every invocation with `AttributeError: 'Namespace' object has no attribute 'verbose'` after conda renamed its dest to `verbosity`. Shipped in d15aad2.
- `conda workspace quickstart --json` promised one JSON object on stdout but leaked Rich status lines from `init` / `add` / `install` alongside the payload, corrupting it for any JSON-parsing caller.
- `conda workspace init --json`, `activate --json`, `run --json`, and `shell --json` all crashed with `unrecognized arguments: --json`, even though scripts and CI wrappers routinely pass `--json` globally.

The fix treats `--json` as an output format owned by whichever subcommand has structured data to emit, mirroring conda's own pre-parser `help=SUPPRESS` trick so side-effect subcommands tolerate the flag without lying about supporting it.

## Changes

Three commits, ordered by blast radius:

1. d15aad2 — **Fix --verbose lookup after conda dest rename (verbose → verbosity).** Updates `prompt_keys` in `execute_quickstart` and `getattr(args, "verbose")` in `conda task run` to track conda's new dest. Also syncs a handful of test fixtures.
2. ef130a7 — **Silence quickstart --json sub-handler output.** `execute_quickstart` now swaps its local `Console` for a `StringIO`-backed throwaway under `--json` and passes it down to `execute_init` / `execute_add` / `execute_install`. Drops `"json"` from `prompt_keys` since no sub-handler actually reads `args.json` today, and propagating it would eat real sub-handler JSON in the future if any ever grew it.
3. 6a3ffe1 — **Tolerate --json on side-effect subcommands.** New `_accept_json_silently` helper in `cli/main.py` (argparse `help=SUPPRESS`, mirroring `conda/cli/conda_argparse.py`). Wired onto `init`, `activate`, `run`, `shell` parsers. `init` also stops printing its "Created ..." status line when `conda_context.json` is true. Documents the full contract in `AGENTS.md` under a new "--json contract" section with a two-column table classifying every workspace/task subcommand.

## Test plan

- [x] `pixi run -e test pytest` — 891 passed, 1 skipped (up from 886; five new regression tests).
- [x] `pixi run -e test ruff check` — clean.
- [x] `pixi run -e test ruff format --check` — clean.
- [x] Manual smoke: `conda workspace init --json` writes the manifest, exits 0, emits nothing on stdout.
- [x] Manual smoke: `conda workspace activate --json` / `run --json -- echo hi` / `shell --json --help` all parse cleanly (no `unrecognized arguments` error).
- [x] Manual smoke: `conda workspace quickstart --json ...` emits exactly one line of JSON, no human status noise.

## Regression coverage added

- `tests/cli/workspace/test_quickstart.py::test_quickstart_json_does_not_forward_flag_to_subhandlers` — `init` / `add` never see `ns.json`.
- `tests/cli/workspace/test_quickstart.py::test_quickstart_json_routes_subhandlers_through_silent_console` — noisy sub-handlers printing through their `Console` do not leak onto stdout; the payload is a single JSON line.
- `tests/cli/test_main.py::test_side_effect_subcommands_accept_json_silently` — parametrized over `init` / `activate` / `run` / `shell`; `parser.parse_args` no longer raises on `--json`.
- `tests/cli/workspace/test_init.py::test_init_silent_on_stdout_under_json` — `execute_init` writes the manifest but emits nothing on stdout when `conda_context.json` is true.