### PR TITLE
Document 0.4.0 features and embed the refreshed demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- Documented and enforced a consistent ``--json`` contract across
+  every `conda workspace` and `conda task` subcommand (see the
+  ``--json contract`` section in ``AGENTS.md``). Commands with
+  structured output (``info``, ``envs``, ``list``, ``export``,
+  ``import``, ``add``, ``remove``, ``install``, ``lock``,
+  ``quickstart``, and the ``conda task`` query commands) keep
+  emitting a single JSON payload on stdout. Side-effect-only
+  commands (``init``, ``activate``, ``run``, ``shell``) used to
+  crash with ``unrecognized arguments: --json`` when CI wrappers
+  passed the flag globally; they now accept it silently — the
+  flag is registered with ``argparse.SUPPRESS`` so it does not
+  show up in ``--help`` — produce no human-readable output, and
+  rely on the exit code for status. ``conda workspace quickstart
+  --json`` now owns the JSON surface end-to-end: sub-handlers
+  (``init`` / ``add`` / ``install``) are routed through a silent
+  Rich console so no status banners leak before the structured
+  payload. ``conda workspace init`` similarly suppresses its
+  ``Created conda.toml workspace`` status line under
+  ``conda_context.json``.
 - `conda workspace export` gained three new manifest-format exporter
   plugins: `conda-toml`, `pixi-toml`, and `pyproject-toml`. They
   register via the same `conda_environment_exporters` hook as

--- a/docs/features.md
+++ b/docs/features.md
@@ -457,6 +457,8 @@ checks entirely and install the lockfile as-is.
 
 ### CI-split locking with `--merge`
 
+![ci-split demo](../demos/ci-split.gif)
+
 Solving every platform in one job becomes expensive as a workspace
 grows. `conda workspace lock` supports matrix pipelines that split
 solving across runners and stitch the fragments back together on a
@@ -492,14 +494,18 @@ conda workspace install -f path/to/conda.toml
 
 ## Export
 
+![export demo](../demos/export.gif)
+
 `conda workspace export` converts a workspace environment into any
 format registered through conda's `conda_environment_exporters`
 plugin hook: the built-in `environment-yaml` / `environment-json`
 exporters, the `conda-workspaces-lock-v1` exporter registered by
