### PR TITLE
Security hardening and manifest discovery performance

### DIFF
--- a/conda_workspaces/context.py
+++ b/conda_workspaces/context.py
@@ -269,5 +269,8 @@ def build_template_context(
     ctx = CondaContext(manifest_path=manifest_path)
     result: dict[str, object] = {"conda": ctx, "pixi": ctx}
     if task_args:
-        result.update(task_args)
+        reserved = {"conda", "pixi"}
+        for key, value in task_args.items():
+            if key not in reserved:
+                result[key] = value
     return result

--- a/conda_workspaces/manifests/__init__.py
+++ b/conda_workspaces/manifests/__init__.py
@@ -40,6 +40,10 @@ _SEARCH_FILES: list[str] = [
     "pyproject.toml",
 ]
 
+PARSER_BY_FILENAME: dict[str, ManifestParser] = {
+    fname: parser for parser in _PARSERS for fname in parser.filenames
+}
+
 
 def _walk_manifests(
     start_dir: Path,
@@ -56,11 +60,9 @@ def _walk_manifests(
         for fname in _SEARCH_FILES:
             candidate = current / fname
             if candidate.is_file():
-                for parser in _PARSERS:
-                    if parser.can_handle(candidate) and getattr(parser, predicate)(
-                        candidate
-                    ):
-                        return candidate
+                parser = PARSER_BY_FILENAME.get(fname)
+                if parser is not None and getattr(parser, predicate)(candidate):
+                    return candidate
         parent = current.parent
         if parent == current:
             break

--- a/conda_workspaces/manifests/base.py
+++ b/conda_workspaces/manifests/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 import shutil
 from abc import ABC, abstractmethod
+from functools import lru_cache
 from typing import TYPE_CHECKING
 
 import tomlkit
@@ -50,6 +51,17 @@ class ManifestParser(ABC):
     #: Optional user-friendly aliases for the exporter plugin (e.g.
     #: ``("conda",)`` for ``conda-toml``).  Empty tuple is fine.
     exporter_aliases: ClassVar[tuple[str, ...]] = ()
+
+    @staticmethod
+    @lru_cache(maxsize=16)
+    def read_toml(path_str: str) -> dict:
+        """Read and parse a TOML file, returning empty dict on failure."""
+        from pathlib import Path
+
+        try:
+            return tomlkit.loads(Path(path_str).read_text(encoding="utf-8"))
+        except Exception:
+            return {}
 
     @property
     def manifest_filename(self) -> str:

--- a/conda_workspaces/manifests/pixi_toml.py
+++ b/conda_workspaces/manifests/pixi_toml.py
@@ -34,12 +34,7 @@ class PixiTomlParser(ManifestParser):
         return path.name in self.filenames
 
     def has_workspace(self, path: Path) -> bool:
-        if not path.exists():
-            return False
-        try:
-            data = tomlkit.loads(path.read_text(encoding="utf-8"))
-        except Exception:
-            return False
+        data = self.read_toml(str(path))
         return "workspace" in data or "project" in data
 
     def parse(self, path: Path) -> WorkspaceConfig:
@@ -77,13 +72,7 @@ class PixiTomlParser(ManifestParser):
         return config
 
     def has_tasks(self, path: Path) -> bool:
-        if not path.exists():
-            return False
-        try:
-            data = tomlkit.loads(path.read_text(encoding="utf-8"))
-        except Exception:
-            return False
-        return bool(data.get("tasks"))
+        return bool(self.read_toml(str(path)).get("tasks"))
 
     def parse_tasks(self, path: Path) -> dict[str, Task]:
         try:

--- a/conda_workspaces/manifests/pyproject_toml.py
+++ b/conda_workspaces/manifests/pyproject_toml.py
@@ -142,16 +142,11 @@ class PyprojectTomlParser(ManifestParser):
         return tomlkit.dumps(doc)
 
     def has_workspace(self, path: Path) -> bool:
-        if not path.exists():
-            return False
-        try:
-            data = tomlkit.loads(path.read_text(encoding="utf-8"))
-        except Exception:
-            return False
-        tool = data.get("tool", {})
-        conda = tool.get("conda", {})
-        pixi = tool.get("pixi", {})
-        return bool(conda.get("workspace") or pixi.get("workspace"))
+        tool = self.read_toml(str(path)).get("tool", {})
+        return bool(
+            tool.get("conda", {}).get("workspace")
+            or tool.get("pixi", {}).get("workspace")
+        )
 
     def parse(self, path: Path) -> WorkspaceConfig:
         try:
@@ -196,13 +191,7 @@ class PyprojectTomlParser(ManifestParser):
         return config
 
     def has_tasks(self, path: Path) -> bool:
-        if not path.exists():
-            return False
-        try:
-            data = tomlkit.loads(path.read_text(encoding="utf-8")).unwrap()
-        except Exception:
-            return False
-        tool = data.get("tool", {})
+        tool = self.read_toml(str(path)).get("tool", {})
         return bool(
             tool.get("conda", {}).get("tasks") or tool.get("pixi", {}).get("tasks")
         )

--- a/conda_workspaces/manifests/toml.py
+++ b/conda_workspaces/manifests/toml.py
@@ -52,13 +52,7 @@ class CondaTomlParser(ManifestParser):
         return path.name in self.filenames
 
     def has_workspace(self, path: Path) -> bool:
-        if not path.exists():
-            return False
-        try:
-            data = tomlkit.loads(path.read_text(encoding="utf-8"))
-        except Exception:
-            return False
-        return "workspace" in data
+        return "workspace" in self.read_toml(str(path))
 
     def parse(self, path: Path) -> WorkspaceConfig:
         # Import inline to avoid circular dependency (pixi_toml imports toml).
@@ -75,13 +69,7 @@ class CondaTomlParser(ManifestParser):
         return config
 
     def has_tasks(self, path: Path) -> bool:
-        if not path.exists():
-            return False
-        try:
-            data = tomlkit.loads(path.read_text(encoding="utf-8"))
-        except Exception:
-            return False
-        return bool(data.get("tasks"))
+        return bool(self.read_toml(str(path)).get("tasks"))
 
     def parse_tasks(self, path: Path) -> dict[str, Task]:
         try:

--- a/conda_workspaces/template.py
+++ b/conda_workspaces/template.py
@@ -15,10 +15,11 @@ if TYPE_CHECKING:
 
 @lru_cache(maxsize=1)
 def _get_jinja_env() -> JinjaEnvironment:
-    """Create and cache a Jinja2 Environment (singleton)."""
-    from jinja2 import Environment, StrictUndefined
+    """Create and cache a sandboxed Jinja2 Environment (singleton)."""
+    from jinja2 import StrictUndefined
+    from jinja2.sandbox import SandboxedEnvironment
 
-    return Environment(undefined=StrictUndefined)
+    return SandboxedEnvironment(undefined=StrictUndefined)
 
 
 def render(


### PR DESCRIPTION
## Summary

- Switch Jinja2 template engine from `Environment` to `SandboxedEnvironment` to prevent template injection attacks via malicious task definitions (blocks attribute traversal exploits like `__class__.__mro__`).
- Prevent task argument names from shadowing the reserved `conda`/`pixi` context keys in template rendering.
- Cache TOML file reads via `ManifestParser.read_toml()` (`@lru_cache`) so `has_workspace`/`has_tasks` don't re-parse the same file on repeated calls within a single CLI invocation.
- Use O(1) filename→parser lookup (`PARSER_BY_FILENAME`) in `walk_manifests` instead of iterating all parsers for each candidate file.

## Test plan

- [x] Existing template tests pass (rendering, strict undefined, context variables)
- [x] Manifest detection tests pass (workspace and task file discovery)
- [x] Integration tests pass (task run with templates, caching)
- [x] Verify `SandboxedEnvironment` blocks `{{ ''.__class__.__mro__[1].__subclasses__() }}` style attacks
- [x] All 218 tests pass, ruff check/format clean