### PR TITLE
Add `conda ws` as a short alias for `conda workspace`

### DIFF
--- a/conda_workspaces/plugin.py
+++ b/conda_workspaces/plugin.py
@@ -37,6 +37,12 @@ def conda_subcommands() -> Iterable[CondaSubcommand]:
         configure_parser=configure_workspace_parser,
     )
     yield CondaSubcommand(
+        name="ws",
+        summary="Shorthand for 'conda workspace'.",
+        action=execute_workspace,  # ty: ignore[invalid-argument-type]
+        configure_parser=configure_workspace_parser,
+    )
+    yield CondaSubcommand(
         name="task",
         summary="Run, list, and manage project tasks.",
         action=execute_task,  # ty: ignore[invalid-argument-type]

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,8 +111,8 @@ This means:
   installs without re-solving
 - Task dependencies, caching, Jinja2 templates, and platform overrides
   all work out of the box
-- Ships as a conda plugin (`conda workspace`, `conda task`) and
-  standalone `conda workspace` / `conda task` CLIs (also available as `cw` / `ct`)
+- Ships as a conda plugin (`conda workspace` / `conda ws`, `conda task`) and
+  standalone `cw` / `ct` CLIs
 
 Read more in [](motivation.md).
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2,6 +2,9 @@
 
 ## conda workspace
 
+`conda ws` is a shorthand alias for `conda workspace`. Both forms
+accept the same subcommands, flags, and arguments.
+
 Auto-generated from the `conda workspace` argument parser.
 
 ```{eval-rst}

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -16,7 +16,10 @@ from conda_workspaces.plugin import (
 def test_conda_subcommands_yields_workspace_and_task() -> None:
     items = {sub.name: sub for sub in conda_subcommands()}
     assert "workspace" in items
+    assert "ws" in items
     assert "task" in items
+    assert items["ws"].action is items["workspace"].action
+    assert items["ws"].configure_parser is items["workspace"].configure_parser
     for sub in items.values():
         assert sub.summary
         assert callable(sub.action)


### PR DESCRIPTION
## Summary

- Register a second `CondaSubcommand` with `name="ws"` that reuses the same parser and action as `workspace`
- All subcommands, flags, and arguments work identically under either form
- Help text correctly shows `conda ws` as the program name
- Document the alias in the CLI reference and index page

Closes #68