### PR TITLE
Cut 0.4.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## Unreleased
 
+## 0.4.0 — 2026-04-29
+
 ### Added
 
 - `conda workspace quickstart` bootstraps a workspace in one step,
@@ -111,6 +113,21 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   the double-prompt / PowerShell `-NoExit` / `$CONDA_ROOT/condabin`
   fixes. The integration in `cli/workspace/shell.py` is unchanged
   (`conda_spawn.main.spawn` is still the entry point).
+- `conda task run <task>` (and the `ct run` alias) now falls back to
+  the workspace's `default` environment when the task doesn't declare
+  a `default_environment`, instead of inheriting whichever conda env
+  happened to be active at the call site. Pass `-e` explicitly to
+  override.
+
+### Fixed
+
+- `conda workspace quickstart` crashed every invocation with
+  `AttributeError: 'Namespace' object has no attribute 'verbose'`
+  after conda renamed the namespace dest to `verbosity`.
+- `conda workspace quickstart --json` no longer leaks Rich status
+  lines from the sub-handlers (`init`, `add`, `install`) into stdout;
+  the JSON payload is the only thing emitted on stdout, matching the
+  documented `--json contract`.
 
 ## 0.3.0 — 2026-03-31
 


### PR DESCRIPTION
## Summary

Promote the curated `Unreleased` section to `## 0.4.0 — 2026-04-29` and seed a fresh empty `## Unreleased` placeholder above it. The bulk of the entry was already tightened in #48; this PR just locks in the date and surfaces two user-visible items that slipped through:

- **Changed**: `ct run <task>` now falls back to the workspace's `default` environment when the task doesn't declare `default_environment`, rather than inheriting whichever conda env happened to be active at the call site (#27). Pass `-e` explicitly to override.
- **Fixed** (new subsection, both from #46): the `quickstart` `verbose → verbosity` `AttributeError` crash, and the `quickstart --json` Rich-status-lines-on-stdout leak.

## Scope check

Cross-referenced `git log --merges 0.3.0..main` (23 PRs, 103 commits since `0.3.0`) against the curated section. The only PRs not represented in the changelog are infrastructure-only (`#17` add-dependabot, `#18`/`#25` dependabot bumps, `#19` CI/demo/gitignore polish, `#40`/`#42`/`#43`/`#48` `AGENTS.md` and changelog meta-edits, `#47` docs-only `0.4.0` annotations).

## Notes for the release

- Update the `0.4.0` date if we don't tag today (matching the `conda-spawn 0.1.0` pattern).
- Cutting the release: tag `0.4.0` on `main` and publish a GitHub Release; the existing PyPI workflow handles the upload via `release: published`. The conda-forge feedstock bot will pick it up after.
- The `Unreleased` heading right above `0.4.0` is intentional — Keep a Changelog convention and consistent with the rest of the file. `links/compare` references aren't used in this changelog.

## Test plan

- [x] Skim the rendered diff and confirm the section ordering is `Unreleased` → `0.4.0 — 2026-04-29` → `0.3.0 — 2026-03-31`.
- [x] Confirm every PR merged since `0.3.0` either appears in the entry or is justifiably skipped (see "Scope check").
- [x] Confirm date once we know the tag day.