-conda-workspaces itself, and any third-party exporter (e.g.
-`conda-lockfiles`' rattler-lock-v6) the moment it is installed. There
-is no separate writer — every exporter reachable through `conda
-export` is reachable through `conda workspace export` and vice versa.
+conda-workspaces itself, the `conda-toml` / `pixi-toml` /
+`pyproject-toml` manifest exporters, and any third-party exporter
+(e.g. `conda-lockfiles`' rattler-lock-v6) the moment it is installed.
+There is no separate writer — every exporter reachable through
+`conda export` is reachable through `conda workspace export` and
+vice versa.
 
 ```bash
 # Default: environment-yaml from the declared manifest (no install needed)
@@ -507,6 +513,13 @@ conda workspace export -e default --file environment.yml
 
 # environment.json; format auto-detected from the filename
 conda workspace export -e default --file environment.json
+
+# Re-emit the workspace as a conda.toml manifest (cross-format export)
+conda workspace export --format conda-toml --file conda.toml
+
+# Same content, nested under [tool.conda] — drops into an existing
+# pyproject.toml next to [project], [build-system], [tool.ruff], ...
+conda workspace export --format pyproject-toml --file pyproject.toml
 
 # Multi-platform conda.lock re-emit via the lockfile exporter
 conda workspace export --format conda-workspaces-lock-v1 \
@@ -534,8 +547,35 @@ Three sources feed the exporter:
 `--platform` (repeatable) intersects declared / available platforms
 with the chosen subset. Passing multiple platforms requires an
 exporter that opts into `multiplatform_export` — the
-`conda-workspaces-lock-v1` and rattler-lock exporters do; the
+`conda-workspaces-lock-v1`, rattler-lock, and the three manifest
+exporters (`conda-toml`, `pixi-toml`, `pyproject-toml`) do; the
 single-platform yaml / json ones raise a clear error.
+
+### Manifest-format exporters
+
+The `conda-toml`, `pixi-toml`, and `pyproject-toml` exporters round-trip
+a workspace back into any of the manifest dialects conda-workspaces
+already reads, so `conda workspace import` and `conda workspace
+export` together form a bidirectional translator across every
+supported format. Declared specs that appear on every requested
+platform land under the top-level `[dependencies]` /
+`[pypi-dependencies]` tables; platform-specific deltas move under
+`[target.<platform>.*]`. The `pyproject-toml` exporter wraps the
+same content under `[tool.conda]`, and when the target
+`pyproject.toml` already exists it splices the `[tool.conda]`
+subtree into the existing document so peer `[project]`,
+`[build-system]`, `[tool.ruff]`, `[tool.pixi]`, and friends
+survive untouched (any stale `[tool.conda]` is replaced).
+`conda.toml` and `pixi.toml` keep the default overwrite semantics
+of every other conda exporter.
+
+When `--file` is not passed, the format is inferred from the
+basename (`conda.toml` → `conda-toml`, `pixi.toml` → `pixi-toml`,
+`pyproject.toml` → `pyproject-toml`, `environment.yml` /
+`environment.yaml` → `environment-yaml`, `environment.json` →
+`environment-json`, `conda.lock` → `conda-workspaces-lock-v1`).
+See [Format aliases](reference/format-aliases.md) for the full
+alias table.
 
 ## Project-local environments
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -172,8 +172,17 @@ clean = "{% if conda.is_win %}rd /s /q build{% else %}rm -rf build/{% endif %}"
 
 ### Task environment targeting
 
-Tasks run in your current conda environment by default. When used with
-a workspace, you can target a specific environment:
+:::{versionchanged} 0.4.0
+When a task is defined in a manifest that also declares workspace
+environments, `conda task run` now falls back to the workspace's
+`default` environment instead of whatever conda environment happens
+to be active. Tasks without a workspace (tasks-only manifests)
+still use the current conda environment. `-e <env>` and a task's
+`default-environment` key continue to take precedence.
+:::
+
+Tasks defined alongside workspace environments run in the workspace's
+`default` environment. Override with `-e <env>`:
 
 ```bash
 conda task run test -e myenv
@@ -272,6 +281,14 @@ Platform overrides are merged on top of the base dependencies when
 resolving for a specific platform.
 
 ### Known vs. declared platforms
+
+:::{versionadded} 0.4.0
+`conda workspace info` surfaces the reachable platform set as a
+`known_platforms` JSON key (and a matching `Known Platforms` row in
+the text view whenever a feature broadens the workspace-level set).
+`conda workspace lock --platform <subdir>` validates against this
+same set.
+:::
 
 The workspace-level `platforms` list is the default set every
 environment can be solved for. Individual features may declare
@@ -384,6 +401,24 @@ conda's default channel priority applies.
 
 ## Lock
 
+:::{versionchanged} 0.4.0
+`conda workspace lock` now writes a single `conda.lock` that covers
+every platform declared by each environment, not just the host
+platform. Target-platform solves run with `context._subdir`
+overridden so conda's virtual package plugins (`__linux`, `__osx`,
+`__win`) match the target platform.
+:::
+
+:::{versionadded} 0.4.0
+`--platform <subdir>` (repeatable) restricts the lock run to a
+subset of declared platforms; unknown platforms raise
+`PlatformError` before any solve runs. `--skip-unsolvable` keeps
+locking the remaining `(environment, platform)` pairs when an
+individual solve fails, aggregating the failures into
+`AllTargetsUnsolvableError` only if *every* pair fails.
+`SolveError` now names the target platform for easier CI triage.
+:::
+
 conda-workspaces generates a `conda.lock` file in YAML format based on
 the rattler-lock v6 specification. The `conda workspace lock` command runs the solver
 and records the solution — it does not require environments to be
@@ -459,6 +494,14 @@ checks entirely and install the lockfile as-is.
 
 ![ci-split demo](../demos/ci-split.gif)
 
+:::{versionadded} 0.4.0
+`conda workspace lock --output <path>` writes the solved lockfile
+to an arbitrary path so matrix runners can each emit one fragment.
+`--merge <glob>` stitches fragments into a single `conda.lock`
+without running the solver, validating schema version, channel
+lists, and rejecting overlapping `(environment, platform)` pairs.
+:::
+
 Solving every platform in one job becomes expensive as a workspace
 grows. `conda workspace lock` supports matrix pipelines that split
 solving across runners and stitch the fragments back together on a
@@ -495,6 +538,17 @@ conda workspace install -f path/to/conda.toml
 ## Export
 
 ![export demo](../demos/export.gif)
+
+:::{versionadded} 0.4.0
+`conda workspace export` plugs into conda's
+`conda_environment_exporters` plugin hook, so every format
+reachable through `conda export` — and anything registered by a
+third-party plugin such as `conda-lockfiles` — is also reachable
+through `conda workspace export`. `--from-lockfile` and
+`--from-prefix` select alternative sources; `--platform`
+(repeatable) drives multi-platform exports for exporters that opt
+into `multiplatform_export`.
+:::
 
 `conda workspace export` converts a workspace environment into any
 format registered through conda's `conda_environment_exporters`
@@ -552,6 +606,14 @@ exporters (`conda-toml`, `pixi-toml`, `pyproject-toml`) do; the
 single-platform yaml / json ones raise a clear error.
 
 ### Manifest-format exporters
+
+:::{versionadded} 0.4.0
+Three new exporter plugins — `conda-toml`, `pixi-toml`, and
+`pyproject-toml` — round-trip a workspace back into any manifest
+dialect conda-workspaces already reads. Combined with
+`conda workspace import`, this makes `conda workspace` a
+bidirectional translator across every supported manifest format.
+:::
 
 The `conda-toml`, `pixi-toml`, and `pyproject-toml` exporters round-trip
 a workspace back into any of the manifest dialects conda-workspaces

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -54,6 +54,12 @@ required — you can start with tasks alone and add workspace features later.
 
 ![workspace-quickstart demo](../demos/workspace-quickstart.gif)
 
+:::{versionadded} 0.4.0
+`conda workspace quickstart` composes `init`, `add`, `install`, and
+`shell` into a single bootstrap command; pass `--no-shell` for CI or
+`--json` for a scriptable summary.
+:::
+
 The fastest path from "empty directory" to "installed environment with
 an activated shell" is `conda workspace quickstart`:
 
@@ -254,6 +260,14 @@ conda workspace shell -e test
 ```
 
 ## Add and remove dependencies
+
+:::{versionchanged} 0.4.0
+`conda workspace add` / `remove` now install into the affected
+environment(s) and refresh `conda.lock` by default (matching
+`pixi add` / `pixi remove`). Use `--no-install` to update the
+manifest and lockfile without touching the prefix, or
+`--no-lockfile-update` for the previous manifest-only behaviour.
+:::
 
 ```bash
 conda workspace add numpy

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -52,15 +52,18 @@ required — you can start with tasks alone and add workspace features later.
 
 ## Your first workspace
 
-![quickstart demo](../demos/quickstart.gif)
+![workspace-quickstart demo](../demos/workspace-quickstart.gif)
 
 The fastest path from "empty directory" to "installed environment with
 an activated shell" is `conda workspace quickstart`:
 
 ```bash
 conda workspace quickstart python=3.14 numpy
-# or:
+# or copy an existing workspace's manifest instead of running init
 conda workspace quickstart --copy ../other-workspace
+# scripted / CI: skip the interactive shell, emit a JSON summary
+conda workspace quickstart --no-shell --name demo "python=3.12" "numpy>=2"
+conda workspace quickstart --json --name demo "python=3.12"
 ```
 
 `quickstart` composes the other commands for you: it runs `init`
@@ -71,11 +74,28 @@ you already know from `init` (`--format`, `--name`, `-c/--channel`,
 `--platform`), `install` (`-e/--environment`, `--force-reinstall`,
 `--locked`, `--frozen`), and conda's shared flags (`--dry-run`,
 `--json`, `--yes`). Use `--no-shell` for CI or scripted runs; `--json`
