### PR TITLE
Add conda workspace archive/unarchive with --lock, --bundle, and --install

### DIFF
--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import fnmatch
+import hashlib
 import io
+import shutil
 import subprocess
 import tarfile
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from .exceptions import ArchiveError, ArchiveHashMismatchError, ArchivePathTraversalError
 
 if TYPE_CHECKING:
     from .models import ArchiveConfig
@@ -168,8 +172,6 @@ def _write_tar_zst(
 # Task 5: safe extraction with path traversal protection
 # ---------------------------------------------------------------------------
 
-from .exceptions import ArchivePathTraversalError
-
 
 def _validate_tar_member(member: tarfile.TarInfo, target: Path) -> None:
     member_path = Path(member.name)
@@ -220,3 +222,84 @@ def extract_archive(archive_path: Path, target: Path) -> Path:
         tf.extractall(path=target, filter="data")
 
     return target
+
+
+# ---------------------------------------------------------------------------
+# Task 6: package bundling and hash verification
+# ---------------------------------------------------------------------------
+
+
+def _parse_lockfile_packages(lockfile_path: Path) -> list[dict]:
+    from conda_lockfiles.load_yaml import load_yaml
+
+    data = load_yaml(lockfile_path)
+    return data.get("packages", []) or []
+
+
+def _url_to_filename(url: str) -> str:
+    return url.rsplit("/", 1)[-1]
+
+
+def collect_bundle_packages(
+    lockfile_path: Path,
+    cache_dirs: list[Path],
+) -> list[Path]:
+    packages_data = _parse_lockfile_packages(lockfile_path)
+    result: list[Path] = []
+    seen: set[str] = set()
+
+    for pkg in packages_data:
+        url = pkg.get("conda") or pkg.get("url", "")
+        if not url:
+            continue
+        filename = _url_to_filename(url)
+        if filename in seen:
+            continue
+        seen.add(filename)
+
+        found = False
+        for cache_dir in cache_dirs:
+            candidate = cache_dir / filename
+            if candidate.is_file():
+                result.append(candidate)
+                found = True
+                break
+
+        if not found:
+            raise ArchiveError(
+                f"Package '{filename}' not found in cache.",
+                hints=[
+                    "Run 'conda workspace install' to populate the package cache,",
+                    "then retry the archive command.",
+                ],
+            )
+
+    return sorted(result, key=lambda p: p.name)
+
+
+def _build_hash_index(lockfile_path: Path) -> dict[str, str]:
+    packages_data = _parse_lockfile_packages(lockfile_path)
+    index: dict[str, str] = {}
+    for pkg in packages_data:
+        url = pkg.get("conda") or pkg.get("url", "")
+        sha256 = pkg.get("sha256", "")
+        if url and sha256:
+            index[_url_to_filename(url)] = sha256
+    return index
+
+
+def verify_package_hashes(
+    packages: list[Path],
+    lockfile_path: Path,
+) -> None:
+    expected = _build_hash_index(lockfile_path)
+
+    for pkg_path in packages:
+        exp_hash = expected.get(pkg_path.name)
+        if not exp_hash:
+            continue
+        actual_hash = hashlib.sha256(pkg_path.read_bytes()).hexdigest()
+        if actual_hash != exp_hash:
+            raise ArchiveHashMismatchError(
+                pkg_path.name, expected=exp_hash, actual=actual_hash
+            )

--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -334,3 +334,23 @@ def prime_package_cache(
             count += 1
 
     return count
+
+
+# ---------------------------------------------------------------------------
+# Task 8: archive inspection helper
+# ---------------------------------------------------------------------------
+
+
+def inspect_archive(archive_path: Path) -> dict[str, object]:
+    with _open_tar(archive_path) as tf:
+        names = set(tf.getnames())
+
+    package_members = [n for n in names if n.startswith("packages/") and n.endswith(".conda")]
+
+    return {
+        "has_manifest": "conda.toml" in names,
+        "has_lockfile": "conda.lock" in names,
+        "has_attestation": "conda.lock.sigstore" in names,
+        "has_packages": len(package_members) > 0,
+        "package_count": len(package_members),
+    }

--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -115,6 +115,10 @@ def collect_archive_files(
         rel = path.relative_to(root).as_posix()
         if is_excluded_by_builtins(rel):
             continue
+        if archive_config.include and not is_included_by_patterns(
+            rel, archive_config.include
+        ):
+            continue
         if is_excluded_by_patterns(rel, archive_config.exclude):
             continue
         result.append(path)
@@ -131,7 +135,31 @@ def detect_compression(output: Path) -> str:
         return "gz"
     if name.endswith(".tar.bz2"):
         return "bz2"
-    return "gz"
+    return "zst"
+
+
+def is_included_by_patterns(rel_path: str, patterns: tuple[str, ...]) -> bool:
+    """Return True if *rel_path* matches any include pattern."""
+    for pattern in patterns:
+        if fnmatch.fnmatch(rel_path, pattern):
+            return True
+        parts = rel_path.split("/")
+        for i in range(len(parts)):
+            partial = "/".join(parts[: i + 1])
+            if fnmatch.fnmatch(partial, pattern):
+                return True
+    return False
+
+
+def _open_tar_for_write(
+    output: Path, mode: str, compression_level: int | None
+) -> tarfile.TarFile:
+    """Open a tar archive for writing, optionally setting compression level."""
+    if compression_level is not None:
+        return tarfile.open(  # type: ignore[call-overload]
+            output, mode, compresslevel=compression_level
+        )
+    return tarfile.open(output, mode)  # type: ignore[call-overload]
 
 
 def create_archive(
@@ -156,7 +184,7 @@ def create_archive(
     compression = detect_compression(output)
     mode = f"w:{compression}"
 
-    with tarfile.open(output, mode) as tf:
+    with _open_tar_for_write(output, mode, archive_config.compression_level) as tf:
         add_files_to_tar(tf, root, files)
         if bundle_packages:
             add_packages_to_tar(tf, bundle_packages)

--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import fnmatch
 import hashlib
+import logging
 import shutil
 import subprocess
 import sys
@@ -32,6 +33,8 @@ except ImportError:
 if TYPE_CHECKING:
     from .models import ArchiveConfig
 
+log = logging.getLogger(__name__)
+
 ARCHIVE_SUFFIXES: tuple[str, ...] = (
     ".tar.zst",
     ".tar.zstd",
@@ -41,7 +44,12 @@ ARCHIVE_SUFFIXES: tuple[str, ...] = (
 )
 """Recognised archive filename suffixes, longest first."""
 
-_MANIFEST_FILENAMES = {"conda.toml", "pixi.toml", "pyproject.toml"}
+MANIFEST_FILENAMES = {"conda.toml", "pixi.toml", "pyproject.toml"}
+
+ALLOWED_TAR_TYPES: frozenset[bytes] = frozenset(
+    {tarfile.REGTYPE, tarfile.AREGTYPE, tarfile.DIRTYPE,
+     tarfile.SYMTYPE, tarfile.LNKTYPE}
+)
 """Filenames recognised as workspace manifests inside an archive."""
 
 BUILTIN_EXCLUDE_DIRS: frozenset[str] = frozenset(
@@ -163,7 +171,7 @@ def is_included_by_patterns(rel_path: str, patterns: tuple[str, ...]) -> bool:
     return False
 
 
-def _open_tar_for_write(
+def open_tar_for_write(
     output: Path, mode: str, compression_level: int | None
 ) -> tarfile.TarFile:
     """Open a tar archive for writing, optionally setting compression level."""
@@ -196,7 +204,7 @@ def create_archive(
     compression = detect_compression(output)
     mode = f"w:{compression}"
 
-    with _open_tar_for_write(output, mode, archive_config.compression_level) as tf:
+    with open_tar_for_write(output, mode, archive_config.compression_level) as tf:
         add_files_to_tar(tf, root, files)
         if bundle_packages:
             add_packages_to_tar(tf, bundle_packages)
@@ -221,8 +229,12 @@ def add_packages_to_tar(tf: tarfile.TarFile, packages: list[Path]) -> None:
 def validate_tar_member(member: tarfile.TarInfo, target: Path) -> None:
     """Raise :class:`ArchivePathTraversalError` if *member* escapes *target*.
 
-    Checks absolute paths, ``..`` components, and symlink targets.
+    Checks for disallowed file types (device nodes, FIFOs, etc.),
+    absolute paths, ``..`` components, and symlink targets.
     """
+    if member.type not in ALLOWED_TAR_TYPES:
+        raise ArchivePathTraversalError(member.name)
+
     member_path = Path(member.name)
 
     if member_path.is_absolute():
@@ -264,12 +276,13 @@ def extract_archive(archive_path: Path, target: Path) -> Path:
     target.mkdir(parents=True, exist_ok=True)
 
     with open_tar(archive_path) as tf:
-        for member in tf.getmembers():
+        members = tf.getmembers()
+        for member in members:
             validate_tar_member(member, target)
         if sys.version_info >= (3, 12):
-            tf.extractall(path=target, filter="data")
+            tf.extractall(path=target, members=members, filter="data")
         else:
-            tf.extractall(path=target)
+            tf.extractall(path=target, members=members)
 
     return target
 
@@ -351,6 +364,10 @@ def verify_package_hashes(
     for pkg_path in packages:
         exp_hash = expected.get(pkg_path.name)
         if not exp_hash:
+            log.warning(
+                "No SHA256 hash in lockfile for %s, skipping verification",
+                pkg_path.name,
+            )
             continue
         actual_hash = hashlib.sha256(pkg_path.read_bytes()).hexdigest()
         if actual_hash != exp_hash:
@@ -384,7 +401,7 @@ def prime_package_cache(
     for pkg in packages:
         dest = cache_dir / pkg.name
         if not dest.exists():
-            shutil.copy2(pkg, dest)
+            shutil.copy(pkg, dest)
             count += 1
 
     return count
@@ -400,7 +417,7 @@ def inspect_archive(archive_path: Path) -> dict[str, object]:
     ]
 
     return {
-        "has_manifest": bool(names & _MANIFEST_FILENAMES),
+        "has_manifest": bool(names & MANIFEST_FILENAMES),
         "has_lockfile": "conda.lock" in names,
         "has_packages": len(package_members) > 0,
         "package_count": len(package_members),

--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import fnmatch
 import hashlib
-import io
 import shutil
 import subprocess
 import sys
@@ -25,6 +24,11 @@ from .exceptions import (
     ArchivePathTraversalError,
 )
 
+try:
+    import backports.zstd  # noqa: F401 -- registers zstd codec with tarfile
+except ImportError:
+    pass  # Python 3.14+ has native support
+
 if TYPE_CHECKING:
     from .models import ArchiveConfig
 
@@ -37,9 +41,6 @@ BUILTIN_EXCLUDE_DIRS: frozenset[str] = frozenset(
     }
 )
 """Directories excluded from archives regardless of user configuration."""
-
-ZSTD_COMPRESSION_LEVEL = 19
-"""Zstandard compression level for archive creation (1=fastest, 22=smallest)."""
 
 
 def is_git_repo(root: Path) -> bool:
@@ -153,15 +154,12 @@ def create_archive(
     files = [f for f in files if f.resolve() != output]
 
     compression = detect_compression(output)
+    mode = f"w:{compression}"
 
-    if compression == "zst":
-        write_tar_zst(root, output, files, bundle_packages)
-    else:
-        mode = f"w:{compression}"
-        with tarfile.open(output, mode) as tf:
-            add_files_to_tar(tf, root, files)
-            if bundle_packages:
-                add_packages_to_tar(tf, bundle_packages)
+    with tarfile.open(output, mode) as tf:
+        add_files_to_tar(tf, root, files)
+        if bundle_packages:
+            add_packages_to_tar(tf, bundle_packages)
 
     return output
 
@@ -178,26 +176,6 @@ def add_packages_to_tar(tf: tarfile.TarFile, packages: list[Path]) -> None:
     for pkg in packages:
         arcname = f"packages/{pkg.name}"
         tf.add(str(pkg), arcname=arcname)
-
-
-def write_tar_zst(
-    root: Path,
-    output: Path,
-    files: list[Path],
-    bundle_packages: list[Path] | None,
-) -> None:
-    """Write a zstandard-compressed tar archive to *output*."""
-    import zstandard
-
-    buf = io.BytesIO()
-    with tarfile.open(fileobj=buf, mode="w:") as tf:
-        add_files_to_tar(tf, root, files)
-        if bundle_packages:
-            add_packages_to_tar(tf, bundle_packages)
-
-    cctx = zstandard.ZstdCompressor(level=ZSTD_COMPRESSION_LEVEL)
-    compressed = cctx.compress(buf.getvalue())
-    output.write_bytes(compressed)
 
 
 def validate_tar_member(member: tarfile.TarInfo, target: Path) -> None:
@@ -233,15 +211,7 @@ def validate_tar_member(member: tarfile.TarInfo, target: Path) -> None:
 def open_tar(archive_path: Path) -> tarfile.TarFile:
     """Open a tar archive, handling zstandard decompression transparently."""
     compression = detect_compression(archive_path)
-    if compression == "zst":
-        import zstandard
-
-        with open(archive_path, "rb") as fh:
-            dctx = zstandard.ZstdDecompressor()
-            decompressed = dctx.decompress(fh.read())
-        return tarfile.open(fileobj=io.BytesIO(decompressed), mode="r:")
-    else:
-        return tarfile.open(archive_path, f"r:{compression}")
+    return tarfile.open(archive_path, f"r:{compression}")
 
 
 def extract_archive(archive_path: Path, target: Path) -> Path:

--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import fnmatch
+import io
 import subprocess
+import tarfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -86,3 +88,77 @@ def collect_archive_files(
         result.append(path)
 
     return sorted(result)
+
+
+# ---------------------------------------------------------------------------
+# Task 4: tarball creation
+# ---------------------------------------------------------------------------
+
+
+def _detect_compression(output: Path) -> str:
+    name = output.name
+    if name.endswith(".tar.zst") or name.endswith(".tar.zstd"):
+        return "zst"
+    if name.endswith(".tar.gz") or name.endswith(".tgz"):
+        return "gz"
+    if name.endswith(".tar.bz2"):
+        return "bz2"
+    return "gz"
+
+
+def create_archive(
+    root: Path,
+    output: Path,
+    archive_config: ArchiveConfig,
+    *,
+    bundle_packages: list[Path] | None = None,
+) -> Path:
+    output = output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    files = collect_archive_files(root, archive_config)
+    files = [f for f in files if f.resolve() != output]
+
+    compression = _detect_compression(output)
+
+    if compression == "zst":
+        _write_tar_zst(root, output, files, bundle_packages)
+    else:
+        mode = f"w:{compression}"
+        with tarfile.open(output, mode) as tf:
+            _add_files_to_tar(tf, root, files)
+            if bundle_packages:
+                _add_packages_to_tar(tf, bundle_packages)
+
+    return output
+
+
+def _add_files_to_tar(tf: tarfile.TarFile, root: Path, files: list[Path]) -> None:
+    for path in files:
+        arcname = str(path.relative_to(root))
+        tf.add(str(path), arcname=arcname)
+
+
+def _add_packages_to_tar(tf: tarfile.TarFile, packages: list[Path]) -> None:
+    for pkg in packages:
+        arcname = f"packages/{pkg.name}"
+        tf.add(str(pkg), arcname=arcname)
+
+
+def _write_tar_zst(
+    root: Path,
+    output: Path,
+    files: list[Path],
+    bundle_packages: list[Path] | None,
+) -> None:
+    import zstandard
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:") as tf:
+        _add_files_to_tar(tf, root, files)
+        if bundle_packages:
+            _add_packages_to_tar(tf, bundle_packages)
+
+    cctx = zstandard.ZstdCompressor(level=3)
+    compressed = cctx.compress(buf.getvalue())
+    output.write_bytes(compressed)

--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -1,4 +1,9 @@
-"""Archive creation and extraction for conda workspaces."""
+"""Archive creation and extraction for conda workspaces.
+
+Provides functions for collecting workspace files, creating tar archives
+(gzip or zstandard), extracting with path traversal protection, bundling
+conda packages for offline use, and inspecting archive contents.
+"""
 
 from __future__ import annotations
 
@@ -11,20 +16,31 @@ import tarfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from .exceptions import ArchiveError, ArchiveHashMismatchError, ArchivePathTraversalError
+from .exceptions import (
+    ArchiveError,
+    ArchiveHashMismatchError,
+    ArchivePathTraversalError,
+)
 
 if TYPE_CHECKING:
     from .models import ArchiveConfig
 
-BUILTIN_EXCLUDE_DIRS: frozenset[str] = frozenset({
-    ".git",
-    ".conda/envs",
-    ".pixi",
-    "__pycache__",
-})
+BUILTIN_EXCLUDE_DIRS: frozenset[str] = frozenset(
+    {
+        ".git",
+        ".conda/envs",
+        ".pixi",
+        "__pycache__",
+    }
+)
+"""Directories excluded from archives regardless of user configuration."""
+
+ZSTD_COMPRESSION_LEVEL = 19
+"""Zstandard compression level for archive creation (1=fastest, 22=smallest)."""
 
 
-def _is_git_repo(root: Path) -> bool:
+def is_git_repo(root: Path) -> bool:
+    """Return True if *root* is inside a git working tree."""
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--is-inside-work-tree"],
@@ -37,7 +53,8 @@ def _is_git_repo(root: Path) -> bool:
         return False
 
 
-def _git_tracked_files(root: Path) -> list[Path]:
+def git_tracked_files(root: Path) -> list[Path]:
+    """Return absolute paths for all git-tracked files under *root*."""
     result = subprocess.run(
         ["git", "ls-files", "-z"],
         cwd=root,
@@ -54,14 +71,16 @@ def _git_tracked_files(root: Path) -> list[Path]:
     return paths
 
 
-def _is_excluded_by_builtins(rel_path: str) -> bool:
+def is_excluded_by_builtins(rel_path: str) -> bool:
+    """Return True if *rel_path* falls under a builtin-excluded directory."""
     for excl in BUILTIN_EXCLUDE_DIRS:
         if rel_path == excl or rel_path.startswith(excl + "/"):
             return True
     return False
 
 
-def _is_excluded_by_patterns(rel_path: str, patterns: tuple[str, ...]) -> bool:
+def is_excluded_by_patterns(rel_path: str, patterns: tuple[str, ...]) -> bool:
+    """Return True if *rel_path* matches any of the user-supplied glob *patterns*."""
     for pattern in patterns:
         if fnmatch.fnmatch(rel_path, pattern):
             return True
@@ -77,29 +96,30 @@ def collect_archive_files(
     root: Path,
     archive_config: ArchiveConfig,
 ) -> list[Path]:
-    if _is_git_repo(root):
-        candidates = _git_tracked_files(root)
+    """Collect workspace files eligible for archiving.
+
+    In git repos, only tracked files are included. Otherwise all files
+    under *root* are considered, filtered by builtin and user excludes.
+    """
+    if is_git_repo(root):
+        candidates = git_tracked_files(root)
     else:
         candidates = [p for p in root.rglob("*") if p.is_file()]
 
     result: list[Path] = []
     for path in candidates:
         rel = str(path.relative_to(root))
-        if _is_excluded_by_builtins(rel):
+        if is_excluded_by_builtins(rel):
             continue
-        if _is_excluded_by_patterns(rel, archive_config.exclude):
+        if is_excluded_by_patterns(rel, archive_config.exclude):
             continue
         result.append(path)
 
     return sorted(result)
 
 
-# ---------------------------------------------------------------------------
-# Task 4: tarball creation
-# ---------------------------------------------------------------------------
-
-
-def _detect_compression(output: Path) -> str:
+def detect_compression(output: Path) -> str:
+    """Infer compression format from the archive filename extension."""
     name = output.name
     if name.endswith(".tar.zst") or name.endswith(".tar.zstd"):
         return "zst"
@@ -117,63 +137,71 @@ def create_archive(
     *,
     bundle_packages: list[Path] | None = None,
 ) -> Path:
+    """Create a tar archive of the workspace at *root*.
+
+    Writes to *output*, creating parent directories as needed.
+    If *bundle_packages* is provided, the listed ``.conda`` files
+    are added under a ``packages/`` prefix inside the archive.
+    """
     output = output.resolve()
     output.parent.mkdir(parents=True, exist_ok=True)
 
     files = collect_archive_files(root, archive_config)
     files = [f for f in files if f.resolve() != output]
 
-    compression = _detect_compression(output)
+    compression = detect_compression(output)
 
     if compression == "zst":
-        _write_tar_zst(root, output, files, bundle_packages)
+        write_tar_zst(root, output, files, bundle_packages)
     else:
         mode = f"w:{compression}"
         with tarfile.open(output, mode) as tf:
-            _add_files_to_tar(tf, root, files)
+            add_files_to_tar(tf, root, files)
             if bundle_packages:
-                _add_packages_to_tar(tf, bundle_packages)
+                add_packages_to_tar(tf, bundle_packages)
 
     return output
 
 
-def _add_files_to_tar(tf: tarfile.TarFile, root: Path, files: list[Path]) -> None:
+def add_files_to_tar(tf: tarfile.TarFile, root: Path, files: list[Path]) -> None:
+    """Add workspace *files* to the tar, using paths relative to *root*."""
     for path in files:
         arcname = str(path.relative_to(root))
         tf.add(str(path), arcname=arcname)
 
 
-def _add_packages_to_tar(tf: tarfile.TarFile, packages: list[Path]) -> None:
+def add_packages_to_tar(tf: tarfile.TarFile, packages: list[Path]) -> None:
+    """Add ``.conda`` *packages* under the ``packages/`` archive prefix."""
     for pkg in packages:
         arcname = f"packages/{pkg.name}"
         tf.add(str(pkg), arcname=arcname)
 
 
-def _write_tar_zst(
+def write_tar_zst(
     root: Path,
     output: Path,
     files: list[Path],
     bundle_packages: list[Path] | None,
 ) -> None:
+    """Write a zstandard-compressed tar archive to *output*."""
     import zstandard
 
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:") as tf:
-        _add_files_to_tar(tf, root, files)
+        add_files_to_tar(tf, root, files)
         if bundle_packages:
-            _add_packages_to_tar(tf, bundle_packages)
+            add_packages_to_tar(tf, bundle_packages)
 
-    cctx = zstandard.ZstdCompressor(level=3)
+    cctx = zstandard.ZstdCompressor(level=ZSTD_COMPRESSION_LEVEL)
     compressed = cctx.compress(buf.getvalue())
     output.write_bytes(compressed)
 
 
-# ---------------------------------------------------------------------------
-# Task 5: safe extraction with path traversal protection
-# ---------------------------------------------------------------------------
+def validate_tar_member(member: tarfile.TarInfo, target: Path) -> None:
+    """Raise :class:`ArchivePathTraversalError` if *member* escapes *target*.
 
-
-def _validate_tar_member(member: tarfile.TarInfo, target: Path) -> None:
+    Checks absolute paths, ``..`` components, and symlink targets.
+    """
     member_path = Path(member.name)
 
     if member_path.is_absolute():
@@ -199,8 +227,9 @@ def _validate_tar_member(member: tarfile.TarInfo, target: Path) -> None:
             raise ArchivePathTraversalError(member.name)
 
 
-def _open_tar(archive_path: Path) -> tarfile.TarFile:
-    compression = _detect_compression(archive_path)
+def open_tar(archive_path: Path) -> tarfile.TarFile:
+    """Open a tar archive, handling zstandard decompression transparently."""
+    compression = detect_compression(archive_path)
     if compression == "zst":
         import zstandard
 
@@ -213,30 +242,32 @@ def _open_tar(archive_path: Path) -> tarfile.TarFile:
 
 
 def extract_archive(archive_path: Path, target: Path) -> Path:
+    """Extract *archive_path* into *target* with path traversal protection.
+
+    Every member is validated before extraction. Uses Python 3.12+
+    ``filter="data"`` for defense-in-depth.
+    """
     target = target.resolve()
     target.mkdir(parents=True, exist_ok=True)
 
-    with _open_tar(archive_path) as tf:
+    with open_tar(archive_path) as tf:
         for member in tf.getmembers():
-            _validate_tar_member(member, target)
+            validate_tar_member(member, target)
         tf.extractall(path=target, filter="data")
 
     return target
 
 
-# ---------------------------------------------------------------------------
-# Task 6: package bundling and hash verification
-# ---------------------------------------------------------------------------
-
-
-def _parse_lockfile_packages(lockfile_path: Path) -> list[dict]:
+def parse_lockfile_packages(lockfile_path: Path) -> list[dict]:
+    """Parse the ``packages`` list from a conda lockfile."""
     from conda_lockfiles.load_yaml import load_yaml
 
     data = load_yaml(lockfile_path)
     return data.get("packages", []) or []
 
 
-def _url_to_filename(url: str) -> str:
+def url_to_filename(url: str) -> str:
+    """Extract the filename from a conda package URL."""
     return url.rsplit("/", 1)[-1]
 
 
@@ -244,7 +275,11 @@ def collect_bundle_packages(
     lockfile_path: Path,
     cache_dirs: list[Path],
 ) -> list[Path]:
-    packages_data = _parse_lockfile_packages(lockfile_path)
+    """Locate ``.conda`` packages referenced by the lockfile in local caches.
+
+    Raises :class:`ArchiveError` if any package is missing from all caches.
+    """
+    packages_data = parse_lockfile_packages(lockfile_path)
     result: list[Path] = []
     seen: set[str] = set()
 
@@ -252,7 +287,7 @@ def collect_bundle_packages(
         url = pkg.get("conda") or pkg.get("url", "")
         if not url:
             continue
-        filename = _url_to_filename(url)
+        filename = url_to_filename(url)
         if filename in seen:
             continue
         seen.add(filename)
@@ -277,14 +312,15 @@ def collect_bundle_packages(
     return sorted(result, key=lambda p: p.name)
 
 
-def _build_hash_index(lockfile_path: Path) -> dict[str, str]:
-    packages_data = _parse_lockfile_packages(lockfile_path)
+def build_hash_index(lockfile_path: Path) -> dict[str, str]:
+    """Build a filename-to-SHA256 mapping from lockfile package entries."""
+    packages_data = parse_lockfile_packages(lockfile_path)
     index: dict[str, str] = {}
     for pkg in packages_data:
         url = pkg.get("conda") or pkg.get("url", "")
         sha256 = pkg.get("sha256")
         if url and sha256 is not None:
-            index[_url_to_filename(url)] = str(sha256)
+            index[url_to_filename(url)] = str(sha256)
     return index
 
 
@@ -292,7 +328,11 @@ def verify_package_hashes(
     packages: list[Path],
     lockfile_path: Path,
 ) -> None:
-    expected = _build_hash_index(lockfile_path)
+    """Verify SHA256 hashes of *packages* against the lockfile.
+
+    Raises :class:`ArchiveHashMismatchError` on the first mismatch.
+    """
+    expected = build_hash_index(lockfile_path)
 
     for pkg_path in packages:
         exp_hash = expected.get(pkg_path.name)
@@ -305,15 +345,15 @@ def verify_package_hashes(
             )
 
 
-# ---------------------------------------------------------------------------
-# Task 7: unarchive with cache priming
-# ---------------------------------------------------------------------------
-
-
 def prime_package_cache(
     extracted_dir: Path,
     cache_dir: Path,
 ) -> int:
+    """Copy bundled packages from an extracted archive into the conda cache.
+
+    Verifies SHA256 hashes against the lockfile before copying.
+    Returns the number of packages added to the cache.
+    """
     packages_dir = extracted_dir / "packages"
     if not packages_dir.is_dir():
         return 0
@@ -336,16 +376,14 @@ def prime_package_cache(
     return count
 
 
-# ---------------------------------------------------------------------------
-# Task 8: archive inspection helper
-# ---------------------------------------------------------------------------
-
-
 def inspect_archive(archive_path: Path) -> dict[str, object]:
-    with _open_tar(archive_path) as tf:
+    """Return metadata about an archive without extracting it."""
+    with open_tar(archive_path) as tf:
         names = set(tf.getnames())
 
-    package_members = [n for n in names if n.startswith("packages/") and n.endswith(".conda")]
+    package_members = [
+        n for n in names if n.startswith("packages/") and n.endswith(".conda")
+    ]
 
     return {
         "has_manifest": "conda.toml" in names,

--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -282,9 +282,9 @@ def _build_hash_index(lockfile_path: Path) -> dict[str, str]:
     index: dict[str, str] = {}
     for pkg in packages_data:
         url = pkg.get("conda") or pkg.get("url", "")
-        sha256 = pkg.get("sha256", "")
-        if url and sha256:
-            index[_url_to_filename(url)] = sha256
+        sha256 = pkg.get("sha256")
+        if url and sha256 is not None:
+            index[_url_to_filename(url)] = str(sha256)
     return index
 
 
@@ -303,3 +303,34 @@ def verify_package_hashes(
             raise ArchiveHashMismatchError(
                 pkg_path.name, expected=exp_hash, actual=actual_hash
             )
+
+
+# ---------------------------------------------------------------------------
+# Task 7: unarchive with cache priming
+# ---------------------------------------------------------------------------
+
+
+def prime_package_cache(
+    extracted_dir: Path,
+    cache_dir: Path,
+) -> int:
+    packages_dir = extracted_dir / "packages"
+    if not packages_dir.is_dir():
+        return 0
+
+    lockfile = extracted_dir / "conda.lock"
+    packages = sorted(packages_dir.glob("*.conda"))
+    if not packages:
+        return 0
+
+    verify_package_hashes(packages, lockfile)
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    count = 0
+    for pkg in packages:
+        dest = cache_dir / pkg.name
+        if not dest.exists():
+            shutil.copy2(pkg, dest)
+            count += 1
+
+    return count

--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -12,9 +12,12 @@ import hashlib
 import io
 import shutil
 import subprocess
+import sys
 import tarfile
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from conda_lockfiles.load_yaml import load_yaml
 
 from .exceptions import (
     ArchiveError,
@@ -244,8 +247,8 @@ def open_tar(archive_path: Path) -> tarfile.TarFile:
 def extract_archive(archive_path: Path, target: Path) -> Path:
     """Extract *archive_path* into *target* with path traversal protection.
 
-    Every member is validated before extraction. Uses Python 3.12+
-    ``filter="data"`` for defense-in-depth.
+    Every member is validated before extraction. On Python 3.12+ the
+    ``filter="data"`` parameter provides additional defense-in-depth.
     """
     target = target.resolve()
     target.mkdir(parents=True, exist_ok=True)
@@ -253,15 +256,16 @@ def extract_archive(archive_path: Path, target: Path) -> Path:
     with open_tar(archive_path) as tf:
         for member in tf.getmembers():
             validate_tar_member(member, target)
-        tf.extractall(path=target, filter="data")
+        if sys.version_info >= (3, 12):
+            tf.extractall(path=target, filter="data")
+        else:
+            tf.extractall(path=target)
 
     return target
 
 
 def parse_lockfile_packages(lockfile_path: Path) -> list[dict]:
     """Parse the ``packages`` list from a conda lockfile."""
-    from conda_lockfiles.load_yaml import load_yaml
-
     data = load_yaml(lockfile_path)
     return data.get("packages", []) or []
 

--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -47,8 +47,13 @@ ARCHIVE_SUFFIXES: tuple[str, ...] = (
 MANIFEST_FILENAMES = {"conda.toml", "pixi.toml", "pyproject.toml"}
 
 ALLOWED_TAR_TYPES: frozenset[bytes] = frozenset(
-    {tarfile.REGTYPE, tarfile.AREGTYPE, tarfile.DIRTYPE,
-     tarfile.SYMTYPE, tarfile.LNKTYPE}
+    {
+        tarfile.REGTYPE,
+        tarfile.AREGTYPE,
+        tarfile.DIRTYPE,
+        tarfile.SYMTYPE,
+        tarfile.LNKTYPE,
+    }
 )
 """Filenames recognised as workspace manifests inside an archive."""
 

--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -111,7 +111,7 @@ def collect_archive_files(
 
     result: list[Path] = []
     for path in candidates:
-        rel = str(path.relative_to(root))
+        rel = path.relative_to(root).as_posix()
         if is_excluded_by_builtins(rel):
             continue
         if is_excluded_by_patterns(rel, archive_config.exclude):

--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -162,3 +162,61 @@ def _write_tar_zst(
     cctx = zstandard.ZstdCompressor(level=3)
     compressed = cctx.compress(buf.getvalue())
     output.write_bytes(compressed)
+
+
+# ---------------------------------------------------------------------------
+# Task 5: safe extraction with path traversal protection
+# ---------------------------------------------------------------------------
+
+from .exceptions import ArchivePathTraversalError
+
+
+def _validate_tar_member(member: tarfile.TarInfo, target: Path) -> None:
+    member_path = Path(member.name)
+
+    if member_path.is_absolute():
+        raise ArchivePathTraversalError(member.name)
+
+    try:
+        resolved = (target / member_path).resolve()
+        resolved.relative_to(target.resolve())
+    except ValueError:
+        raise ArchivePathTraversalError(member.name)
+
+    if ".." in member_path.parts:
+        raise ArchivePathTraversalError(member.name)
+
+    if member.issym() or member.islnk():
+        link_target = Path(member.linkname)
+        if link_target.is_absolute():
+            raise ArchivePathTraversalError(member.name)
+        resolved_link = (target / member_path.parent / link_target).resolve()
+        try:
+            resolved_link.relative_to(target.resolve())
+        except ValueError:
+            raise ArchivePathTraversalError(member.name)
+
+
+def _open_tar(archive_path: Path) -> tarfile.TarFile:
+    compression = _detect_compression(archive_path)
+    if compression == "zst":
+        import zstandard
+
+        with open(archive_path, "rb") as fh:
+            dctx = zstandard.ZstdDecompressor()
+            decompressed = dctx.decompress(fh.read())
+        return tarfile.open(fileobj=io.BytesIO(decompressed), mode="r:")
+    else:
+        return tarfile.open(archive_path, f"r:{compression}")
+
+
+def extract_archive(archive_path: Path, target: Path) -> Path:
+    target = target.resolve()
+    target.mkdir(parents=True, exist_ok=True)
+
+    with _open_tar(archive_path) as tf:
+        for member in tf.getmembers():
+            _validate_tar_member(member, target)
+        tf.extractall(path=target, filter="data")
+
+    return target

--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -1,0 +1,88 @@
+"""Archive creation and extraction for conda workspaces."""
+
+from __future__ import annotations
+
+import fnmatch
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .models import ArchiveConfig
+
+BUILTIN_EXCLUDE_DIRS: frozenset[str] = frozenset({
+    ".git",
+    ".conda/envs",
+    ".pixi",
+    "__pycache__",
+})
+
+
+def _is_git_repo(root: Path) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode == 0 and result.stdout.strip() == "true"
+    except FileNotFoundError:
+        return False
+
+
+def _git_tracked_files(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    paths = []
+    for entry in result.stdout.split("\0"):
+        if entry:
+            full = root / entry
+            if full.is_file():
+                paths.append(full)
+    return paths
+
+
+def _is_excluded_by_builtins(rel_path: str) -> bool:
+    for excl in BUILTIN_EXCLUDE_DIRS:
+        if rel_path == excl or rel_path.startswith(excl + "/"):
+            return True
+    return False
+
+
+def _is_excluded_by_patterns(rel_path: str, patterns: tuple[str, ...]) -> bool:
+    for pattern in patterns:
+        if fnmatch.fnmatch(rel_path, pattern):
+            return True
+        parts = rel_path.split("/")
+        for i in range(len(parts)):
+            partial = "/".join(parts[: i + 1])
+            if fnmatch.fnmatch(partial, pattern):
+                return True
+    return False
+
+
+def collect_archive_files(
+    root: Path,
+    archive_config: ArchiveConfig,
+) -> list[Path]:
+    if _is_git_repo(root):
+        candidates = _git_tracked_files(root)
+    else:
+        candidates = [p for p in root.rglob("*") if p.is_file()]
+
+    result: list[Path] = []
+    for path in candidates:
+        rel = str(path.relative_to(root))
+        if _is_excluded_by_builtins(rel):
+            continue
+        if _is_excluded_by_patterns(rel, archive_config.exclude):
+            continue
+        result.append(path)
+
+    return sorted(result)

--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -32,6 +32,18 @@ except ImportError:
 if TYPE_CHECKING:
     from .models import ArchiveConfig
 
+ARCHIVE_SUFFIXES: tuple[str, ...] = (
+    ".tar.zst",
+    ".tar.zstd",
+    ".tar.gz",
+    ".tgz",
+    ".tar.bz2",
+)
+"""Recognised archive filename suffixes, longest first."""
+
+_MANIFEST_FILENAMES = {"conda.toml", "pixi.toml", "pyproject.toml"}
+"""Filenames recognised as workspace manifests inside an archive."""
+
 BUILTIN_EXCLUDE_DIRS: frozenset[str] = frozenset(
     {
         ".git",
@@ -388,9 +400,8 @@ def inspect_archive(archive_path: Path) -> dict[str, object]:
     ]
 
     return {
-        "has_manifest": "conda.toml" in names,
+        "has_manifest": bool(names & _MANIFEST_FILENAMES),
         "has_lockfile": "conda.lock" in names,
-        "has_attestation": "conda.lock.sigstore" in names,
         "has_packages": len(package_members) > 0,
         "package_count": len(package_members),
     }

--- a/conda_workspaces/cli/main.py
+++ b/conda_workspaces/cli/main.py
@@ -527,7 +527,7 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
         type=Path,
         default=None,
         help=(
-            "Output archive path (default: <workspace-name>.tar.gz)."
+            "Output archive path (default: <workspace-name>.tar.zst)."
             " Supports .tar.gz and .tar.zst extensions."
         ),
     )

--- a/conda_workspaces/cli/main.py
+++ b/conda_workspaces/cli/main.py
@@ -541,6 +541,12 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
         ),
     )
     archive_parser.add_argument(
+        "--lock",
+        action="store_true",
+        default=False,
+        help="Run 'conda workspace lock' before creating the archive.",
+    )
+    archive_parser.add_argument(
         "--exclude",
         action="append",
         default=None,

--- a/conda_workspaces/cli/main.py
+++ b/conda_workspaces/cli/main.py
@@ -536,15 +536,9 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         default=False,
         help=(
-            "Bundle .conda packages from the local cache for"
-            " offline/air-gapped deployment."
+            "Bundle resolved .conda packages from the local cache into"
+            " the archive for offline/air-gapped deployment."
         ),
-    )
-    archive_parser.add_argument(
-        "-e",
-        "--environment",
-        default=None,
-        help="Archive packages for this environment only (with --bundle).",
     )
     archive_parser.add_argument(
         "--exclude",

--- a/conda_workspaces/cli/main.py
+++ b/conda_workspaces/cli/main.py
@@ -573,16 +573,10 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
         help="Target directory (default: directory named after the archive).",
     )
     unarchive_parser.add_argument(
-        "--install",
-        action="store_true",
-        default=False,
-        help="Install environments from the lockfile after extraction.",
-    )
-    unarchive_parser.add_argument(
         "--no-install",
         action="store_true",
         default=False,
-        help="Skip installing environments.",
+        help="Skip cache priming for bundled packages.",
     )
 
     quickstart_parser = sub.add_parser(

--- a/conda_workspaces/cli/main.py
+++ b/conda_workspaces/cli/main.py
@@ -550,7 +550,8 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
         "--exclude",
         action="append",
         default=None,
-        help="Additional exclude patterns (repeatable). Added to [workspace.archive] exclude.",
+        help="Additional exclude patterns (repeatable)."
+        " Added to [workspace.archive] exclude.",
     )
 
     unarchive_parser = sub.add_parser(

--- a/conda_workspaces/cli/main.py
+++ b/conda_workspaces/cli/main.py
@@ -573,6 +573,12 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
         help="Target directory (default: directory named after the archive).",
     )
     unarchive_parser.add_argument(
+        "--install",
+        action="store_true",
+        default=False,
+        help="Install environments from the lockfile after extraction.",
+    )
+    unarchive_parser.add_argument(
         "--no-install",
         action="store_true",
         default=False,

--- a/conda_workspaces/cli/main.py
+++ b/conda_workspaces/cli/main.py
@@ -514,6 +514,76 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
         help="Optional command to run in the spawned shell.",
     )
 
+    archive_parser = sub.add_parser(
+        "archive",
+        help="Create a workspace archive.",
+        add_help=False,
+    )
+    add_parser_help(archive_parser)
+    add_output_and_prompt_options(archive_parser)
+    archive_parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help=(
+            "Output archive path (default: <workspace-name>.tar.gz)."
+            " Supports .tar.gz and .tar.zst extensions."
+        ),
+    )
+    archive_parser.add_argument(
+        "--bundle",
+        action="store_true",
+        default=False,
+        help=(
+            "Bundle .conda packages from the local cache for"
+            " offline/air-gapped deployment."
+        ),
+    )
+    archive_parser.add_argument(
+        "-e",
+        "--environment",
+        default=None,
+        help="Archive packages for this environment only (with --bundle).",
+    )
+    archive_parser.add_argument(
+        "--exclude",
+        action="append",
+        default=None,
+        help="Additional exclude patterns (repeatable). Added to [workspace.archive] exclude.",
+    )
+
+    unarchive_parser = sub.add_parser(
+        "unarchive",
+        help="Extract a workspace archive.",
+        add_help=False,
+    )
+    add_parser_help(unarchive_parser)
+    add_output_and_prompt_options(unarchive_parser)
+    unarchive_parser.add_argument(
+        "archive_path",
+        type=Path,
+        help="Path to the workspace archive.",
+    )
+    unarchive_parser.add_argument(
+        "--target",
+        type=Path,
+        default=None,
+        help="Target directory (default: directory named after the archive).",
+    )
+    unarchive_parser.add_argument(
+        "--install",
+        action="store_true",
+        default=False,
+        help="Install environments from the lockfile after extraction.",
+    )
+    unarchive_parser.add_argument(
+        "--no-install",
+        action="store_true",
+        default=False,
+        help="Skip installing environments.",
+    )
+
     quickstart_parser = sub.add_parser(
         "quickstart",
         help=(
@@ -705,6 +775,14 @@ def _dispatch_workspace(args: argparse.Namespace, subcmd: str) -> int:
         from .workspace.import_manifest import execute_import
 
         return execute_import(args)
+    elif subcmd == "archive":
+        from .workspace.archive import execute_archive
+
+        return execute_archive(args)
+    elif subcmd == "unarchive":
+        from .workspace.archive import execute_unarchive
+
+        return execute_unarchive(args)
     elif subcmd == "quickstart":
         from .workspace.quickstart import execute_quickstart
 

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from rich.console import Console
 
@@ -21,9 +21,6 @@ from ...lockfile import lockfile_path as _lockfile_path
 from ...models import ArchiveConfig
 from .. import status
 from . import workspace_context_from_args
-
-if TYPE_CHECKING:
-    import argparse
 
 
 def execute_archive(
@@ -166,5 +163,19 @@ def execute_unarchive(
                     str(count),
                     detail="into conda cache",
                 )
+
+    if args.install:
+        from .install import execute_install
+
+        install_args = argparse.Namespace(
+            file=str(target),
+            environment=None,
+            force_reinstall=False,
+            locked=True,
+            frozen=False,
+            dry_run=False,
+            json=False,
+        )
+        return execute_install(install_args, console=console)
 
     return 0

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -142,18 +142,7 @@ def execute_unarchive(
                     detail="into conda cache",
                 )
 
-    has_attestation = info["has_attestation"]
-
-    if args.install:
-        pass
-    elif args.no_install:
-        pass
-    elif has_attestation:
-        console.print(
-            "  [bold yellow]WARNING:[/bold yellow] Attestation verification"
-            " is not yet implemented. Skipping auto-install."
-        )
-    else:
+    if not args.no_install and not info["has_attestation"]:
         console.print(
             "  [bold yellow]WARNING:[/bold yellow] Archive is not signed."
             " Cannot verify origin or integrity."

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -37,13 +37,19 @@ def execute_archive(
 
     cli_excludes = tuple(args.exclude or [])
     archive_config = ArchiveConfig(
+        include=config.archive.include,
         exclude=config.archive.exclude + cli_excludes,
+        compression=config.archive.compression,
+        compression_level=config.archive.compression_level,
     )
 
     output: Path | None = args.output
     if output is None:
         name = config.name or ctx.root.name
-        output = ctx.root / f"{name}.tar.gz"
+        ext = {"zst": ".tar.zst", "gz": ".tar.gz", "bz2": ".tar.bz2"}.get(
+            config.archive.compression, ".tar.zst"
+        )
+        output = ctx.root / f"{name}{ext}"
 
     bundle_packages = None
     if args.bundle:

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -127,9 +127,7 @@ def execute_unarchive(
     status.message(console, "Extracted", "archive", str(target))
 
     if info["has_packages"]:
-        console.print(
-            f"  Archive includes {info['package_count']} bundled packages"
-        )
+        console.print(f"  Archive includes {info['package_count']} bundled packages")
         if not args.no_install:
             from conda.base.context import context as conda_context
 

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from rich.console import Console
 
 from ...archive import (
+    ARCHIVE_SUFFIXES,
     collect_bundle_packages,
     create_archive,
     extract_archive,
@@ -16,6 +17,7 @@ from ...archive import (
     verify_package_hashes,
 )
 from ...exceptions import ArchiveError
+from ...lockfile import lockfile_path as _lockfile_path
 from ...models import ArchiveConfig
 from .. import status
 from . import workspace_context_from_args
@@ -55,7 +57,7 @@ def execute_archive(
     if args.bundle:
         from conda.base.context import context as conda_context
 
-        lockfile = ctx.root / "conda.lock"
+        lockfile = _lockfile_path(ctx)
         if not lockfile.is_file():
             raise ArchiveError(
                 "Cannot bundle packages: no conda.lock found.",
@@ -105,7 +107,7 @@ def execute_unarchive(
     target: Path | None = args.target
     if target is None:
         stem = archive_path.name
-        for suffix in (".tar.gz", ".tar.zst", ".tar.zstd", ".tar.bz2", ".tgz"):
+        for suffix in ARCHIVE_SUFFIXES:
             if stem.endswith(suffix):
                 stem = stem[: -len(suffix)]
                 break
@@ -115,7 +117,7 @@ def execute_unarchive(
 
     if not info["has_manifest"]:
         raise ArchiveError(
-            "Not a workspace archive: no conda.toml found.",
+            "Not a workspace archive: no manifest found.",
             hints=["This does not appear to be a conda workspace archive."],
         )
 
@@ -147,15 +149,5 @@ def execute_unarchive(
                     str(count),
                     detail="into conda cache",
                 )
-
-    if not args.no_install and not info["has_attestation"]:
-        console.print(
-            "  [bold yellow]WARNING:[/bold yellow] Archive is not signed."
-            " Cannot verify origin or integrity."
-        )
-        console.print(
-            "  Run 'conda workspace install --locked' inside the extracted"
-            " directory to install environments."
-        )
 
     return 0

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -37,6 +37,23 @@ def execute_archive(
 
     config, ctx = workspace_context_from_args(args)
 
+    if args.lock:
+        from ...lockfile import generate_lockfile
+        from ...resolver import resolve_all_environments
+
+        resolved_envs = resolve_all_environments(config, ctx.platform)
+
+        status.message(
+            console,
+            "Locking",
+            "workspace",
+            "environments",
+            style="bold blue",
+            ellipsis=True,
+        )
+        generate_lockfile(ctx, resolved_envs)
+        status.message(console, "Updated", "lockfile", "conda.lock")
+
     cli_excludes = tuple(args.exclude or [])
     archive_config = ArchiveConfig(
         include=config.archive.include,

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -1,0 +1,168 @@
+"""``conda workspace archive`` and ``conda workspace unarchive``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rich.console import Console
+
+from ...archive import (
+    collect_bundle_packages,
+    create_archive,
+    extract_archive,
+    inspect_archive,
+    prime_package_cache,
+    verify_package_hashes,
+)
+from ...exceptions import ArchiveError
+from ...models import ArchiveConfig
+from .. import status
+from . import workspace_context_from_args
+
+if TYPE_CHECKING:
+    import argparse
+
+
+def execute_archive(
+    args: argparse.Namespace,
+    *,
+    console: Console | None = None,
+) -> int:
+    """Create a workspace archive."""
+    if console is None:
+        console = Console(highlight=False)
+
+    config, ctx = workspace_context_from_args(args)
+
+    cli_excludes = tuple(args.exclude or [])
+    archive_config = ArchiveConfig(
+        exclude=config.archive.exclude + cli_excludes,
+    )
+
+    output: Path | None = args.output
+    if output is None:
+        name = config.name or ctx.root.name
+        output = ctx.root / f"{name}.tar.gz"
+
+    bundle_packages = None
+    if args.bundle:
+        from conda.base.context import context as conda_context
+
+        lockfile = ctx.root / "conda.lock"
+        if not lockfile.is_file():
+            raise ArchiveError(
+                "Cannot bundle packages: no conda.lock found.",
+                hints=["Run 'conda workspace lock' first."],
+            )
+        cache_dirs = [Path(d) for d in conda_context.pkgs_dirs]
+        bundle_packages = collect_bundle_packages(lockfile, cache_dirs)
+        verify_package_hashes(bundle_packages, lockfile)
+
+        status.message(
+            console,
+            "Bundling",
+            "packages",
+            str(len(bundle_packages)),
+            style="bold blue",
+            ellipsis=True,
+        )
+
+    status.message(
+        console,
+        "Creating",
+        "archive",
+        str(output.name),
+        style="bold blue",
+        ellipsis=True,
+    )
+
+    create_archive(ctx.root, output, archive_config, bundle_packages=bundle_packages)
+
+    status.message(console, "Created", "archive", str(output))
+    return 0
+
+
+def execute_unarchive(
+    args: argparse.Namespace,
+    *,
+    console: Console | None = None,
+) -> int:
+    """Extract a workspace archive."""
+    if console is None:
+        console = Console(highlight=False)
+
+    archive_path = Path(args.archive_path).resolve()
+    if not archive_path.is_file():
+        raise ArchiveError(f"Archive not found: {archive_path}")
+
+    target: Path | None = args.target
+    if target is None:
+        stem = archive_path.name
+        for suffix in (".tar.gz", ".tar.zst", ".tar.zstd", ".tar.bz2", ".tgz"):
+            if stem.endswith(suffix):
+                stem = stem[: -len(suffix)]
+                break
+        target = Path.cwd() / stem
+
+    info = inspect_archive(archive_path)
+
+    if not info["has_manifest"]:
+        raise ArchiveError(
+            "Not a workspace archive: no conda.toml found.",
+            hints=["This does not appear to be a conda workspace archive."],
+        )
+
+    status.message(
+        console,
+        "Extracting",
+        "archive",
+        str(archive_path.name),
+        style="bold blue",
+        ellipsis=True,
+    )
+
+    extract_archive(archive_path, target)
+
+    status.message(console, "Extracted", "archive", str(target))
+
+    if info["has_packages"]:
+        console.print(
+            f"  Archive includes {info['package_count']} bundled packages"
+        )
+        if not args.no_install:
+            from conda.base.context import context as conda_context
+
+            cache_dir = Path(conda_context.pkgs_dirs[0])
+            count = prime_package_cache(target, cache_dir)
+            if count > 0:
+                status.message(
+                    console,
+                    "Primed",
+                    "packages",
+                    str(count),
+                    detail="into conda cache",
+                )
+
+    has_attestation = info["has_attestation"]
+
+    if args.install:
+        pass
+    elif args.no_install:
+        pass
+    elif has_attestation:
+        console.print(
+            "  [bold yellow]WARNING:[/bold yellow] Attestation verification"
+            " is not yet implemented. Skipping auto-install."
+        )
+    else:
+        console.print(
+            "  [bold yellow]WARNING:[/bold yellow] Archive is not signed."
+            " Cannot verify origin or integrity."
+        )
+        console.print(
+            "  Run 'conda workspace install --locked' inside the extracted"
+            " directory to install environments."
+        )
+
+    return 0

--- a/conda_workspaces/exceptions.py
+++ b/conda_workspaces/exceptions.py
@@ -307,3 +307,38 @@ class NoTaskFileError(CondaWorkspacesError):
                 " with task definitions.",
             ],
         )
+
+
+class ArchiveError(CondaWorkspacesError):
+    """General archive operation failure."""
+
+    def __init__(self, message: str, *, hints: list[str] | None = None) -> None:
+        super().__init__(message, hints=hints)
+
+
+class ArchivePathTraversalError(ArchiveError):
+    """A tar member attempts to write outside the target directory."""
+
+    def __init__(self, member_path: str) -> None:
+        self.member_path = member_path
+        super().__init__(
+            f"Archive member '{member_path}' attempts path traversal.",
+            hints=["The archive may be malicious. Do not extract it."],
+        )
+
+
+class ArchiveHashMismatchError(ArchiveError):
+    """A bundled package hash does not match the lockfile."""
+
+    def __init__(self, filename: str, *, expected: str, actual: str) -> None:
+        self.filename = filename
+        self.expected = expected
+        self.actual = actual
+        super().__init__(
+            f"Hash mismatch for '{filename}': "
+            f"expected {expected[:12]}..., got {actual[:12]}...",
+            hints=[
+                "The package file may have been tampered with.",
+                "Re-create the archive from a trusted source.",
+            ],
+        )

--- a/conda_workspaces/manifests/pixi_toml.py
+++ b/conda_workspaces/manifests/pixi_toml.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 import tomlkit
 
 from ..exceptions import TaskNotFoundError, TaskParseError, WorkspaceParseError
-from ..models import WorkspaceConfig
+from ..models import ArchiveConfig, WorkspaceConfig
 from .base import ManifestParser
 from .normalize import parse_feature_tasks, parse_tasks_and_targets
 from .toml import _parse_channels, _parse_features_and_envs
@@ -21,6 +21,13 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from ..models import Task
+
+
+def _parse_archive_config(ws: dict) -> ArchiveConfig:
+    """Parse [workspace.archive] into an ArchiveConfig."""
+    archive_data = ws.get("archive", {})
+    exclude = tuple(archive_data.get("exclude", []))
+    return ArchiveConfig(exclude=exclude)
 
 
 class PixiTomlParser(ManifestParser):
@@ -66,6 +73,7 @@ class PixiTomlParser(ManifestParser):
             root=root,
             manifest_path=str(path),
             channel_priority=ws.get("channel-priority"),
+            archive=_parse_archive_config(ws),
         )
 
         _parse_features_and_envs(data, config, path)

--- a/conda_workspaces/manifests/pixi_toml.py
+++ b/conda_workspaces/manifests/pixi_toml.py
@@ -12,22 +12,15 @@ from typing import TYPE_CHECKING
 import tomlkit
 
 from ..exceptions import TaskNotFoundError, TaskParseError, WorkspaceParseError
-from ..models import ArchiveConfig, WorkspaceConfig
+from ..models import WorkspaceConfig
 from .base import ManifestParser
 from .normalize import parse_feature_tasks, parse_tasks_and_targets
-from .toml import _parse_channels, _parse_features_and_envs
+from .toml import _parse_channels, _parse_features_and_envs, parse_archive_config
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from ..models import Task
-
-
-def _parse_archive_config(ws: dict) -> ArchiveConfig:
-    """Parse [workspace.archive] into an ArchiveConfig."""
-    archive_data = ws.get("archive", {})
-    exclude = tuple(archive_data.get("exclude", []))
-    return ArchiveConfig(exclude=exclude)
 
 
 class PixiTomlParser(ManifestParser):
@@ -73,7 +66,7 @@ class PixiTomlParser(ManifestParser):
             root=root,
             manifest_path=str(path),
             channel_priority=ws.get("channel-priority"),
-            archive=_parse_archive_config(ws),
+            archive=parse_archive_config(ws),
         )
 
         _parse_features_and_envs(data, config, path)

--- a/conda_workspaces/manifests/pyproject_toml.py
+++ b/conda_workspaces/manifests/pyproject_toml.py
@@ -19,7 +19,7 @@ from ..exceptions import (
     TaskParseError,
     WorkspaceParseError,
 )
-from ..models import WorkspaceConfig
+from ..models import ArchiveConfig, WorkspaceConfig
 from .base import ManifestParser
 from .normalize import parse_feature_tasks, parse_tasks_and_targets
 from .toml import _parse_channels, _parse_features_and_envs
@@ -32,6 +32,13 @@ if TYPE_CHECKING:
     from tomlkit.items import Table
 
     from ..models import Task
+
+
+def _parse_archive_config(ws: dict) -> ArchiveConfig:
+    """Parse [workspace.archive] into an ArchiveConfig."""
+    archive_data = ws.get("archive", {})
+    exclude = tuple(archive_data.get("exclude", []))
+    return ArchiveConfig(exclude=exclude)
 
 
 class PyprojectTomlParser(ManifestParser):
@@ -185,6 +192,7 @@ class PyprojectTomlParser(ManifestParser):
             root=root,
             manifest_path=str(path),
             channel_priority=ws.get("channel-priority"),
+            archive=_parse_archive_config(ws),
         )
 
         _parse_features_and_envs(source, config, path)

--- a/conda_workspaces/manifests/pyproject_toml.py
+++ b/conda_workspaces/manifests/pyproject_toml.py
@@ -19,10 +19,10 @@ from ..exceptions import (
     TaskParseError,
     WorkspaceParseError,
 )
-from ..models import ArchiveConfig, WorkspaceConfig
+from ..models import WorkspaceConfig
 from .base import ManifestParser
 from .normalize import parse_feature_tasks, parse_tasks_and_targets
-from .toml import _parse_channels, _parse_features_and_envs
+from .toml import _parse_channels, _parse_features_and_envs, parse_archive_config
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -32,13 +32,6 @@ if TYPE_CHECKING:
     from tomlkit.items import Table
 
     from ..models import Task
-
-
-def _parse_archive_config(ws: dict) -> ArchiveConfig:
-    """Parse [workspace.archive] into an ArchiveConfig."""
-    archive_data = ws.get("archive", {})
-    exclude = tuple(archive_data.get("exclude", []))
-    return ArchiveConfig(exclude=exclude)
 
 
 class PyprojectTomlParser(ManifestParser):
@@ -192,7 +185,7 @@ class PyprojectTomlParser(ManifestParser):
             root=root,
             manifest_path=str(path),
             channel_priority=ws.get("channel-priority"),
-            archive=_parse_archive_config(ws),
+            archive=parse_archive_config(ws),
         )
 
         _parse_features_and_envs(source, config, path)

--- a/conda_workspaces/manifests/toml.py
+++ b/conda_workspaces/manifests/toml.py
@@ -17,6 +17,7 @@ import tomlkit
 
 from ..exceptions import TaskNotFoundError, TaskParseError, WorkspaceParseError
 from ..models import (
+    ArchiveConfig,
     Channel,
     Environment,
     Feature,
@@ -149,6 +150,13 @@ def tasks_to_toml(tasks: dict[str, Task]) -> str:
         )
 
     return tomlkit.dumps(doc)
+
+
+def parse_archive_config(ws: dict[str, Any]) -> ArchiveConfig:
+    """Parse ``[workspace.archive]`` into an ArchiveConfig."""
+    archive_data = ws.get("archive", {})
+    exclude = tuple(archive_data.get("exclude", []))
+    return ArchiveConfig(exclude=exclude)
 
 
 def _parse_channels(raw: list[Any]) -> list[Channel]:

--- a/conda_workspaces/manifests/toml.py
+++ b/conda_workspaces/manifests/toml.py
@@ -155,8 +155,12 @@ def tasks_to_toml(tasks: dict[str, Task]) -> str:
 def parse_archive_config(ws: dict[str, Any]) -> ArchiveConfig:
     """Parse ``[workspace.archive]`` into an ArchiveConfig."""
     archive_data = ws.get("archive", {})
-    exclude = tuple(archive_data.get("exclude", []))
-    return ArchiveConfig(exclude=exclude)
+    return ArchiveConfig(
+        include=tuple(archive_data.get("include", [])),
+        exclude=tuple(archive_data.get("exclude", [])),
+        compression=archive_data.get("compression", "zst"),
+        compression_level=archive_data.get("compression-level"),
+    )
 
 
 def _parse_channels(raw: list[Any]) -> list[Channel]:

--- a/conda_workspaces/models.py
+++ b/conda_workspaces/models.py
@@ -127,7 +127,10 @@ class Environment:
 class ArchiveConfig:
     """Archive settings from ``[workspace.archive]``."""
 
+    include: tuple[str, ...] = ()
     exclude: tuple[str, ...] = ()
+    compression: str = "zst"
+    compression_level: int | None = None
 
 
 @dataclass

--- a/conda_workspaces/models.py
+++ b/conda_workspaces/models.py
@@ -123,6 +123,13 @@ class Environment:
         return self.name == self.DEFAULT_NAME
 
 
+@dataclass(frozen=True)
+class ArchiveConfig:
+    """Archive settings from ``[workspace.archive]``."""
+
+    exclude: tuple[str, ...] = ()
+
+
 @dataclass
 class WorkspaceConfig:
     """Complete parsed workspace configuration.
@@ -159,6 +166,7 @@ class WorkspaceConfig:
 
     # Preview / optional fields
     channel_priority: str | None = None  # "strict" | "flexible" | "disabled"
+    archive: ArchiveConfig = field(default_factory=ArchiveConfig)
 
     def __post_init__(self) -> None:
         """Ensure the default feature and environment always exist.

--- a/demos/README.md
+++ b/demos/README.md
@@ -18,6 +18,7 @@ Animated terminal demos recorded with [VHS](https://github.com/charmbracelet/vhs
 | `pixi-compat` | Use an existing pixi.toml with conda-workspaces |
 | `import` | Import environment.yml and anaconda-project.yml into conda.toml |
 | `shell` | Interactive shell and one-shot commands |
+| `archives` | Create and extract workspace archives |
 
 ### Tasks
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -20,6 +20,7 @@ Animated terminal demos recorded with [VHS](https://github.com/charmbracelet/vhs
 | `shell` | Interactive shell and one-shot commands |
 | `archives` | Create and extract workspace archives |
 | `archives-bundle` | Bundle packages for offline/air-gapped deployment |
+| `archives-install` | Extract and install in one step with --install |
 
 ### Tasks
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -19,6 +19,7 @@ Animated terminal demos recorded with [VHS](https://github.com/charmbracelet/vhs
 | `import` | Import environment.yml and anaconda-project.yml into conda.toml |
 | `shell` | Interactive shell and one-shot commands |
 | `archives` | Create and extract workspace archives |
+| `archives-bundle` | Bundle packages for offline/air-gapped deployment |
 
 ### Tasks
 

--- a/demos/archives-bundle.tape
+++ b/demos/archives-bundle.tape
@@ -1,0 +1,67 @@
+Source demos/_settings.tape
+
+Output demos/archives-bundle.gif
+Output demos/archives-bundle.mp4
+
+Hide
+Type `eval "$(pixi shell-hook -s bash -e dev)"`
+Enter
+Wait /\)/
+Type `export PS1="$DEMO_PS1" && mkdir -p /tmp/.demo-home && echo 'PS1="$ "' > /tmp/.demo-home/.bash_profile && export HOME=/tmp/.demo-home`
+Enter
+Wait /\$/
+Type `FIXTURES=$(pwd)/demos/fixtures`
+Enter
+Wait /\$/
+Type "rm -rf /tmp/bundle-demo && mkdir -p /tmp/bundle-demo && cd /tmp/bundle-demo"
+Enter
+Wait /\$/
+Type `cp "$FIXTURES/archives.toml" conda.toml`
+Enter
+Wait /\$/
+Type `mkdir -p src tests && echo 'from flask import Flask; app = Flask(__name__)' > src/app.py && echo 'def test_health(): assert True' > tests/test_app.py`
+Enter
+Wait /\$/
+Type "conda workspace install"
+Enter
+Wait /\$/
+Type "clear"
+Enter
+Wait /\$/
+Show
+
+Type "# Bundle packages for offline/air-gapped deployment"
+Enter
+Sleep 500ms
+
+Type "# --lock solves first, --bundle includes .conda packages"
+Enter
+Sleep 500ms
+
+Type@80ms "conda workspace archive --lock --bundle -o offline.tar.zst"
+Enter
+Wait /\$/
+Sleep 2s
+
+Type "# The archive now includes a packages/ directory"
+Enter
+Sleep 500ms
+
+Type@80ms "tar --list -f offline.tar.zst | grep packages/ | head -5"
+Enter
+Wait /\$/
+Sleep 3s
+
+Type "# On the air-gapped machine: extract and install"
+Enter
+Sleep 500ms
+
+Type@80ms "conda workspace unarchive offline.tar.zst --target /tmp/offline"
+Enter
+Wait /\$/
+Sleep 2s
+
+Type@80ms "cd /tmp/offline && conda workspace install --locked"
+Enter
+Wait /\$/
+Sleep 3s

--- a/demos/archives-install.tape
+++ b/demos/archives-install.tape
@@ -1,0 +1,62 @@
+Source demos/_settings.tape
+
+Output demos/archives-install.gif
+Output demos/archives-install.mp4
+
+Hide
+Type `eval "$(pixi shell-hook -s bash -e dev)"`
+Enter
+Wait /\)/
+Type `export PS1="$DEMO_PS1" && mkdir -p /tmp/.demo-home && echo 'PS1="$ "' > /tmp/.demo-home/.bash_profile && export HOME=/tmp/.demo-home`
+Enter
+Wait /\$/
+Type `FIXTURES=$(pwd)/demos/fixtures`
+Enter
+Wait /\$/
+Type "rm -rf /tmp/install-demo && mkdir -p /tmp/install-demo && cd /tmp/install-demo"
+Enter
+Wait /\$/
+Type `cp "$FIXTURES/archives.toml" conda.toml`
+Enter
+Wait /\$/
+Type `mkdir -p src tests && echo 'from flask import Flask; app = Flask(__name__)' > src/app.py && echo 'def test_health(): assert True' > tests/test_app.py`
+Enter
+Wait /\$/
+Type "conda workspace lock"
+Enter
+Wait /\$/
+Type "conda workspace archive"
+Enter
+Wait /\$/
+Type "clear"
+Enter
+Wait /\$/
+Show
+
+Type "# Extract and install in one step with --install"
+Enter
+Sleep 500ms
+
+Type@80ms "ls weather-api.tar.zst"
+Enter
+Wait /\$/
+Sleep 1s
+
+Type@80ms "conda workspace unarchive weather-api.tar.zst --target /tmp/deployed --install"
+Enter
+Wait /\$/
+Sleep 3s
+
+Type "# The workspace is ready to use"
+Enter
+Sleep 500ms
+
+Type@80ms "ls /tmp/deployed/"
+Enter
+Wait /\$/
+Sleep 2s
+
+Type@80ms "conda workspace envs -f /tmp/deployed/conda.toml"
+Enter
+Wait /\$/
+Sleep 3s

--- a/demos/archives.tape
+++ b/demos/archives.tape
@@ -1,0 +1,70 @@
+Source demos/_settings.tape
+
+Output demos/archives.gif
+Output demos/archives.mp4
+
+Hide
+Type `eval "$(pixi shell-hook -s bash -e dev)"`
+Enter
+Wait /\)/
+Type `export PS1="$DEMO_PS1" && mkdir -p /tmp/.demo-home && echo 'PS1="$ "' > /tmp/.demo-home/.bash_profile && export HOME=/tmp/.demo-home`
+Enter
+Wait /\$/
+Type `FIXTURES=$(pwd)/demos/fixtures`
+Enter
+Wait /\$/
+Type "rm -rf /tmp/archives-demo && mkdir -p /tmp/archives-demo && cd /tmp/archives-demo"
+Enter
+Wait /\$/
+Type `cp "$FIXTURES/archives.toml" conda.toml`
+Enter
+Wait /\$/
+Type `mkdir -p src && echo 'print("hello")' > src/app.py`
+Enter
+Wait /\$/
+Type "clear"
+Enter
+Wait /\$/
+Show
+
+Type "# Create a workspace archive from the current project"
+Enter
+Sleep 500ms
+
+Type@80ms "bat conda.toml"
+Enter
+Wait /\$/
+Sleep 3s
+
+Type@80ms "conda workspace lock"
+Enter
+Wait /\$/
+Sleep 2s
+
+Type@80ms "conda workspace archive -o my-project.tar.gz"
+Enter
+Wait /\$/
+Sleep 2s
+
+Type "# Archive includes the manifest, lockfile, and source files"
+Enter
+Sleep 500ms
+
+Type@80ms "tar tzf my-project.tar.gz"
+Enter
+Wait /\$/
+Sleep 3s
+
+Type "# Extract the archive into a new directory"
+Enter
+Sleep 500ms
+
+Type@80ms "conda workspace unarchive my-project.tar.gz --target /tmp/restored"
+Enter
+Wait /\$/
+Sleep 2s
+
+Type@80ms "ls /tmp/restored/"
+Enter
+Wait /\$/
+Sleep 3s

--- a/demos/archives.tape
+++ b/demos/archives.tape
@@ -19,7 +19,7 @@ Wait /\$/
 Type `cp "$FIXTURES/archives.toml" conda.toml`
 Enter
 Wait /\$/
-Type `mkdir -p src && echo 'print("hello")' > src/app.py`
+Type `mkdir -p src tests && echo 'from flask import Flask; app = Flask(__name__)' > src/app.py && echo 'def test_health(): assert True' > tests/test_app.py`
 Enter
 Wait /\$/
 Type "clear"
@@ -34,18 +34,13 @@ Sleep 500ms
 Type@80ms "bat conda.toml"
 Enter
 Wait /\$/
-Sleep 3s
+Sleep 4s
 
-Type "# Lock and create the archive (defaults to .tar.zst)"
+Type "# --lock solves and writes conda.lock before archiving"
 Enter
 Sleep 500ms
 
-Type@80ms "conda workspace lock"
-Enter
-Wait /\$/
-Sleep 2s
-
-Type@80ms "conda workspace archive"
+Type@80ms "conda workspace archive --lock"
 Enter
 Wait /\$/
 Sleep 2s
@@ -54,16 +49,16 @@ Type "# Archive contains manifest, lockfile, and source files"
 Enter
 Sleep 500ms
 
-Type@80ms "tar --list -f my-project.tar.zst | head -10"
+Type@80ms "tar --list -f weather-api.tar.zst"
 Enter
 Wait /\$/
 Sleep 3s
 
-Type "# Extract the archive on another machine"
+Type "# Extract and restore the workspace elsewhere"
 Enter
 Sleep 500ms
 
-Type@80ms "conda workspace unarchive my-project.tar.zst --target /tmp/restored"
+Type@80ms "conda workspace unarchive weather-api.tar.zst --target /tmp/restored"
 Enter
 Wait /\$/
 Sleep 2s

--- a/demos/archives.tape
+++ b/demos/archives.tape
@@ -27,7 +27,7 @@ Enter
 Wait /\$/
 Show
 
-Type "# Create a workspace archive from the current project"
+Type "# Package a workspace into a portable archive"
 Enter
 Sleep 500ms
 
@@ -36,35 +36,48 @@ Enter
 Wait /\$/
 Sleep 3s
 
+Type "# Lock and create the archive (defaults to .tar.zst)"
+Enter
+Sleep 500ms
+
 Type@80ms "conda workspace lock"
 Enter
 Wait /\$/
 Sleep 2s
 
-Type@80ms "conda workspace archive -o my-project.tar.gz"
+Type@80ms "conda workspace archive"
 Enter
 Wait /\$/
 Sleep 2s
 
-Type "# Archive includes the manifest, lockfile, and source files"
+Type "# Archive contains manifest, lockfile, and source files"
 Enter
 Sleep 500ms
 
-Type@80ms "tar tzf my-project.tar.gz"
+Type@80ms "tar --list -f my-project.tar.zst | head -10"
 Enter
 Wait /\$/
 Sleep 3s
 
-Type "# Extract the archive into a new directory"
+Type "# Extract the archive on another machine"
 Enter
 Sleep 500ms
 
-Type@80ms "conda workspace unarchive my-project.tar.gz --target /tmp/restored"
+Type@80ms "conda workspace unarchive my-project.tar.zst --target /tmp/restored"
 Enter
 Wait /\$/
 Sleep 2s
 
 Type@80ms "ls /tmp/restored/"
+Enter
+Wait /\$/
+Sleep 2s
+
+Type "# Install from the lockfile -- no solving needed"
+Enter
+Sleep 500ms
+
+Type@80ms "cd /tmp/restored && conda workspace install --locked"
 Enter
 Wait /\$/
 Sleep 3s

--- a/demos/fixtures/archives.toml
+++ b/demos/fixtures/archives.toml
@@ -1,14 +1,23 @@
 [workspace]
-name = "my-project"
+name = "weather-api"
 channels = ["conda-forge"]
 platforms = ["osx-arm64", "linux-64"]
 
 [dependencies]
 python = ">=3.12"
+flask = ">=3"
+pandas = ">=2"
 requests = "*"
 
+[feature.test.dependencies]
+pytest = ">=8"
+
+[environments]
+test = ["test"]
+
 [tasks]
-test = { cmd = "python -m pytest", description = "Run tests" }
+serve = { cmd = "flask run", description = "Start the dev server" }
+test = { cmd = "pytest tests/ -v", depends-on = ["serve"], description = "Run test suite" }
 
 [workspace.archive]
-exclude = ["docs/**", "*.log"]
+exclude = ["docs/**", "*.log", "data/raw/**"]

--- a/demos/fixtures/archives.toml
+++ b/demos/fixtures/archives.toml
@@ -1,0 +1,14 @@
+[workspace]
+name = "my-project"
+channels = ["conda-forge"]
+platforms = ["osx-arm64", "linux-64"]
+
+[dependencies]
+python = ">=3.12"
+requests = "*"
+
+[tasks]
+test = { cmd = "python -m pytest", description = "Run tests" }
+
+[workspace.archive]
+exclude = ["docs/**", "*.log"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -358,3 +358,32 @@ depends-on = [
   { task = "test", environment = "py311" },
 ]
 ```
+
+## Archive configuration
+
+The `[workspace.archive]` table controls which files are excluded when
+creating archives with `conda workspace archive`.
+
+```toml
+[workspace.archive]
+exclude = ["docs/**", "*.log", "data/raw/**"]
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `exclude` | list of strings | Glob patterns for files to exclude from archives |
+
+Patterns use `fnmatch` matching against paths relative to the
+workspace root. Both directory globs (`docs/**`) and file globs
+(`*.log`) are supported.
+
+Built-in exclusions always apply regardless of this setting:
+
+- `.git`
+- `.conda/envs`
+- `.pixi`
+- `__pycache__`
+
+CLI `--exclude` flags are combined with manifest exclusions. In git
+repos, only tracked files are considered regardless of exclusion
+patterns.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -361,17 +361,28 @@ depends-on = [
 
 ## Archive configuration
 
-The `[workspace.archive]` table controls which files are excluded when
-creating archives with `conda workspace archive`.
+The `[workspace.archive]` table controls which files are included and
+excluded when creating archives with `conda workspace archive`, as well
+as the compression format.
 
 ```toml
 [workspace.archive]
-exclude = ["docs/**", "*.log", "data/raw/**"]
+include = ["src/**", "conda.toml", "conda.lock"]
+exclude = ["*.log", "data/raw/**"]
+compression = "zst"
+compression-level = 19
 ```
 
 | Field | Type | Description |
 |---|---|---|
+| `include` | list of strings | Glob patterns for files to include in archives. When set, only matching files are archived. |
 | `exclude` | list of strings | Glob patterns for files to exclude from archives |
+| `compression` | string | Compression algorithm: `"zst"` (default), `"gz"`, or `"bz2"` |
+| `compression-level` | integer | Compression level (algorithm-dependent, omit for library default) |
+
+When both `include` and `exclude` are set, `include` patterns narrow
+the file set first, then `exclude` patterns remove from that set. When
+`include` is empty (the default), all files are candidates.
 
 Patterns use `fnmatch` matching against paths relative to the
 workspace root. Both directory globs (`docs/**`) and file globs

--- a/docs/features.md
+++ b/docs/features.md
@@ -677,11 +677,11 @@ alias table.
 
 ![archive demo](../demos/archives.gif)
 
-Package a workspace into a portable `.tar.gz` or `.tar.zst` archive
+Package a workspace into a portable `.tar.zst` or `.tar.gz` archive
 that includes the manifest, lockfile, and source files:
 
 ```bash
-conda workspace archive -o my-project.tar.gz
+conda workspace archive -o my-project.tar.zst
 ```
 
 In git repos, only tracked files are included. Built-in exclusions
@@ -702,7 +702,7 @@ conda workspace archive --exclude "benchmarks/**"
 Extract an archive on another machine:
 
 ```bash
-conda workspace unarchive my-project.tar.gz --target ./restored
+conda workspace unarchive my-project.tar.zst --target ./restored
 cd restored
 conda workspace install --locked
 ```
@@ -712,7 +712,7 @@ packages inside the archive. Package hashes are verified against the
 lockfile on both bundling and extraction:
 
 ```bash
-conda workspace archive --bundle -o offline.tar.gz
+conda workspace archive --bundle -o offline.tar.zst
 ```
 
 See the [archive tutorial](tutorials/archives.md) for a

--- a/docs/features.md
+++ b/docs/features.md
@@ -699,12 +699,10 @@ Or pass them on the command line:
 conda workspace archive --exclude "benchmarks/**"
 ```
 
-Extract an archive on another machine:
+Extract an archive and install environments in one step:
 
 ```bash
-conda workspace unarchive my-project.tar.zst --target ./restored
-cd restored
-conda workspace install --locked
+conda workspace unarchive my-project.tar.zst --target ./restored --install
 ```
 
 Pass `--lock` to solve and update the lockfile before archiving:

--- a/docs/features.md
+++ b/docs/features.md
@@ -673,6 +673,53 @@ basename (`conda.toml` → `conda-toml`, `pixi.toml` → `pixi-toml`,
 See [Format aliases](reference/format-aliases.md) for the full
 alias table.
 
+## Archives
+
+![archive demo](../demos/archives.gif)
+
+Package a workspace into a portable `.tar.gz` or `.tar.zst` archive
+that includes the manifest, lockfile, and source files:
+
+```bash
+conda workspace archive -o my-project.tar.gz
+```
+
+In git repos, only tracked files are included. Built-in exclusions
+(`.git`, `__pycache__`, `.conda/envs`, `.pixi`) always apply.
+Configure additional exclusions in the manifest:
+
+```toml
+[workspace.archive]
+exclude = ["docs/**", "*.log"]
+```
+
+Or pass them on the command line:
+
+```bash
+conda workspace archive --exclude "benchmarks/**"
+```
+
+Extract an archive on another machine:
+
+```bash
+conda workspace unarchive my-project.tar.gz --target ./restored
+cd restored
+conda workspace install --locked
+```
+
+For offline deployment, `--bundle` includes all resolved `.conda`
+packages inside the archive. Package hashes are verified against the
+lockfile on both bundling and extraction:
+
+```bash
+conda workspace archive --bundle -o offline.tar.gz
+```
+
+See the [archive tutorial](tutorials/archives.md) for a
+full walkthrough.
+
+---
+
 ## Project-local environments
 
 All environments are installed under `.conda/envs/` in your project

--- a/docs/features.md
+++ b/docs/features.md
@@ -707,12 +707,18 @@ cd restored
 conda workspace install --locked
 ```
 
+Pass `--lock` to solve and update the lockfile before archiving:
+
+```bash
+conda workspace archive --lock
+```
+
 For offline deployment, `--bundle` includes all resolved `.conda`
 packages inside the archive. Package hashes are verified against the
 lockfile on both bundling and extraction:
 
 ```bash
-conda workspace archive --bundle -o offline.tar.zst
+conda workspace archive --lock --bundle -o offline.tar.zst
 ```
 
 See the [archive tutorial](tutorials/archives.md) for a

--- a/docs/index.md
+++ b/docs/index.md
@@ -178,6 +178,7 @@ tutorials/pypi-dependencies
 tutorials/multi-platform-locking
 tutorials/coming-from/index
 tutorials/ci-pipeline
+tutorials/archives
 ```
 
 ```{toctree}

--- a/docs/tutorials/archives.md
+++ b/docs/tutorials/archives.md
@@ -85,6 +85,20 @@ cd my-project
 conda workspace install --locked
 ```
 
+## Extract and install in one step
+
+![archive install demo](../../demos/archives-install.gif)
+
+Pass `--install` to extract the archive and install all environments
+from the lockfile in a single command:
+
+```bash
+conda workspace unarchive my-project.tar.zst --target /path/to/destination --install
+```
+
+This is equivalent to extracting, changing into the directory, and
+running `conda workspace install --locked`, but without the extra steps.
+
 ## Lock before archiving
 
 If your lockfile is out of date or does not exist yet, pass `--lock`

--- a/docs/tutorials/archives.md
+++ b/docs/tutorials/archives.md
@@ -117,17 +117,31 @@ conda workspace unarchive my-project-offline.tar.zst --no-install
 ## Security
 
 Archives are extracted with path traversal protection. Every member is
-validated before extraction, and on Python 3.12+ the `filter="data"`
-parameter provides additional defense-in-depth.
+validated before extraction: absolute paths, `..` components, symlinks
+escaping the target directory, and special file types (device nodes,
+FIFOs) are all rejected. On Python 3.12+ the `filter="data"` parameter
+provides additional defense-in-depth.
 
-Unsigned archives produce a warning on extraction:
+When `--bundle` is used, package hashes are verified against the
+lockfile's SHA256 entries both at archive creation and at extraction.
+Packages without a SHA256 entry in the lockfile produce a warning and
+are not verified.
 
-```
-WARNING: Archive is not signed. Cannot verify origin or integrity.
-```
+### Trust model for bundled archives
 
-Review the manifest and lockfile before installing environments from
-an unsigned archive.
+A bundled archive is *self-consistent*: the package hashes match the
+lockfile that ships inside the archive. However, the lockfile itself is
+not externally signed. If the archive came from an untrusted source, the
+lockfile inside it could have been tampered with to match altered
+packages.
+
+To guard against this:
+
+- Obtain archives only from trusted sources.
+- When possible, compare the lockfile inside the archive against a
+  separately obtained copy (e.g. from version control).
+- Use `conda workspace install --locked` so the solver does not
+  silently add packages beyond what the lockfile specifies.
 
 ## Next steps
 

--- a/docs/tutorials/archives.md
+++ b/docs/tutorials/archives.md
@@ -1,0 +1,137 @@
+# Archives
+
+This tutorial walks through packaging a workspace into a portable
+archive and restoring it on another machine or in CI.
+
+## Prerequisites
+
+- conda (>= 24.7) with the conda-workspaces plugin installed
+- A workspace with a `conda.toml` and `conda.lock`
+
+## Create a workspace archive
+
+An archive bundles your manifest, lockfile, and source files into a
+single `.tar.gz` (or `.tar.zst`) file. In a git repo, only tracked
+files are included.
+
+```bash
+conda workspace archive -o my-project.tar.gz
+```
+
+The resulting file contains everything needed to reproduce the
+workspace elsewhere:
+
+```
+my-project.tar.gz
+  conda.toml
+  conda.lock
+  src/
+    app.py
+    ...
+```
+
+If no `-o` is given, the archive is named after the workspace
+(`<name>.tar.gz`) and placed in the project root.
+
+## Use zstandard compression
+
+For smaller archives, use a `.tar.zst` extension. conda-workspaces
+detects the format from the filename and compresses at level 19:
+
+```bash
+conda workspace archive -o my-project.tar.zst
+```
+
+## Exclude files
+
+Some files should not be included in archives. Configure permanent
+exclusions in your manifest:
+
+```toml
+[workspace.archive]
+exclude = ["docs/**", "*.log", "data/raw/**"]
+```
+
+Or pass one-off exclusions on the command line:
+
+```bash
+conda workspace archive --exclude "benchmarks/**" --exclude "*.csv"
+```
+
+Both sources are combined. Built-in exclusions (`.git`, `__pycache__`,
+`.conda/envs`, `.pixi`) always apply regardless of configuration.
+
+## Extract an archive
+
+On the receiving end, extract the archive with:
+
+```bash
+conda workspace unarchive my-project.tar.gz
+```
+
+This creates a `my-project/` directory (derived from the archive
+filename) containing the full workspace. To choose a different
+location:
+
+```bash
+conda workspace unarchive my-project.tar.gz --target /path/to/destination
+```
+
+After extraction, install the environments from the lockfile:
+
+```bash
+cd my-project
+conda workspace install --locked
+```
+
+## Bundle packages for offline use
+
+When the target machine has no internet access, use `--bundle` to
+include all resolved `.conda` packages inside the archive:
+
+```bash
+conda workspace archive --bundle -o my-project-offline.tar.gz
+```
+
+This adds a `packages/` directory inside the archive. Package hashes
+are verified against the lockfile before bundling.
+
+On the receiving end, `conda workspace unarchive` detects the bundled
+packages, verifies their hashes, and copies them into the local conda
+cache before installation:
+
+```bash
+conda workspace unarchive my-project-offline.tar.gz
+# packages are primed into the conda cache automatically
+cd my-project-offline
+conda workspace install --locked
+```
+
+Pass `--no-install` to skip cache priming if you only want the files:
+
+```bash
+conda workspace unarchive my-project-offline.tar.gz --no-install
+```
+
+## Security
+
+Archives are extracted with path traversal protection. Every member is
+validated before extraction, and on Python 3.12+ the `filter="data"`
+parameter provides additional defense-in-depth.
+
+Unsigned archives produce a warning on extraction:
+
+```
+WARNING: Archive is not signed. Cannot verify origin or integrity.
+```
+
+Review the manifest and lockfile before installing environments from
+an unsigned archive.
+
+## Next steps
+
+- [Configuration](../configuration.md#archive-configuration) for all
+  archive settings
+- [Features](../features.md#archives) for a feature overview
+- [CLI reference](../reference/cli.md) for the full `archive` and
+  `unarchive` command-line options

--- a/docs/tutorials/archives.md
+++ b/docs/tutorials/archives.md
@@ -99,6 +99,8 @@ This is equivalent to running `conda workspace lock` followed by
 
 ## Bundle packages for offline use
 
+![archive bundle demo](../../demos/archives-bundle.gif)
+
 When the target machine has no internet access, use `--bundle` to
 include all resolved `.conda` packages inside the archive.
 

--- a/docs/tutorials/archives.md
+++ b/docs/tutorials/archives.md
@@ -5,24 +5,24 @@ archive and restoring it on another machine or in CI.
 
 ## Prerequisites
 
-- conda (>= 24.7) with the conda-workspaces plugin installed
-- A workspace with a `conda.toml` and `conda.lock`
+- conda (>= 26.3) with the conda-workspaces plugin installed
+- A workspace with a manifest (`conda.toml`, `pixi.toml`, or `pyproject.toml`) and `conda.lock`
 
 ## Create a workspace archive
 
 An archive bundles your manifest, lockfile, and source files into a
-single `.tar.gz` (or `.tar.zst`) file. In a git repo, only tracked
+single `.tar.zst` (or `.tar.gz`) file. In a git repo, only tracked
 files are included.
 
 ```bash
-conda workspace archive -o my-project.tar.gz
+conda workspace archive -o my-project.tar.zst
 ```
 
 The resulting file contains everything needed to reproduce the
 workspace elsewhere:
 
 ```
-my-project.tar.gz
+my-project.tar.zst
   conda.toml
   conda.lock
   src/
@@ -31,15 +31,14 @@ my-project.tar.gz
 ```
 
 If no `-o` is given, the archive is named after the workspace
-(`<name>.tar.gz`) and placed in the project root.
+(`<name>.tar.zst`) and placed in the project root.
 
-## Use zstandard compression
+## Use gzip compression
 
-For smaller archives, use a `.tar.zst` extension. conda-workspaces
-detects the format from the filename and compresses at level 19:
+For broader compatibility, use a `.tar.gz` extension:
 
 ```bash
-conda workspace archive -o my-project.tar.zst
+conda workspace archive -o my-project.tar.gz
 ```
 
 ## Exclude files
@@ -66,7 +65,7 @@ Both sources are combined. Built-in exclusions (`.git`, `__pycache__`,
 On the receiving end, extract the archive with:
 
 ```bash
-conda workspace unarchive my-project.tar.gz
+conda workspace unarchive my-project.tar.zst
 ```
 
 This creates a `my-project/` directory (derived from the archive
@@ -74,7 +73,7 @@ filename) containing the full workspace. To choose a different
 location:
 
 ```bash
-conda workspace unarchive my-project.tar.gz --target /path/to/destination
+conda workspace unarchive my-project.tar.zst --target /path/to/destination
 ```
 
 After extraction, install the environments from the lockfile:
@@ -87,10 +86,12 @@ conda workspace install --locked
 ## Bundle packages for offline use
 
 When the target machine has no internet access, use `--bundle` to
-include all resolved `.conda` packages inside the archive:
+include all resolved `.conda` packages inside the archive.
+
+You need a lockfile first. Run `conda workspace lock` if you don't have one.
 
 ```bash
-conda workspace archive --bundle -o my-project-offline.tar.gz
+conda workspace archive --bundle -o my-project-offline.tar.zst
 ```
 
 This adds a `packages/` directory inside the archive. Package hashes
@@ -101,7 +102,7 @@ packages, verifies their hashes, and copies them into the local conda
 cache before installation:
 
 ```bash
-conda workspace unarchive my-project-offline.tar.gz
+conda workspace unarchive my-project-offline.tar.zst
 # packages are primed into the conda cache automatically
 cd my-project-offline
 conda workspace install --locked
@@ -110,7 +111,7 @@ conda workspace install --locked
 Pass `--no-install` to skip cache priming if you only want the files:
 
 ```bash
-conda workspace unarchive my-project-offline.tar.gz --no-install
+conda workspace unarchive my-project-offline.tar.zst --no-install
 ```
 
 ## Security

--- a/docs/tutorials/archives.md
+++ b/docs/tutorials/archives.md
@@ -1,5 +1,7 @@
 # Archives
 
+![archive demo](../../demos/archives.gif)
+
 This tutorial walks through packaging a workspace into a portable
 archive and restoring it on another machine or in CI.
 
@@ -21,7 +23,7 @@ conda workspace archive -o my-project.tar.zst
 The resulting file contains everything needed to reproduce the
 workspace elsewhere:
 
-```
+```text
 my-project.tar.zst
   conda.toml
   conda.lock
@@ -83,15 +85,28 @@ cd my-project
 conda workspace install --locked
 ```
 
+## Lock before archiving
+
+If your lockfile is out of date or does not exist yet, pass `--lock`
+to solve and write `conda.lock` before creating the archive:
+
+```bash
+conda workspace archive --lock
+```
+
+This is equivalent to running `conda workspace lock` followed by
+`conda workspace archive`, but in a single command.
+
 ## Bundle packages for offline use
 
 When the target machine has no internet access, use `--bundle` to
 include all resolved `.conda` packages inside the archive.
 
-You need a lockfile first. Run `conda workspace lock` if you don't have one.
+You need a lockfile first. Pass `--lock` to generate one automatically,
+or run `conda workspace lock` beforehand.
 
 ```bash
-conda workspace archive --bundle -o my-project-offline.tar.zst
+conda workspace archive --lock --bundle -o my-project-offline.tar.zst
 ```
 
 This adds a `packages/` directory inside the archive. Package hashes

--- a/docs/tutorials/coming-from/anaconda-project.md
+++ b/docs/tutorials/coming-from/anaconda-project.md
@@ -44,7 +44,7 @@ and interactive variable prompting have no direct equivalent.
 | Variables | `variables:` with prompting | Jinja2 templates + environment variables |
 | Downloads | `downloads:` (auto-fetched files) | not supported (use tasks instead) |
 | Services | `services:` (e.g. Redis) | not supported (use tasks or Docker instead) |
-| Archives | `anaconda-project archive` | not supported |
+| Archives | `anaconda-project archive` | `conda workspace archive` / `unarchive` |
 | Solver | conda | conda / libmamba |
 | pixi compatibility | no | reads `pixi.toml` and `pyproject.toml` |
 
@@ -263,7 +263,7 @@ your workspace.
 
 Some anaconda-project concepts have no direct equivalent:
 
-- `anaconda-project archive` — project archives are not supported
+- `anaconda-project archive` — see `conda workspace archive` ([tutorial](../archives.md))
 - Interactive variable prompting — use environment variables or
   Jinja2 defaults instead
 - `services:` — use tasks, Docker Compose, or external service

--- a/docs/tutorials/coming-from/anaconda-project.md
+++ b/docs/tutorials/coming-from/anaconda-project.md
@@ -263,7 +263,6 @@ your workspace.
 
 Some anaconda-project concepts have no direct equivalent:
 
-- `anaconda-project archive` — see `conda workspace archive` ([tutorial](../archives.md))
 - Interactive variable prompting — use environment variables or
   Jinja2 defaults instead
 - `services:` — use tasks, Docker Compose, or external service

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -44,4 +44,11 @@ Lock your workspace for Linux, macOS, and Windows from a single machine.
 Set up conda-workspaces in GitHub Actions.
 :::
 
+:::{grid-item-card} {octicon}`package` Archives
+:link: archives
+:link-type: doc
+
+Package a workspace into a portable archive and restore it elsewhere.
+:::
+
 ::::

--- a/pixi.lock
+++ b/pixi.lock
@@ -8608,6 +8608,7 @@ packages:
 - pypi: .
   name: conda-workspaces
   requires_dist:
+  - backports-zstd ; python_full_version < '3.14'
   - jinja2>=3.0
   - packaging>=21.0
   - platformdirs>=3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "platformdirs >=3.0",
   "rich >=13.0",
   "tomlkit >=0.13",
+  "backports.zstd; python_version < '3.14'",
 ]
 # TODO: bump conda-lockfiles to the first release that ships the public
 # `rattler_lock_v6_to_conda_env` + `RattlerLockV6` pydantic model (added

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -283,3 +283,17 @@ def test_task_parser_args(
     parser = generate_task_parser()
     parsed = parser.parse_args(args)
     assert getattr(parsed, expected_attr) == expected_value
+
+
+def test_archive_subparser_registered() -> None:
+    parser = generate_workspace_parser()
+    ns = parser.parse_args(["archive", "-o", "out.tar.gz"])
+    assert ns.subcmd == "archive"
+    assert str(ns.output) == "out.tar.gz"
+
+
+def test_unarchive_subparser_registered() -> None:
+    parser = generate_workspace_parser()
+    ns = parser.parse_args(["unarchive", "project.tar.gz"])
+    assert ns.subcmd == "unarchive"
+    assert str(ns.archive_path) == "project.tar.gz"

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -1,0 +1,179 @@
+"""Tests for conda workspace archive and unarchive."""
+
+from __future__ import annotations
+
+import tarfile
+from io import StringIO
+from typing import TYPE_CHECKING
+
+import pytest
+from rich.console import Console
+
+from conda_workspaces.cli.workspace.archive import execute_archive, execute_unarchive
+
+from ..conftest import make_args
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_ARCHIVE_DEFAULTS = {
+    "file": None,
+    "output": None,
+    "bundle": False,
+    "environment": None,
+    "exclude": None,
+    "dry_run": False,
+    "json": False,
+}
+
+_UNARCHIVE_DEFAULTS = {
+    "file": None,
+    "archive_path": None,
+    "target": None,
+    "install": False,
+    "no_install": False,
+    "dry_run": False,
+    "json": False,
+}
+
+
+@pytest.fixture
+def archive_workspace(tmp_path: Path) -> Path:
+    manifest = """\
+[workspace]
+name = "archive-test"
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-arm64"]
+
+[dependencies]
+python = ">=3.10"
+"""
+    (tmp_path / "conda.toml").write_text(manifest, encoding="utf-8")
+    (tmp_path / "conda.lock").write_text(
+        "version: 1\nenvironments:\n  default:\n    channels:\n"
+        "      - url: https://conda.anaconda.org/conda-forge/\n"
+        "    packages:\n      linux-64: []\n      osx-arm64: []\npackages: []\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('hello')\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_execute_archive_default(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    output = tmp_path / "out.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    args = make_args(_ARCHIVE_DEFAULTS, output=output)
+    result = execute_archive(args, console=console)
+
+    assert result == 0
+    assert output.is_file()
+    with tarfile.open(output, "r:gz") as tf:
+        names = tf.getnames()
+    assert "conda.toml" in names
+    assert "conda.lock" in names
+    assert "src/app.py" in names
+
+
+def test_execute_archive_no_output(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    args = make_args(_ARCHIVE_DEFAULTS)
+    result = execute_archive(args, console=console)
+
+    assert result == 0
+    expected = archive_workspace / "archive-test.tar.gz"
+    assert expected.is_file()
+
+
+def test_execute_archive_exclude(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    output = tmp_path / "out.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    args = make_args(_ARCHIVE_DEFAULTS, output=output, exclude=["src/**"])
+    result = execute_archive(args, console=console)
+
+    assert result == 0
+    with tarfile.open(output, "r:gz") as tf:
+        names = tf.getnames()
+    assert "conda.toml" in names
+    assert "src/app.py" not in names
+
+
+def test_execute_unarchive_basic(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    args_a = make_args(_ARCHIVE_DEFAULTS, output=archive)
+    execute_archive(args_a, console=console)
+
+    target = tmp_path / "extracted"
+    args_u = make_args(_UNARCHIVE_DEFAULTS, archive_path=archive, target=target)
+    result = execute_unarchive(args_u, console=console)
+
+    assert result == 0
+    assert (target / "conda.toml").is_file()
+    assert (target / "conda.lock").is_file()
+    assert (target / "src" / "app.py").is_file()
+
+
+def test_execute_unarchive_default_target(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    archive = tmp_path / "my-project.tar.gz"
+
+    monkeypatch.chdir(archive_workspace)
+    console = Console(file=StringIO(), width=200, highlight=False)
+    args_a = make_args(_ARCHIVE_DEFAULTS, output=archive)
+    execute_archive(args_a, console=console)
+    monkeypatch.chdir(tmp_path)
+
+    args_u = make_args(_UNARCHIVE_DEFAULTS, archive_path=archive, target=None)
+    result = execute_unarchive(args_u, console=console)
+
+    assert result == 0
+    assert (tmp_path / "my-project" / "conda.toml").is_file()
+
+
+def test_execute_unarchive_no_install_by_default(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    args_a = make_args(_ARCHIVE_DEFAULTS, output=archive)
+    execute_archive(args_a, console=console)
+
+    target = tmp_path / "extracted"
+    args_u = make_args(_UNARCHIVE_DEFAULTS, archive_path=archive, target=target)
+    result = execute_unarchive(args_u, console=console)
+
+    assert result == 0
+    output = console.file.getvalue()
+    assert "not signed" in output.lower() or "unsigned" in output.lower() or "WARNING" in output

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -20,6 +20,7 @@ _ARCHIVE_DEFAULTS = {
     "file": None,
     "output": None,
     "bundle": False,
+    "lock": False,
     "exclude": None,
     "dry_run": False,
     "json": False,

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -20,7 +20,6 @@ _ARCHIVE_DEFAULTS = {
     "file": None,
     "output": None,
     "bundle": False,
-    "environment": None,
     "exclude": None,
     "dry_run": False,
     "json": False,
@@ -157,7 +156,7 @@ def test_execute_unarchive_default_target(
     assert (tmp_path / "my-project" / "conda.toml").is_file()
 
 
-def test_execute_unarchive_no_install_by_default(
+def test_execute_unarchive_no_unsigned_warning(
     archive_workspace: Path,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -176,4 +175,5 @@ def test_execute_unarchive_no_install_by_default(
     assert result == 0
     output = console.file.getvalue()
     lower = output.lower()
-    assert "not signed" in lower or "unsigned" in lower or "WARNING" in output
+    assert "not signed" not in lower
+    assert "unsigned" not in lower

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -30,6 +30,7 @@ _UNARCHIVE_DEFAULTS = {
     "file": None,
     "archive_path": None,
     "target": None,
+    "install": False,
     "no_install": False,
     "dry_run": False,
     "json": False,

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -176,4 +176,5 @@ def test_execute_unarchive_no_install_by_default(
 
     assert result == 0
     output = console.file.getvalue()
-    assert "not signed" in output.lower() or "unsigned" in output.lower() or "WARNING" in output
+    lower = output.lower()
+    assert "not signed" in lower or "unsigned" in lower or "WARNING" in output

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -91,7 +91,7 @@ def test_execute_archive_no_output(
     result = execute_archive(args, console=console)
 
     assert result == 0
-    expected = archive_workspace / "archive-test.tar.gz"
+    expected = archive_workspace / "archive-test.tar.zst"
     assert expected.is_file()
 
 

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -30,7 +30,6 @@ _UNARCHIVE_DEFAULTS = {
     "file": None,
     "archive_path": None,
     "target": None,
-    "install": False,
     "no_install": False,
     "dry_run": False,
     "json": False,

--- a/tests/manifests/test_pixi_toml.py
+++ b/tests/manifests/test_pixi_toml.py
@@ -282,3 +282,44 @@ cuda = ["gpu"]
         assert type(feat_name) is str, type(feat_name).__name__
         for platform in feature.platforms:
             assert type(platform) is str, type(platform).__name__
+
+
+def test_parse_workspace_archive_exclude(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "pixi.toml").write_text(
+        '[workspace]\nname = "test"\nchannels = ["conda-forge"]\n'
+        'platforms = ["linux-64"]\n\n'
+        '[workspace.archive]\nexclude = ["data/**", "*.bin"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    from conda_workspaces.manifests import detect_and_parse
+
+    _, config = detect_and_parse()
+    assert config.archive.exclude == ("data/**", "*.bin")
+
+
+def test_parse_workspace_archive_defaults(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "pixi.toml").write_text(
+        '[workspace]\nname = "test"\nchannels = ["conda-forge"]\n'
+        'platforms = ["linux-64"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    from conda_workspaces.manifests import detect_and_parse
+
+    _, config = detect_and_parse()
+    assert config.archive.exclude == ()
+
+
+def test_parse_conda_toml_archive_exclude(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "conda.toml").write_text(
+        '[workspace]\nname = "test"\nchannels = ["conda-forge"]\n'
+        'platforms = ["linux-64"]\n\n'
+        '[workspace.archive]\nexclude = ["data/**"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    from conda_workspaces.manifests import detect_and_parse
+
+    _, config = detect_and_parse()
+    assert config.archive.exclude == ("data/**",)

--- a/tests/manifests/test_pixi_toml.py
+++ b/tests/manifests/test_pixi_toml.py
@@ -308,7 +308,31 @@ def test_parse_workspace_archive_defaults(tmp_path: Path, monkeypatch) -> None:
     from conda_workspaces.manifests import detect_and_parse
 
     _, config = detect_and_parse()
+    assert config.archive.include == ()
     assert config.archive.exclude == ()
+    assert config.archive.compression == "zst"
+    assert config.archive.compression_level is None
+
+
+def test_parse_workspace_archive_all_fields(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "pixi.toml").write_text(
+        '[workspace]\nname = "test"\nchannels = ["conda-forge"]\n'
+        'platforms = ["linux-64"]\n\n'
+        "[workspace.archive]\n"
+        'include = ["src/**", "conda.toml"]\n'
+        'exclude = ["data/**"]\n'
+        'compression = "gz"\n'
+        "compression-level = 6\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    from conda_workspaces.manifests import detect_and_parse
+
+    _, config = detect_and_parse()
+    assert config.archive.include == ("src/**", "conda.toml")
+    assert config.archive.exclude == ("data/**",)
+    assert config.archive.compression == "gz"
+    assert config.archive.compression_level == 6
 
 
 def test_parse_conda_toml_archive_exclude(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -410,3 +410,49 @@ packages:
 
     with pytest.raises(ArchiveHashMismatchError, match="bad-1.0-h000"):
         prime_package_cache(extracted, cache_dir)
+
+
+# ---------------------------------------------------------------------------
+# Task 8: archive inspection helper
+# ---------------------------------------------------------------------------
+
+from conda_workspaces.archive import inspect_archive
+
+
+def test_inspect_archive_lightweight(project_dir: Path, tmp_path: Path) -> None:
+    output = tmp_path / "test.tar.gz"
+    config = ArchiveConfig()
+    create_archive(project_dir, output, config)
+
+    info = inspect_archive(output)
+    assert info["has_manifest"] is True
+    assert info["has_lockfile"] is True
+    assert info["has_packages"] is False
+    assert info["has_attestation"] is False
+
+
+def test_inspect_archive_bundled(lockfile_with_packages: Path, tmp_path: Path) -> None:
+    cache_dir = lockfile_with_packages / "pkg_cache"
+    lockfile = lockfile_with_packages / "conda.lock"
+    packages = collect_bundle_packages(lockfile, [cache_dir])
+
+    output = tmp_path / "bundled.tar.gz"
+    config = ArchiveConfig()
+    create_archive(lockfile_with_packages, output, config, bundle_packages=packages)
+
+    info = inspect_archive(output)
+    assert info["has_manifest"] is True
+    assert info["has_lockfile"] is True
+    assert info["has_packages"] is True
+    assert info["package_count"] == 2
+
+
+def test_inspect_archive_not_workspace(tmp_path: Path) -> None:
+    archive = tmp_path / "random.tar.gz"
+    with tarfile.open(archive, "w:gz") as tf:
+        info = tarfile.TarInfo(name="readme.txt")
+        info.size = 5
+        tf.addfile(info, io.BytesIO(b"hello"))
+
+    result = inspect_archive(archive)
+    assert result["has_manifest"] is False

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -119,18 +119,14 @@ packages:
 
 
 @pytest.fixture
-def bundled_archive(
-    lockfile_with_packages: Path, tmp_path: Path
-) -> tuple[Path, Path]:
+def bundled_archive(lockfile_with_packages: Path, tmp_path: Path) -> tuple[Path, Path]:
     """Create a bundled archive from lockfile_with_packages, return (archive, root)."""
     cache_dir = lockfile_with_packages / "pkg_cache"
     lockfile = lockfile_with_packages / "conda.lock"
     packages = collect_bundle_packages(lockfile, [cache_dir])
     output = tmp_path / "bundled.tar.gz"
     config = ArchiveConfig()
-    create_archive(
-        lockfile_with_packages, output, config, bundle_packages=packages
-    )
+    create_archive(lockfile_with_packages, output, config, bundle_packages=packages)
     return output, lockfile_with_packages
 
 
@@ -183,9 +179,7 @@ def test_collect_files_custom_exclude(project_dir: Path) -> None:
 
 
 @pytest.mark.parametrize("suffix", [".tar.gz", ".tar.zst"])
-def test_create_archive(
-    project_dir: Path, tmp_path: Path, suffix: str
-) -> None:
+def test_create_archive(project_dir: Path, tmp_path: Path, suffix: str) -> None:
     output = tmp_path / "out" / f"project{suffix}"
     config = ArchiveConfig()
     create_archive(project_dir, output, config)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -146,3 +146,76 @@ def test_create_archive_output_dir_created(project_dir: Path, tmp_path: Path) ->
     config = ArchiveConfig()
     create_archive(project_dir, output, config)
     assert output.is_file()
+
+
+# ---------------------------------------------------------------------------
+# Task 5: safe extraction with path traversal protection
+# ---------------------------------------------------------------------------
+
+from conda_workspaces.archive import extract_archive
+from conda_workspaces.exceptions import ArchivePathTraversalError
+
+
+def test_extract_archive_basic(project_dir: Path, tmp_path: Path) -> None:
+    archive_path = tmp_path / "test.tar.gz"
+    config = ArchiveConfig()
+    create_archive(project_dir, archive_path, config)
+
+    target = tmp_path / "extracted"
+    result = extract_archive(archive_path, target)
+
+    assert result == target
+    assert (target / "conda.toml").is_file()
+    assert (target / "conda.lock").is_file()
+    assert (target / "src" / "main.py").is_file()
+
+
+def test_extract_archive_path_traversal_blocked(tmp_path: Path) -> None:
+    evil_archive = tmp_path / "evil.tar.gz"
+    with tarfile.open(evil_archive, "w:gz") as tf:
+        info = tarfile.TarInfo(name="../../../etc/passwd")
+        info.size = 4
+        tf.addfile(info, io.BytesIO(b"evil"))
+
+    target = tmp_path / "safe"
+    with pytest.raises(ArchivePathTraversalError, match="etc/passwd"):
+        extract_archive(evil_archive, target)
+
+    assert not (target / "etc" / "passwd").exists()
+
+
+def test_extract_archive_absolute_path_blocked(tmp_path: Path) -> None:
+    evil_archive = tmp_path / "abs.tar.gz"
+    with tarfile.open(evil_archive, "w:gz") as tf:
+        info = tarfile.TarInfo(name="/tmp/evil_file")
+        info.size = 4
+        tf.addfile(info, io.BytesIO(b"evil"))
+
+    target = tmp_path / "safe"
+    with pytest.raises(ArchivePathTraversalError):
+        extract_archive(evil_archive, target)
+
+
+def test_extract_archive_symlink_escape_blocked(tmp_path: Path) -> None:
+    evil_archive = tmp_path / "symlink.tar.gz"
+    with tarfile.open(evil_archive, "w:gz") as tf:
+        info = tarfile.TarInfo(name="escape")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "../../../etc"
+        tf.addfile(info)
+
+    target = tmp_path / "safe"
+    with pytest.raises(ArchivePathTraversalError):
+        extract_archive(evil_archive, target)
+
+
+def test_extract_archive_zst(project_dir: Path, tmp_path: Path) -> None:
+    archive_path = tmp_path / "test.tar.zst"
+    config = ArchiveConfig()
+    create_archive(project_dir, archive_path, config)
+
+    target = tmp_path / "extracted"
+    extract_archive(archive_path, target)
+
+    assert (target / "conda.toml").is_file()
+    assert (target / "src" / "main.py").is_file()

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -18,6 +18,7 @@ from conda_workspaces.archive import (
     verify_package_hashes,
 )
 from conda_workspaces.exceptions import (
+    ArchiveError,
     ArchiveHashMismatchError,
     ArchivePathTraversalError,
 )
@@ -273,6 +274,16 @@ def test_extract_archive_zst(project_dir: Path, tmp_path: Path) -> None:
 
     assert (target / "conda.toml").is_file()
     assert (target / "src" / "main.py").is_file()
+
+
+def test_collect_bundle_packages_missing(
+    lockfile_with_packages: Path,
+) -> None:
+    empty_cache = lockfile_with_packages / "empty_cache"
+    empty_cache.mkdir()
+    lockfile = lockfile_with_packages / "conda.lock"
+    with pytest.raises(ArchiveError, match="not found in cache"):
+        collect_bundle_packages(lockfile, [empty_cache])
 
 
 def test_collect_bundle_packages(lockfile_with_packages: Path) -> None:

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -170,6 +170,23 @@ def test_collect_files_builtin_exclusions(project_dir: Path) -> None:
     assert not any(p.startswith(".pixi/") for p in rel_strs)
 
 
+def test_collect_files_include_filter(project_dir: Path) -> None:
+    config = ArchiveConfig(include=("src/**",))
+    files = collect_archive_files(project_dir, config)
+    rel_paths = {f.relative_to(project_dir).as_posix() for f in files}
+    assert "src/main.py" in rel_paths
+    assert "conda.toml" not in rel_paths
+
+
+def test_collect_files_include_and_exclude(project_dir: Path) -> None:
+    """Include narrows, then exclude removes from that set."""
+    config = ArchiveConfig(include=("src/**", "conda.toml"), exclude=("src/main.py",))
+    files = collect_archive_files(project_dir, config)
+    rel_paths = {f.relative_to(project_dir).as_posix() for f in files}
+    assert "conda.toml" in rel_paths
+    assert "src/main.py" not in rel_paths
+
+
 def test_collect_files_custom_exclude(project_dir: Path) -> None:
     config = ArchiveConfig(exclude=("data/**",))
     files = collect_archive_files(project_dir, config)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -219,3 +219,103 @@ def test_extract_archive_zst(project_dir: Path, tmp_path: Path) -> None:
 
     assert (target / "conda.toml").is_file()
     assert (target / "src" / "main.py").is_file()
+
+
+# ---------------------------------------------------------------------------
+# Task 6: package bundling and hash verification
+# ---------------------------------------------------------------------------
+
+import hashlib
+
+from conda_workspaces.archive import (
+    collect_bundle_packages,
+    verify_package_hashes,
+)
+from conda_workspaces.exceptions import ArchiveHashMismatchError
+
+
+@pytest.fixture
+def lockfile_with_packages(project_dir: Path) -> Path:
+    """Create a conda.lock with fake package entries and matching .conda files."""
+    pkg_content = b"fake conda package data"
+    sha256 = hashlib.sha256(pkg_content).hexdigest()
+
+    lockfile_content = f"""\
+version: 1
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h4dc568a_6.conda
+      osx-arm64:
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_6.conda
+packages:
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h4dc568a_6.conda
+    sha256: {sha256}
+    md5: abc123
+    name: zlib
+    version: 1.2.13
+    build: h4dc568a_6
+    subdir: linux-64
+    depends: []
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_6.conda
+    sha256: {sha256}
+    md5: def456
+    name: zlib
+    version: 1.2.13
+    build: h53f4e23_6
+    subdir: osx-arm64
+    depends: []
+"""
+    (project_dir / "conda.lock").write_text(lockfile_content, encoding="utf-8")
+
+    cache_dir = project_dir / "pkg_cache"
+    cache_dir.mkdir()
+    (cache_dir / "zlib-1.2.13-h4dc568a_6.conda").write_bytes(pkg_content)
+    (cache_dir / "zlib-1.2.13-h53f4e23_6.conda").write_bytes(pkg_content)
+
+    return project_dir
+
+
+def test_collect_bundle_packages(lockfile_with_packages: Path) -> None:
+    cache_dir = lockfile_with_packages / "pkg_cache"
+    lockfile = lockfile_with_packages / "conda.lock"
+    packages = collect_bundle_packages(lockfile, [cache_dir])
+    assert len(packages) == 2
+    filenames = {p.name for p in packages}
+    assert "zlib-1.2.13-h4dc568a_6.conda" in filenames
+    assert "zlib-1.2.13-h53f4e23_6.conda" in filenames
+
+
+def test_verify_package_hashes_pass(lockfile_with_packages: Path) -> None:
+    cache_dir = lockfile_with_packages / "pkg_cache"
+    lockfile = lockfile_with_packages / "conda.lock"
+    packages = collect_bundle_packages(lockfile, [cache_dir])
+    verify_package_hashes(packages, lockfile)
+
+
+def test_verify_package_hashes_fail(lockfile_with_packages: Path) -> None:
+    cache_dir = lockfile_with_packages / "pkg_cache"
+    lockfile = lockfile_with_packages / "conda.lock"
+    (cache_dir / "zlib-1.2.13-h4dc568a_6.conda").write_bytes(b"tampered")
+    packages = collect_bundle_packages(lockfile, [cache_dir])
+    with pytest.raises(ArchiveHashMismatchError, match="zlib-1.2.13-h4dc568a_6"):
+        verify_package_hashes(packages, lockfile)
+
+
+def test_create_archive_with_bundle(lockfile_with_packages: Path, tmp_path: Path) -> None:
+    cache_dir = lockfile_with_packages / "pkg_cache"
+    lockfile = lockfile_with_packages / "conda.lock"
+    packages = collect_bundle_packages(lockfile, [cache_dir])
+
+    output = tmp_path / "bundled.tar.gz"
+    config = ArchiveConfig()
+    create_archive(lockfile_with_packages, output, config, bundle_packages=packages)
+
+    with tarfile.open(output, "r:gz") as tf:
+        names = tf.getnames()
+    assert "packages/zlib-1.2.13-h4dc568a_6.conda" in names
+    assert "packages/zlib-1.2.13-h53f4e23_6.conda" in names
+    assert "conda.toml" in names

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -423,7 +423,6 @@ def test_inspect_archive_lightweight(project_dir: Path, tmp_path: Path) -> None:
     assert info["has_manifest"] is True
     assert info["has_lockfile"] is True
     assert info["has_packages"] is False
-    assert info["has_attestation"] is False
 
 
 def test_inspect_archive_bundled(bundled_archive: tuple[Path, Path]) -> None:

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import io
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from conda_workspaces.archive import collect_archive_files
+from conda_workspaces.models import ArchiveConfig
+
+
+@pytest.fixture
+def project_dir(tmp_path: Path) -> Path:
+    """Create a minimal project directory with various files."""
+    (tmp_path / "conda.toml").write_text("[workspace]\nname = 'test'\n")
+    (tmp_path / "conda.lock").write_text("version: 1\n")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("print('hello')\n")
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "big.bin").write_text("binary data\n")
+    (tmp_path / ".env").write_text("SECRET=abc\n")
+    return tmp_path
+
+
+@pytest.fixture
+def git_project(project_dir: Path) -> Path:
+    """Initialize a git repo and track some files."""
+    subprocess.run(["git", "init"], cwd=project_dir, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=project_dir, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=project_dir, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "add", "conda.toml", "conda.lock", "src/main.py"],
+        cwd=project_dir, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=project_dir, check=True, capture_output=True,
+    )
+    return project_dir
+
+
+def test_collect_files_git_tracked(git_project: Path) -> None:
+    config = ArchiveConfig()
+    files = collect_archive_files(git_project, config)
+    rel_paths = {str(f.relative_to(git_project)) for f in files}
+    assert "conda.toml" in rel_paths
+    assert "conda.lock" in rel_paths
+    assert "src/main.py" in rel_paths
+    assert ".env" not in rel_paths
+    assert "data/big.bin" not in rel_paths
+
+
+def test_collect_files_non_git(project_dir: Path) -> None:
+    config = ArchiveConfig()
+    files = collect_archive_files(project_dir, config)
+    rel_paths = {str(f.relative_to(project_dir)) for f in files}
+    assert "conda.toml" in rel_paths
+    assert "src/main.py" in rel_paths
+    assert "data/big.bin" in rel_paths
+    assert ".env" in rel_paths
+
+
+def test_collect_files_builtin_exclusions(project_dir: Path) -> None:
+    (project_dir / ".git").mkdir()
+    (project_dir / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+    (project_dir / ".conda").mkdir()
+    (project_dir / ".conda" / "envs").mkdir()
+    (project_dir / ".conda" / "envs" / "default").mkdir()
+    (project_dir / ".conda" / "envs" / "default" / "marker").write_text("")
+    (project_dir / ".pixi").mkdir()
+    (project_dir / ".pixi" / "envs").mkdir()
+
+    config = ArchiveConfig()
+    files = collect_archive_files(project_dir, config)
+    rel_strs = {str(f.relative_to(project_dir)) for f in files}
+
+    assert not any(p.startswith(".git/") or p == ".git" for p in rel_strs)
+    assert not any(p.startswith(".conda/envs") for p in rel_strs)
+    assert not any(p.startswith(".pixi/") for p in rel_strs)
+
+
+def test_collect_files_custom_exclude(project_dir: Path) -> None:
+    config = ArchiveConfig(exclude=("data/**",))
+    files = collect_archive_files(project_dir, config)
+    rel_paths = {str(f.relative_to(project_dir)) for f in files}
+    assert "data/big.bin" not in rel_paths
+    assert "conda.toml" in rel_paths

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -319,3 +319,94 @@ def test_create_archive_with_bundle(lockfile_with_packages: Path, tmp_path: Path
     assert "packages/zlib-1.2.13-h4dc568a_6.conda" in names
     assert "packages/zlib-1.2.13-h53f4e23_6.conda" in names
     assert "conda.toml" in names
+
+
+# ---------------------------------------------------------------------------
+# Task 7: cache priming
+# ---------------------------------------------------------------------------
+
+from conda_workspaces.archive import prime_package_cache
+
+
+def test_prime_package_cache(tmp_path: Path) -> None:
+    pkg_content = b"fake package content"
+    sha256 = hashlib.sha256(pkg_content).hexdigest()
+
+    extracted = tmp_path / "project"
+    extracted.mkdir()
+    (extracted / "packages").mkdir()
+    (extracted / "packages" / "numpy-1.26-h1234.conda").write_bytes(pkg_content)
+
+    lockfile_content = f"""\
+version: 1
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26-h1234.conda
+packages:
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26-h1234.conda
+    sha256: {sha256}
+    name: numpy
+    version: "1.26"
+    build: h1234
+    subdir: linux-64
+    depends: []
+"""
+    (extracted / "conda.lock").write_text(lockfile_content, encoding="utf-8")
+
+    cache_dir = tmp_path / "pkgs"
+    cache_dir.mkdir()
+
+    count = prime_package_cache(extracted, cache_dir)
+
+    assert count == 1
+    assert (cache_dir / "numpy-1.26-h1234.conda").is_file()
+    assert (cache_dir / "numpy-1.26-h1234.conda").read_bytes() == pkg_content
+
+
+def test_prime_package_cache_no_packages(tmp_path: Path) -> None:
+    extracted = tmp_path / "project"
+    extracted.mkdir()
+    (extracted / "conda.lock").write_text("version: 1\nenvironments: {}\npackages: []\n")
+
+    cache_dir = tmp_path / "pkgs"
+    cache_dir.mkdir()
+
+    count = prime_package_cache(extracted, cache_dir)
+    assert count == 0
+
+
+def test_prime_package_cache_hash_mismatch(tmp_path: Path) -> None:
+    extracted = tmp_path / "project"
+    extracted.mkdir()
+    (extracted / "packages").mkdir()
+    (extracted / "packages" / "bad-1.0-h000.conda").write_bytes(b"tampered")
+
+    lockfile_content = """\
+version: 1
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/bad-1.0-h000.conda
+packages:
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/bad-1.0-h000.conda
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+    name: bad
+    version: "1.0"
+    build: h000
+    subdir: linux-64
+    depends: []
+"""
+    (extracted / "conda.lock").write_text(lockfile_content, encoding="utf-8")
+
+    cache_dir = tmp_path / "pkgs"
+    cache_dir.mkdir()
+
+    with pytest.raises(ArchiveHashMismatchError, match="bad-1.0-h000"):
+        prime_package_cache(extracted, cache_dir)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -14,6 +14,7 @@ from conda_workspaces.archive import (
     create_archive,
     extract_archive,
     inspect_archive,
+    open_tar,
     prime_package_cache,
     verify_package_hashes,
 )
@@ -117,6 +118,22 @@ packages:
     return project_dir
 
 
+@pytest.fixture
+def bundled_archive(
+    lockfile_with_packages: Path, tmp_path: Path
+) -> tuple[Path, Path]:
+    """Create a bundled archive from lockfile_with_packages, return (archive, root)."""
+    cache_dir = lockfile_with_packages / "pkg_cache"
+    lockfile = lockfile_with_packages / "conda.lock"
+    packages = collect_bundle_packages(lockfile, [cache_dir])
+    output = tmp_path / "bundled.tar.gz"
+    config = ArchiveConfig()
+    create_archive(
+        lockfile_with_packages, output, config, bundle_packages=packages
+    )
+    return output, lockfile_with_packages
+
+
 def test_collect_files_git_tracked(git_project: Path) -> None:
     config = ArchiveConfig()
     files = collect_archive_files(git_project, config)
@@ -165,33 +182,20 @@ def test_collect_files_custom_exclude(project_dir: Path) -> None:
     assert "conda.toml" in rel_paths
 
 
-def test_create_archive_tar_gz(project_dir: Path, tmp_path: Path) -> None:
-    output = tmp_path / "out" / "project.tar.gz"
+@pytest.mark.parametrize("suffix", [".tar.gz", ".tar.zst"])
+def test_create_archive(
+    project_dir: Path, tmp_path: Path, suffix: str
+) -> None:
+    output = tmp_path / "out" / f"project{suffix}"
     config = ArchiveConfig()
     create_archive(project_dir, output, config)
 
     assert output.is_file()
-    with tarfile.open(output, "r:gz") as tf:
+    with open_tar(output) as tf:
         names = tf.getnames()
     assert "conda.toml" in names
     assert "conda.lock" in names
     assert "src/main.py" in names
-
-
-def test_create_archive_tar_zst(project_dir: Path, tmp_path: Path) -> None:
-    output = tmp_path / "out" / "project.tar.zst"
-    config = ArchiveConfig()
-    create_archive(project_dir, output, config)
-
-    assert output.is_file()
-    import zstandard
-
-    dctx = zstandard.ZstdDecompressor()
-    with open(output, "rb") as fh:
-        decompressed = dctx.decompress(fh.read())
-    with tarfile.open(fileobj=io.BytesIO(decompressed), mode="r:") as tf:
-        names = tf.getnames()
-    assert "conda.toml" in names
 
 
 def test_create_archive_excludes_self(project_dir: Path) -> None:
@@ -225,39 +229,29 @@ def test_extract_archive_basic(project_dir: Path, tmp_path: Path) -> None:
     assert (target / "src" / "main.py").is_file()
 
 
-def test_extract_archive_path_traversal_blocked(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("name", "link_type", "linkname"),
+    [
+        pytest.param("../../../etc/passwd", None, None, id="dotdot-traversal"),
+        pytest.param("/tmp/evil_file", None, None, id="absolute-path"),
+        pytest.param("escape", tarfile.SYMTYPE, "../../../etc", id="symlink-escape"),
+    ],
+)
+def test_extract_archive_path_traversal_blocked(
+    tmp_path: Path,
+    name: str,
+    link_type: int | None,
+    linkname: str | None,
+) -> None:
     evil_archive = tmp_path / "evil.tar.gz"
     with tarfile.open(evil_archive, "w:gz") as tf:
-        info = tarfile.TarInfo(name="../../../etc/passwd")
-        info.size = 4
-        tf.addfile(info, io.BytesIO(b"evil"))
-
-    target = tmp_path / "safe"
-    with pytest.raises(ArchivePathTraversalError, match="etc/passwd"):
-        extract_archive(evil_archive, target)
-
-    assert not (target / "etc" / "passwd").exists()
-
-
-def test_extract_archive_absolute_path_blocked(tmp_path: Path) -> None:
-    evil_archive = tmp_path / "abs.tar.gz"
-    with tarfile.open(evil_archive, "w:gz") as tf:
-        info = tarfile.TarInfo(name="/tmp/evil_file")
-        info.size = 4
-        tf.addfile(info, io.BytesIO(b"evil"))
-
-    target = tmp_path / "safe"
-    with pytest.raises(ArchivePathTraversalError):
-        extract_archive(evil_archive, target)
-
-
-def test_extract_archive_symlink_escape_blocked(tmp_path: Path) -> None:
-    evil_archive = tmp_path / "symlink.tar.gz"
-    with tarfile.open(evil_archive, "w:gz") as tf:
-        info = tarfile.TarInfo(name="escape")
-        info.type = tarfile.SYMTYPE
-        info.linkname = "../../../etc"
-        tf.addfile(info)
+        info = tarfile.TarInfo(name=name)
+        if link_type is not None:
+            info.type = link_type
+            info.linkname = linkname
+        else:
+            info.size = 4
+        tf.addfile(info, io.BytesIO(b"evil") if info.size else None)
 
     target = tmp_path / "safe"
     with pytest.raises(ArchivePathTraversalError):
@@ -313,17 +307,9 @@ def test_verify_package_hashes_fail(lockfile_with_packages: Path) -> None:
 
 
 def test_create_archive_with_bundle(
-    lockfile_with_packages: Path,
-    tmp_path: Path,
+    bundled_archive: tuple[Path, Path],
 ) -> None:
-    cache_dir = lockfile_with_packages / "pkg_cache"
-    lockfile = lockfile_with_packages / "conda.lock"
-    packages = collect_bundle_packages(lockfile, [cache_dir])
-
-    output = tmp_path / "bundled.tar.gz"
-    config = ArchiveConfig()
-    create_archive(lockfile_with_packages, output, config, bundle_packages=packages)
-
+    output, _ = bundled_archive
     with tarfile.open(output, "r:gz") as tf:
         names = tf.getnames()
     assert "packages/zlib-1.2.13-h4dc568a_6.conda" in names
@@ -429,15 +415,8 @@ def test_inspect_archive_lightweight(project_dir: Path, tmp_path: Path) -> None:
     assert info["has_attestation"] is False
 
 
-def test_inspect_archive_bundled(lockfile_with_packages: Path, tmp_path: Path) -> None:
-    cache_dir = lockfile_with_packages / "pkg_cache"
-    lockfile = lockfile_with_packages / "conda.lock"
-    packages = collect_bundle_packages(lockfile, [cache_dir])
-
-    output = tmp_path / "bundled.tar.gz"
-    config = ArchiveConfig()
-    create_archive(lockfile_with_packages, output, config, bundle_packages=packages)
-
+def test_inspect_archive_bundled(bundled_archive: tuple[Path, Path]) -> None:
+    output, _ = bundled_archive
     info = inspect_archive(output)
     assert info["has_manifest"] is True
     assert info["has_lockfile"] is True
@@ -480,22 +459,11 @@ def test_archive_roundtrip(git_project: Path, tmp_path: Path) -> None:
 
 
 def test_archive_roundtrip_with_bundle(
-    lockfile_with_packages: Path,
+    bundled_archive: tuple[Path, Path],
     tmp_path: Path,
 ) -> None:
     """Round-trip with bundled packages: archive, extract, prime cache."""
-    cache_dir = lockfile_with_packages / "pkg_cache"
-    lockfile = lockfile_with_packages / "conda.lock"
-    packages = collect_bundle_packages(lockfile, [cache_dir])
-
-    archive_path = tmp_path / "bundled.tar.gz"
-    config = ArchiveConfig()
-    create_archive(
-        lockfile_with_packages,
-        archive_path,
-        config,
-        bundle_packages=packages,
-    )
+    archive_path, _ = bundled_archive
 
     target = tmp_path / "extracted"
     extract_archive(archive_path, target)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -93,3 +93,56 @@ def test_collect_files_custom_exclude(project_dir: Path) -> None:
     rel_paths = {str(f.relative_to(project_dir)) for f in files}
     assert "data/big.bin" not in rel_paths
     assert "conda.toml" in rel_paths
+
+
+# ---------------------------------------------------------------------------
+# Task 4: tarball creation
+# ---------------------------------------------------------------------------
+
+from conda_workspaces.archive import create_archive
+
+
+def test_create_archive_tar_gz(project_dir: Path, tmp_path: Path) -> None:
+    output = tmp_path / "out" / "project.tar.gz"
+    config = ArchiveConfig()
+    create_archive(project_dir, output, config)
+
+    assert output.is_file()
+    with tarfile.open(output, "r:gz") as tf:
+        names = tf.getnames()
+    assert "conda.toml" in names
+    assert "conda.lock" in names
+    assert "src/main.py" in names
+
+
+def test_create_archive_tar_zst(project_dir: Path, tmp_path: Path) -> None:
+    output = tmp_path / "out" / "project.tar.zst"
+    config = ArchiveConfig()
+    create_archive(project_dir, output, config)
+
+    assert output.is_file()
+    import zstandard
+
+    dctx = zstandard.ZstdDecompressor()
+    with open(output, "rb") as fh:
+        decompressed = dctx.decompress(fh.read())
+    with tarfile.open(fileobj=io.BytesIO(decompressed), mode="r:") as tf:
+        names = tf.getnames()
+    assert "conda.toml" in names
+
+
+def test_create_archive_excludes_self(project_dir: Path) -> None:
+    output = project_dir / "project.tar.gz"
+    config = ArchiveConfig()
+    create_archive(project_dir, output, config)
+
+    with tarfile.open(output, "r:gz") as tf:
+        names = tf.getnames()
+    assert "project.tar.gz" not in names
+
+
+def test_create_archive_output_dir_created(project_dir: Path, tmp_path: Path) -> None:
+    output = tmp_path / "deep" / "nested" / "archive.tar.gz"
+    config = ArchiveConfig()
+    create_archive(project_dir, output, config)
+    assert output.is_file()

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,14 +1,30 @@
 from __future__ import annotations
 
+import hashlib
 import io
 import subprocess
 import tarfile
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
-from conda_workspaces.archive import collect_archive_files
+from conda_workspaces.archive import (
+    collect_archive_files,
+    collect_bundle_packages,
+    create_archive,
+    extract_archive,
+    inspect_archive,
+    prime_package_cache,
+    verify_package_hashes,
+)
+from conda_workspaces.exceptions import (
+    ArchiveHashMismatchError,
+    ArchivePathTraversalError,
+)
 from conda_workspaces.models import ArchiveConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.fixture
@@ -30,20 +46,73 @@ def git_project(project_dir: Path) -> Path:
     subprocess.run(["git", "init"], cwd=project_dir, check=True, capture_output=True)
     subprocess.run(
         ["git", "config", "user.email", "test@test.com"],
-        cwd=project_dir, check=True, capture_output=True,
+        cwd=project_dir,
+        check=True,
+        capture_output=True,
     )
     subprocess.run(
         ["git", "config", "user.name", "Test"],
-        cwd=project_dir, check=True, capture_output=True,
+        cwd=project_dir,
+        check=True,
+        capture_output=True,
     )
     subprocess.run(
         ["git", "add", "conda.toml", "conda.lock", "src/main.py"],
-        cwd=project_dir, check=True, capture_output=True,
+        cwd=project_dir,
+        check=True,
+        capture_output=True,
     )
     subprocess.run(
         ["git", "commit", "-m", "init"],
-        cwd=project_dir, check=True, capture_output=True,
+        cwd=project_dir,
+        check=True,
+        capture_output=True,
     )
+    return project_dir
+
+
+@pytest.fixture
+def lockfile_with_packages(project_dir: Path) -> Path:
+    """Create a conda.lock with fake package entries and matching .conda files."""
+    pkg_content = b"fake conda package data"
+    sha256 = hashlib.sha256(pkg_content).hexdigest()
+
+    lockfile_content = f"""\
+version: 1
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h4dc568a_6.conda
+      osx-arm64:
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_6.conda
+packages:
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h4dc568a_6.conda
+    sha256: {sha256}
+    md5: abc123
+    name: zlib
+    version: 1.2.13
+    build: h4dc568a_6
+    subdir: linux-64
+    depends: []
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_6.conda
+    sha256: {sha256}
+    md5: def456
+    name: zlib
+    version: 1.2.13
+    build: h53f4e23_6
+    subdir: osx-arm64
+    depends: []
+"""
+    (project_dir / "conda.lock").write_text(lockfile_content, encoding="utf-8")
+
+    cache_dir = project_dir / "pkg_cache"
+    cache_dir.mkdir()
+    (cache_dir / "zlib-1.2.13-h4dc568a_6.conda").write_bytes(pkg_content)
+    (cache_dir / "zlib-1.2.13-h53f4e23_6.conda").write_bytes(pkg_content)
+
     return project_dir
 
 
@@ -95,13 +164,6 @@ def test_collect_files_custom_exclude(project_dir: Path) -> None:
     assert "conda.toml" in rel_paths
 
 
-# ---------------------------------------------------------------------------
-# Task 4: tarball creation
-# ---------------------------------------------------------------------------
-
-from conda_workspaces.archive import create_archive
-
-
 def test_create_archive_tar_gz(project_dir: Path, tmp_path: Path) -> None:
     output = tmp_path / "out" / "project.tar.gz"
     config = ArchiveConfig()
@@ -146,14 +208,6 @@ def test_create_archive_output_dir_created(project_dir: Path, tmp_path: Path) ->
     config = ArchiveConfig()
     create_archive(project_dir, output, config)
     assert output.is_file()
-
-
-# ---------------------------------------------------------------------------
-# Task 5: safe extraction with path traversal protection
-# ---------------------------------------------------------------------------
-
-from conda_workspaces.archive import extract_archive
-from conda_workspaces.exceptions import ArchivePathTraversalError
 
 
 def test_extract_archive_basic(project_dir: Path, tmp_path: Path) -> None:
@@ -221,64 +275,6 @@ def test_extract_archive_zst(project_dir: Path, tmp_path: Path) -> None:
     assert (target / "src" / "main.py").is_file()
 
 
-# ---------------------------------------------------------------------------
-# Task 6: package bundling and hash verification
-# ---------------------------------------------------------------------------
-
-import hashlib
-
-from conda_workspaces.archive import (
-    collect_bundle_packages,
-    verify_package_hashes,
-)
-from conda_workspaces.exceptions import ArchiveHashMismatchError
-
-
-@pytest.fixture
-def lockfile_with_packages(project_dir: Path) -> Path:
-    """Create a conda.lock with fake package entries and matching .conda files."""
-    pkg_content = b"fake conda package data"
-    sha256 = hashlib.sha256(pkg_content).hexdigest()
-
-    lockfile_content = f"""\
-version: 1
-environments:
-  default:
-    channels:
-      - url: https://conda.anaconda.org/conda-forge/
-    packages:
-      linux-64:
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h4dc568a_6.conda
-      osx-arm64:
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_6.conda
-packages:
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h4dc568a_6.conda
-    sha256: {sha256}
-    md5: abc123
-    name: zlib
-    version: 1.2.13
-    build: h4dc568a_6
-    subdir: linux-64
-    depends: []
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_6.conda
-    sha256: {sha256}
-    md5: def456
-    name: zlib
-    version: 1.2.13
-    build: h53f4e23_6
-    subdir: osx-arm64
-    depends: []
-"""
-    (project_dir / "conda.lock").write_text(lockfile_content, encoding="utf-8")
-
-    cache_dir = project_dir / "pkg_cache"
-    cache_dir.mkdir()
-    (cache_dir / "zlib-1.2.13-h4dc568a_6.conda").write_bytes(pkg_content)
-    (cache_dir / "zlib-1.2.13-h53f4e23_6.conda").write_bytes(pkg_content)
-
-    return project_dir
-
-
 def test_collect_bundle_packages(lockfile_with_packages: Path) -> None:
     cache_dir = lockfile_with_packages / "pkg_cache"
     lockfile = lockfile_with_packages / "conda.lock"
@@ -305,7 +301,10 @@ def test_verify_package_hashes_fail(lockfile_with_packages: Path) -> None:
         verify_package_hashes(packages, lockfile)
 
 
-def test_create_archive_with_bundle(lockfile_with_packages: Path, tmp_path: Path) -> None:
+def test_create_archive_with_bundle(
+    lockfile_with_packages: Path,
+    tmp_path: Path,
+) -> None:
     cache_dir = lockfile_with_packages / "pkg_cache"
     lockfile = lockfile_with_packages / "conda.lock"
     packages = collect_bundle_packages(lockfile, [cache_dir])
@@ -319,13 +318,6 @@ def test_create_archive_with_bundle(lockfile_with_packages: Path, tmp_path: Path
     assert "packages/zlib-1.2.13-h4dc568a_6.conda" in names
     assert "packages/zlib-1.2.13-h53f4e23_6.conda" in names
     assert "conda.toml" in names
-
-
-# ---------------------------------------------------------------------------
-# Task 7: cache priming
-# ---------------------------------------------------------------------------
-
-from conda_workspaces.archive import prime_package_cache
 
 
 def test_prime_package_cache(tmp_path: Path) -> None:
@@ -370,7 +362,9 @@ packages:
 def test_prime_package_cache_no_packages(tmp_path: Path) -> None:
     extracted = tmp_path / "project"
     extracted.mkdir()
-    (extracted / "conda.lock").write_text("version: 1\nenvironments: {}\npackages: []\n")
+    (extracted / "conda.lock").write_text(
+        "version: 1\nenvironments: {}\npackages: []\n"
+    )
 
     cache_dir = tmp_path / "pkgs"
     cache_dir.mkdir()
@@ -412,13 +406,6 @@ packages:
         prime_package_cache(extracted, cache_dir)
 
 
-# ---------------------------------------------------------------------------
-# Task 8: archive inspection helper
-# ---------------------------------------------------------------------------
-
-from conda_workspaces.archive import inspect_archive
-
-
 def test_inspect_archive_lightweight(project_dir: Path, tmp_path: Path) -> None:
     output = tmp_path / "test.tar.gz"
     config = ArchiveConfig()
@@ -458,11 +445,6 @@ def test_inspect_archive_not_workspace(tmp_path: Path) -> None:
     assert result["has_manifest"] is False
 
 
-# ---------------------------------------------------------------------------
-# Task 13: full integration tests (round-trip)
-# ---------------------------------------------------------------------------
-
-
 def test_archive_roundtrip(git_project: Path, tmp_path: Path) -> None:
     """Full round-trip: create archive, extract, verify contents match."""
     config = ArchiveConfig()
@@ -472,8 +454,12 @@ def test_archive_roundtrip(git_project: Path, tmp_path: Path) -> None:
     target = tmp_path / "extracted"
     extract_archive(archive_path, target)
 
-    assert (target / "conda.toml").read_text() == (git_project / "conda.toml").read_text()
-    assert (target / "conda.lock").read_text() == (git_project / "conda.lock").read_text()
+    assert (target / "conda.toml").read_text() == (
+        git_project / "conda.toml"
+    ).read_text()
+    assert (target / "conda.lock").read_text() == (
+        git_project / "conda.lock"
+    ).read_text()
     assert (target / "src" / "main.py").read_text() == (
         git_project / "src" / "main.py"
     ).read_text()
@@ -482,7 +468,10 @@ def test_archive_roundtrip(git_project: Path, tmp_path: Path) -> None:
     assert not (target / "data").exists()
 
 
-def test_archive_roundtrip_with_bundle(lockfile_with_packages: Path, tmp_path: Path) -> None:
+def test_archive_roundtrip_with_bundle(
+    lockfile_with_packages: Path,
+    tmp_path: Path,
+) -> None:
     """Round-trip with bundled packages: archive, extract, prime cache."""
     cache_dir = lockfile_with_packages / "pkg_cache"
     lockfile = lockfile_with_packages / "conda.lock"
@@ -490,7 +479,12 @@ def test_archive_roundtrip_with_bundle(lockfile_with_packages: Path, tmp_path: P
 
     archive_path = tmp_path / "bundled.tar.gz"
     config = ArchiveConfig()
-    create_archive(lockfile_with_packages, archive_path, config, bundle_packages=packages)
+    create_archive(
+        lockfile_with_packages,
+        archive_path,
+        config,
+        bundle_packages=packages,
+    )
 
     target = tmp_path / "extracted"
     extract_archive(archive_path, target)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -456,3 +456,50 @@ def test_inspect_archive_not_workspace(tmp_path: Path) -> None:
 
     result = inspect_archive(archive)
     assert result["has_manifest"] is False
+
+
+# ---------------------------------------------------------------------------
+# Task 13: full integration tests (round-trip)
+# ---------------------------------------------------------------------------
+
+
+def test_archive_roundtrip(git_project: Path, tmp_path: Path) -> None:
+    """Full round-trip: create archive, extract, verify contents match."""
+    config = ArchiveConfig()
+    archive_path = tmp_path / "roundtrip.tar.gz"
+    create_archive(git_project, archive_path, config)
+
+    target = tmp_path / "extracted"
+    extract_archive(archive_path, target)
+
+    assert (target / "conda.toml").read_text() == (git_project / "conda.toml").read_text()
+    assert (target / "conda.lock").read_text() == (git_project / "conda.lock").read_text()
+    assert (target / "src" / "main.py").read_text() == (
+        git_project / "src" / "main.py"
+    ).read_text()
+
+    assert not (target / ".env").exists()
+    assert not (target / "data").exists()
+
+
+def test_archive_roundtrip_with_bundle(lockfile_with_packages: Path, tmp_path: Path) -> None:
+    """Round-trip with bundled packages: archive, extract, prime cache."""
+    cache_dir = lockfile_with_packages / "pkg_cache"
+    lockfile = lockfile_with_packages / "conda.lock"
+    packages = collect_bundle_packages(lockfile, [cache_dir])
+
+    archive_path = tmp_path / "bundled.tar.gz"
+    config = ArchiveConfig()
+    create_archive(lockfile_with_packages, archive_path, config, bundle_packages=packages)
+
+    target = tmp_path / "extracted"
+    extract_archive(archive_path, target)
+
+    new_cache = tmp_path / "fresh_cache"
+    new_cache.mkdir()
+    count = prime_package_cache(target, new_cache)
+    assert count == 2
+
+    cached_files = {f.name for f in new_cache.iterdir()}
+    assert "zlib-1.2.13-h4dc568a_6.conda" in cached_files
+    assert "zlib-1.2.13-h53f4e23_6.conda" in cached_files

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from conda_workspaces.archive import (
+    ALLOWED_TAR_TYPES,
     collect_archive_files,
     collect_bundle_packages,
     create_archive,
@@ -16,6 +17,7 @@ from conda_workspaces.archive import (
     inspect_archive,
     open_tar,
     prime_package_cache,
+    validate_tar_member,
     verify_package_hashes,
 )
 from conda_workspaces.exceptions import (
@@ -486,3 +488,60 @@ def test_archive_roundtrip_with_bundle(
     cached_files = {f.name for f in new_cache.iterdir()}
     assert "zlib-1.2.13-h4dc568a_6.conda" in cached_files
     assert "zlib-1.2.13-h53f4e23_6.conda" in cached_files
+
+
+@pytest.mark.parametrize(
+    "file_type",
+    [
+        tarfile.CHRTYPE,
+        tarfile.BLKTYPE,
+        tarfile.FIFOTYPE,
+    ],
+    ids=["char-device", "block-device", "fifo"],
+)
+def test_validate_tar_member_rejects_special_file_types(
+    tmp_path: Path, file_type: bytes
+) -> None:
+    member = tarfile.TarInfo(name="evil_device")
+    member.type = file_type
+    with pytest.raises(ArchivePathTraversalError):
+        validate_tar_member(member, tmp_path)
+
+
+def test_validate_tar_member_allows_regular_types(tmp_path: Path) -> None:
+    for file_type in ALLOWED_TAR_TYPES:
+        member = tarfile.TarInfo(name="normal_file")
+        member.type = file_type
+        validate_tar_member(member, tmp_path)
+
+
+def test_verify_package_hashes_warns_on_missing_hash(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    pkg = tmp_path / "nohash-1.0-h000.conda"
+    pkg.write_bytes(b"data")
+
+    lockfile_content = """\
+version: 1
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/nohash-1.0-h000.conda
+packages:
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/nohash-1.0-h000.conda
+    name: nohash
+    version: "1.0"
+    build: h000
+    subdir: linux-64
+    depends: []
+"""
+    lockfile = tmp_path / "conda.lock"
+    lockfile.write_text(lockfile_content, encoding="utf-8")
+
+    with caplog.at_level("WARNING", logger="conda_workspaces.archive"):
+        verify_package_hashes([pkg], lockfile)
+
+    assert "No SHA256 hash in lockfile for nohash-1.0-h000.conda" in caplog.text

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -120,7 +120,7 @@ packages:
 def test_collect_files_git_tracked(git_project: Path) -> None:
     config = ArchiveConfig()
     files = collect_archive_files(git_project, config)
-    rel_paths = {str(f.relative_to(git_project)) for f in files}
+    rel_paths = {f.relative_to(git_project).as_posix() for f in files}
     assert "conda.toml" in rel_paths
     assert "conda.lock" in rel_paths
     assert "src/main.py" in rel_paths
@@ -131,7 +131,7 @@ def test_collect_files_git_tracked(git_project: Path) -> None:
 def test_collect_files_non_git(project_dir: Path) -> None:
     config = ArchiveConfig()
     files = collect_archive_files(project_dir, config)
-    rel_paths = {str(f.relative_to(project_dir)) for f in files}
+    rel_paths = {f.relative_to(project_dir).as_posix() for f in files}
     assert "conda.toml" in rel_paths
     assert "src/main.py" in rel_paths
     assert "data/big.bin" in rel_paths
@@ -150,7 +150,7 @@ def test_collect_files_builtin_exclusions(project_dir: Path) -> None:
 
     config = ArchiveConfig()
     files = collect_archive_files(project_dir, config)
-    rel_strs = {str(f.relative_to(project_dir)) for f in files}
+    rel_strs = {f.relative_to(project_dir).as_posix() for f in files}
 
     assert not any(p.startswith(".git/") or p == ".git" for p in rel_strs)
     assert not any(p.startswith(".conda/envs") for p in rel_strs)
@@ -160,7 +160,7 @@ def test_collect_files_builtin_exclusions(project_dir: Path) -> None:
 def test_collect_files_custom_exclude(project_dir: Path) -> None:
     config = ArchiveConfig(exclude=("data/**",))
     files = collect_archive_files(project_dir, config)
-    rel_paths = {str(f.relative_to(project_dir)) for f in files}
+    rel_paths = {f.relative_to(project_dir).as_posix() for f in files}
     assert "data/big.bin" not in rel_paths
     assert "conda.toml" in rel_paths
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -140,3 +140,29 @@ def test_error_message_and_hints_separate(exc):
     for hint in exc.hints:
         assert hint in str(exc)
     assert exc.error_message != str(exc) or not exc.hints
+
+
+from conda_workspaces.exceptions import (
+    ArchiveError,
+    ArchivePathTraversalError,
+    ArchiveHashMismatchError,
+)
+
+
+def test_archive_error():
+    exc = ArchiveError("something broke")
+    assert "something broke" in str(exc)
+    assert exc.error_message == "something broke"
+
+
+def test_archive_path_traversal_error():
+    exc = ArchivePathTraversalError("../../etc/passwd")
+    assert "../../etc/passwd" in str(exc)
+    assert exc.hints
+
+
+def test_archive_hash_mismatch_error():
+    exc = ArchiveHashMismatchError("numpy-1.26.conda", expected="abc", actual="def")
+    assert "numpy-1.26.conda" in str(exc)
+    assert "abc" in str(exc)
+    assert "def" in str(exc)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -9,6 +9,9 @@ from conda.exceptions import CondaError
 
 from conda_workspaces.exceptions import (
     ActivationError,
+    ArchiveError,
+    ArchiveHashMismatchError,
+    ArchivePathTraversalError,
     CondaWorkspacesError,
     EnvironmentNotFoundError,
     EnvironmentNotInstalledError,
@@ -140,13 +143,6 @@ def test_error_message_and_hints_separate(exc):
     for hint in exc.hints:
         assert hint in str(exc)
     assert exc.error_message != str(exc) or not exc.hints
-
-
-from conda_workspaces.exceptions import (
-    ArchiveError,
-    ArchivePathTraversalError,
-    ArchiveHashMismatchError,
-)
 
 
 def test_archive_error():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,6 +11,7 @@ from conda_workspaces.exceptions import (
     TaskNotFoundError,
 )
 from conda_workspaces.models import (
+    ArchiveConfig,
     Channel,
     Environment,
     Feature,
@@ -379,3 +380,13 @@ def test_task_not_found_error(available, expected_in, expected_not_in):
         assert expected_in in str(err)
     if expected_not_in:
         assert expected_not_in not in str(err)
+
+
+def test_archive_config_defaults():
+    cfg = ArchiveConfig()
+    assert cfg.exclude == ()
+
+
+def test_archive_config_custom():
+    cfg = ArchiveConfig(exclude=("data/**", "*.bin"))
+    assert cfg.exclude == ("data/**", "*.bin")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -384,9 +384,20 @@ def test_task_not_found_error(available, expected_in, expected_not_in):
 
 def test_archive_config_defaults():
     cfg = ArchiveConfig()
+    assert cfg.include == ()
     assert cfg.exclude == ()
+    assert cfg.compression == "zst"
+    assert cfg.compression_level is None
 
 
 def test_archive_config_custom():
-    cfg = ArchiveConfig(exclude=("data/**", "*.bin"))
+    cfg = ArchiveConfig(
+        include=("src/**",),
+        exclude=("data/**", "*.bin"),
+        compression="gz",
+        compression_level=6,
+    )
+    assert cfg.include == ("src/**",)
     assert cfg.exclude == ("data/**", "*.bin")
+    assert cfg.compression == "gz"
+    assert cfg.compression_level == 6


### PR DESCRIPTION
## Summary

Adds `conda workspace archive` and `conda workspace unarchive` subcommands for packaging workspaces into portable archives and restoring them elsewhere or in CI.

- `conda workspace archive` collects workspace files into a `.tar.zst` archive (default) with `.tar.gz` and `.tar.bz2` also supported. In git repos only tracked files are included. User-configurable include/exclude patterns via `[workspace.archive]` and `--exclude`.
- `--lock` solves and writes `conda.lock` before archiving, combining two steps into one.
- `--bundle` adds `.conda` packages from the local conda cache, verified against lockfile SHA256 hashes, for offline/air-gapped installs. Packages without hashes produce a warning.
- `conda workspace unarchive` extracts archives with defense-in-depth security: member validation (path traversal, symlink escape, device node rejection), plus `filter="data"` on Python 3.12+.
- `--install` extracts and installs environments from the lockfile in a single command.
- Bundled packages are hash-verified and primed into the local conda cache on extraction.
- Compression uses `backports.zstd` (Python <3.14) or stdlib `compression.zstd` (3.14+) via `tarfile.open("w:zst")`.

### Archive configuration

```toml
[workspace.archive]
include = ["src/**", "conda.toml", "conda.lock"]
exclude = ["*.log", "data/raw/**"]
compression = "zst"
compression-level = 19
```

Include narrows the file set first, then exclude removes from it. When include is empty (default), all files are candidates.

### New files

- `conda_workspaces/archive.py`: core archive logic (file collection, tar creation/extraction, package bundling, hash verification, cache priming, inspection, security validation)
- `conda_workspaces/cli/workspace/archive.py`: CLI handlers for both subcommands
- `tests/test_archive.py`: 33 tests covering round-trips, path traversal attacks, device node rejection, hash verification, hashless package warnings, cache priming, and bundled archives
- `tests/cli/workspace/test_archive.py`: 6 CLI-level tests
- `demos/archives.tape`, `archives-bundle.tape`, `archives-install.tape`: VHS demo recordings
- `docs/tutorials/archives.md`: tutorial with embedded demos

### Modified files

- `conda_workspaces/exceptions.py`: `ArchiveError`, `ArchivePathTraversalError`, `ArchiveHashMismatchError`
- `conda_workspaces/models.py`: `ArchiveConfig` with `include`, `exclude`, `compression`, `compression_level`
- `conda_workspaces/cli/main.py`: subparser registration with `--lock`, `--bundle`, `--install`, `--exclude`
- `conda_workspaces/manifests/toml.py`: `parse_archive_config` for all config fields
- `pyproject.toml`: `backports.zstd` dependency for Python <3.14
- `docs/configuration.md`, `docs/features.md`: archive configuration and feature docs

### Security

- Path traversal protection: absolute paths, `..` components, symlink escapes blocked
- Special file type rejection: device nodes, block devices, FIFOs rejected on all Python versions
- Validated member list passed to `extractall` to prevent TOCTOU races
- SHA256 hash verification for bundled packages (warning on missing hashes)
- `shutil.copy` (not `copy2`) for cache priming to avoid preserving archive permissions
- Trust model documented: bundled archives are self-consistent but not externally signed

## Test plan

- [x] 950 tests pass (`pixi run -e test pytest`)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] Round-trip: archive a git project, extract, verify contents match and excluded files absent
- [x] Round-trip with bundle: archive with packages, extract, prime cache, verify cache contents
- [x] Path traversal: `../` paths, absolute paths, symlink escapes all blocked
- [x] Device nodes, block devices, FIFOs rejected
- [x] Hash verification: tampered packages detected; hashless packages warned
- [x] VHS demos recorded and embedded in docs

Closes #57.