### PR TITLE
Add FAQ page and link conda.toml spec prominently

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ everything including its own solver, see [pixi](https://pixi.sh).
 
 ## Documentation
 
-https://conda-incubator.github.io/conda-workspaces/
+- [User guide](https://conda-incubator.github.io/conda-workspaces/)
+- [`conda.toml` specification](https://conda-incubator.github.io/conda-workspaces/reference/conda-toml-spec/)
+- [JSON schema](https://github.com/conda-incubator/conda-workspaces/blob/main/schema/conda-toml-1.schema.json)
 
 ## Demos
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,37 @@
+# FAQ
+
+## How does conda-workspaces handle manifest format changes in pixi?
+
+conda-workspaces tracks the pixi manifest format and maintains
+compatibility. The format is also being standardized through a Conda
+Enhancement Proposal (CEP); see the [CEP tracker
+issue](https://github.com/conda-incubator/conda-workspaces/issues/52)
+for progress.
+
+The [`conda.toml` specification](reference/conda-toml-spec.md) is the
+normative prose reference, and
+[`schema/conda-toml-1.schema.json`][schema] is the machine-readable
+schema. Any pixi-originated fields that conda-workspaces accepts but
+does not implement (like `solve-group`) are documented explicitly in the
+spec.
+
+[schema]: https://github.com/conda-incubator/conda-workspaces/blob/main/schema/conda-toml-1.schema.json
+
+## How does conda-workspaces differ from conda-project and anaconda-project?
+
+See the [Motivation](motivation.md) page for a detailed comparison. The
+key differences:
+
+1. conda-workspaces uses pixi's TOML manifest format rather than
+   inventing a new one, so projects can share manifests between tools.
+2. It integrates as a conda plugin rather than a standalone CLI.
+3. It includes `conda workspace import` commands to convert from both
+   `conda-project.yml` and `anaconda-project.yml`.
+
+## What happens if I add keys to conda.toml that conda-workspaces doesn't recognize?
+
+Unknown keys are silently preserved and do not produce warnings. This is
+intentional: it allows other tools or future extensions to use the same
+file without causing noise. The `[workspace]` table already supports
+optional fields like `description` and `version` that not every workflow
+uses.

--- a/docs/index.md
+++ b/docs/index.md
@@ -166,6 +166,22 @@ Python API for models, manifests, resolver, context, environments,
 and task execution.
 :::
 
+:::{grid-item-card} {octicon}`book` `conda.toml` specification
+:link: reference/conda-toml-spec
+:link-type: doc
+
+Normative reference for the `conda.toml` manifest format and JSON
+schema.
+:::
+
+:::{grid-item-card} {octicon}`question` FAQ
+:link: faq
+:link-type: doc
+
+Answers to common questions about format compatibility, prior art,
+and unknown keys.
+:::
+
 ::::
 
 ```{toctree}
@@ -198,6 +214,7 @@ reference/format-aliases
 
 features
 motivation
+faq
 ```
 
 ```{toctree}


### PR DESCRIPTION
## Summary

- Add `docs/faq.md` with three FAQ entries: manifest format drift with pixi, comparison with conda-project/anaconda-project, and behavior with unknown keys
- Add `conda.toml` specification and FAQ grid cards to the docs landing page
- Update README Documentation section with links to the spec and JSON schema

Closes #59, closes #60

## Test plan

- [x] Verify `pixi run -e docs sphinx-build docs docs/_build` builds without warnings
- [x] Verify FAQ page renders correctly
- [x] Verify spec and FAQ cards appear on the landing page
- [x] Verify README links point to correct URLs