-implies `--no-shell` and prints a single structured result at the
-end.
+implies `--no-shell`, silences the status banners the nested
+`init` / `add` / `install` handlers would otherwise print, and emits
+a single structured `{workspace, environment, manifest, specs_added,
+shell_spawned}` payload on stdout — safe to pipe into `jq`.
 
-If you prefer a manual setup, add workspace configuration to a
-`conda.toml` yourself:
+### Manual setup
+
+![quickstart demo](../demos/quickstart.gif)
+
+If you prefer to wire the commands together yourself, start from
+`conda workspace init` and incrementally add dependencies — each
+`add` installs into the affected environment and refreshes
+`conda.lock`:
+
+```bash
+conda workspace init --name my-project
+conda workspace add "python>=3.12" "numpy>=2"
+conda workspace add -e test "pytest>=8.0"
+conda workspace envs
+```
+
+Or add workspace configuration to a `conda.toml` by hand:
 
 ::::{tab-set}
 

--- a/docs/tutorials/ci-pipeline.md
+++ b/docs/tutorials/ci-pipeline.md
@@ -88,6 +88,10 @@ jobs:
 
 ![ci-split demo](../../demos/ci-split.gif)
 
+:::{versionadded} 0.4.0
+Requires `--output` and `--merge`, both introduced in 0.4.0.
+:::
+
 `conda workspace lock` can split solving across a matrix and stitch
 the per-platform fragments back into a single `conda.lock` on a
 coordinator job. This keeps lock refreshes fast as the platform

--- a/docs/tutorials/ci-pipeline.md
+++ b/docs/tutorials/ci-pipeline.md
@@ -84,6 +84,92 @@ jobs:
       - run: conda task run -e docs build-docs
 ```
 
+## Matrix-split locking
+
+![ci-split demo](../../demos/ci-split.gif)
+
+`conda workspace lock` can split solving across a matrix and stitch
+the per-platform fragments back into a single `conda.lock` on a
+coordinator job. This keeps lock refreshes fast as the platform
+list grows, and each runner only has to install the solver bits for
+the platforms it owns.
+
+`--output <path>` writes the solved lockfile to an arbitrary
+location so each matrix runner emits exactly one fragment;
+`--merge <glob>` (repeatable) combines fragments without running
+the solver. The merger validates schema-version agreement, each
+environment's channel list, and rejects overlapping `(environment,
+platform)` pairs — the resulting `conda.lock` is byte-stable with
+what a single-run `conda workspace lock` would produce. `--merge`
+is mutually exclusive with `--environment`, `--platform`,
+`--skip-unsolvable`, and `--output`.
+
+```yaml
+# .github/workflows/lock.yml
+name: Refresh conda.lock
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"   # Mondays, 06:00 UTC
+
+jobs:
+  solve:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux-64
+          - os: macos-latest
+            platform: osx-arm64
+          - os: windows-latest
+            platform: win-64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          activate-environment: ""
+      - run: conda install -c conda-forge conda-workspaces
+      - name: Solve ${{ matrix.platform }}
+        run: |
+          conda workspace lock \
+            --platform ${{ matrix.platform }} \
+            --output conda.lock.${{ matrix.platform }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: conda-lock-fragment-${{ matrix.platform }}
+          path: conda.lock.${{ matrix.platform }}
+
+  merge:
+    needs: solve
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          activate-environment: ""
+      - run: conda install -c conda-forge conda-workspaces
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: conda-lock-fragment-*
+          merge-multiple: true
+      - name: Merge fragments into conda.lock
+        run: conda workspace lock --merge "conda.lock.*"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: conda-lock
+          path: conda.lock
+```
+
+The coordinator never runs a solver, so it can stay on the
+lightest runner available. On failure, any fragment that violates
+schema or channel invariants raises `LockfileMergeError` and no
+`conda.lock` is written.
+
 ## Task caching in CI
 
 If your tasks use `inputs`/`outputs` caching, the cache directory can

--- a/docs/tutorials/coming-from/pixi.md
+++ b/docs/tutorials/coming-from/pixi.md
@@ -153,6 +153,21 @@ conda task export --file pixi.toml -o conda.toml
 
 ## Cross-platform solving
 
+:::{versionchanged} 0.4.0
+`conda workspace lock` now writes a single multi-platform
+`conda.lock` covering every platform declared in the manifest,
+matching `pixi lock`.
+:::
+
+:::{versionadded} 0.4.0
+Conservative virtual package baselines are seeded automatically
+for cross-platform solves: `CONDA_OVERRIDE_GLIBC=2.17` for
+`linux-64`, `CONDA_OVERRIDE_OSX=11.0` for `osx-arm64`, `10.15` for
+`osx-64`, and a `CONDA_OVERRIDE_WIN=0` presence marker for `win-*`.
+This mirrors rattler's `VirtualPackages::detect_for_platform`, so
+most cross-compiles resolve without any manifest changes.
+:::
+
 `conda workspace lock` writes a multi-platform `conda.lock` just like
 `pixi lock`. It iterates over every platform listed under
 `[workspace]` / `[project]` and solves each one in isolation, pointing


### PR DESCRIPTION
## Summary

Stacked on #45. Closes the documentation gap for the 0.4.0 milestone by covering the last merged feature (the `--json` contract from #46), embedding all three new demos shipped in #45, and expanding the sections that described the new features only in prose.

- **`CHANGELOG.md`** — adds the missing `Unreleased` entry for #46: side-effect commands (`init`, `activate`, `run`, `shell`) accept `--json` silently via `argparse.SUPPRESS`, `quickstart --json` owns the JSON surface end-to-end by routing nested handlers through a silent Rich console, and `init` suppresses its `Created conda.toml workspace` status under `conda_context.json`.
- **`docs/features.md`** — embeds `ci-split.gif` in the existing `--merge` subsection, embeds `export.gif` at the top of the Export section, and adds a new *Manifest-format exporters* subsection documenting the `conda-toml` / `pixi-toml` / `pyproject-toml` plugins: shared-vs-per-platform projection, the `pyproject.toml` splice behaviour that keeps `[project]` / `[build-system]` / `[tool.ruff]` / `[tool.pixi]` tables untouched, overwrite semantics for `conda.toml` / `pixi.toml`, and the filename-based format inference (linking out to the existing format-aliases reference).
- **`docs/quickstart.md`** — embeds `workspace-quickstart.gif` next to the `conda workspace quickstart` section and shows the `--no-shell` / `--json` variants that the demo exercises. The older `quickstart.gif` moves into a new *Manual setup* subsection that wires `init` + `add` together step by step, so both flows are showable side by side.
- **`docs/tutorials/ci-pipeline.md`** — new *Matrix-split locking* section with the `ci-split.gif` demo and a complete GitHub Actions workflow that solves each platform on a matrix runner (`conda workspace lock --platform X --output conda.lock.X`), uploads per-platform fragments, and stitches them on a coordinator job (`conda workspace lock --merge 'conda.lock.*'`).

The auto-generated CLI reference (`docs/reference/cli.md`) already picks up the new `quickstart` / `lock --merge` / `export --format` surface through the `sphinx-argparse` directives, so no changes are needed there.

## Test plan

- [x] `pixi run -e docs docs` — builds cleanly; all three new demo GIFs (`ci-split.gif`, `export.gif`, `workspace-quickstart.gif`) are copied through Sphinx.
- [x] `pixi run -e docs sphinx-build -W --keep-going` — only residual warnings (`docs/reference/format-aliases.md`, `docs/tutorials/index.md` not in a toctree) pre-date this branch; verified by building the same target off `demos/0.4.0-refresh` without the doc changes.
- [ ] Spot-check the rendered Export, CI-split, and Matrix-split locking sections in the preview build once #45 lands and this PR can retarget `main`.

## Rebase note

This PR is stacked on #45 (`demos/0.4.0-refresh`) because the new sections embed the demo artifacts that PR introduces. Once #45 lands, rebase onto `main`.