### PR TITLE
Link changelog issue and PR references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,75 +15,78 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   manifest. Project tasks override user tasks on name collision.
   `conda task list` annotates user-sourced tasks with `(user)` in text
   output and `"source": "user"` in JSON output. XDG paths are also
-  supported (`$XDG_CONFIG_HOME/conda/tasks.toml`). (#53, #54)
+  supported (`$XDG_CONFIG_HOME/conda/tasks.toml`).
+  (<gh-issue:53>, <gh-pr:54>)
 - `conda workspace archive` packages a workspace into a portable
   archive. Git repositories include tracked files by default, while
   non-git projects include workspace files filtered by built-in
   exclusions, `[workspace.archive]` settings, and `--exclude`.
   `.tar.zst` is the default output format; `.tar.gz` and `.tar.bz2`
-  are also supported. (#57, #63)
+  are also supported. (<gh-issue:57>, <gh-pr:63>)
 - `conda workspace archive --lock` refreshes `conda.lock` before
   writing the archive, and `--bundle` includes package archives from
   the local conda package cache for offline or air-gapped installs.
   Bundled package archives are checked against lockfile SHA-256 hashes
-  when hashes are available. (#57, #63, #71)
+  when hashes are available. (<gh-issue:57>, <gh-pr:63>, <gh-pr:71>)
 - `conda workspace unarchive` restores an archived workspace, and
   `conda workspace unarchive --install` extracts the workspace and
   installs its environments from the bundled or local package cache in
-  one step. (#57, #63)
+  one step. (<gh-issue:57>, <gh-pr:63>)
 - `conda workspace install` now checks whether `conda.lock` satisfies
   the manifest before deciding whether to solve. In local use it
   prefers the lockfile when it is still valid and solves when it is
   not. In CI (`CI=true`) the default behaves like a locked install and
-  fails fast when the lockfile is missing or unsatisfiable. (#61, #67)
+  fails fast when the lockfile is missing or unsatisfiable.
+  (<gh-issue:61>, <gh-pr:67>)
 - `conda workspace install --no-lock` forces a solve even when the
-  existing lockfile satisfies the manifest. (#61, #67)
+  existing lockfile satisfies the manifest. (<gh-issue:61>, <gh-pr:67>)
 - `conda workspace info` now reports lockfile status
   (`up-to-date`, `out-of-date`, or `missing`) in text output and as
-  `lockfile_status` in JSON output. (#61, #67)
+  `lockfile_status` in JSON output. (<gh-issue:61>, <gh-pr:67>)
 - `conda ws` is now a short alias for `conda workspace`, with the same
-  subcommands, flags, arguments, and help text. (#68, #69)
+  subcommands, flags, arguments, and help text. (<gh-issue:68>, <gh-pr:69>)
 - Added tutorials and reference material for workspace archives, PyPI
   dependencies, multi-platform locking, and the `conda.toml`
-  specification. (#51, #56, #65, #66)
+  specification. (<gh-pr:51>, <gh-pr:56>, <gh-pr:65>, <gh-pr:66>)
 
 ### Changed
 
 - The minimum supported conda dependency is now `conda >=26.3`, and
   the minimum `conda-pypi` dependency is now `conda-pypi >=0.9.0`.
   conda-workspaces also uses the current conda environment specifier
-  and exporter plugin metadata APIs. (#65)
+  and exporter plugin metadata APIs. (<gh-pr:65>)
 - Projects that declare PyPI dependencies now receive a clearer
   runtime warning when `conda-rattler-solver` is not installed.
   `conda-rattler-solver` remains an explicit dependency in the pixi
-  development environments. (#65)
+  development environments. (<gh-pr:65>)
 
 ### Fixed
 
 - `.tar.zst` archive creation and extraction now work on every
   supported Python version. Python 3.10 through 3.13 use
   `backports.zstd`; Python 3.14+ uses the standard library zstd
-  support. (#72)
+  support. (<gh-pr:72>)
 - Workspace archive file collection uses POSIX archive paths on
-  Windows, so archives are portable across platforms. (#57, #63)
+  Windows, so archives are portable across platforms.
+  (<gh-issue:57>, <gh-pr:63>)
 - Lockfile loading now raises the project-specific platform mismatch
   error for missing-platform cases instead of a generic `ValueError`.
-  (#65)
+  (<gh-pr:65>)
 
 ### Security
 
 - Task templates now render with Jinja2's sandboxed environment, which
   blocks template attribute traversal attacks from malicious task
   definitions. Task argument names can no longer shadow the reserved
-  `conda` and `pixi` template context keys. (#55)
+  `conda` and `pixi` template context keys. (<gh-pr:55>)
 - Archive extraction validates every tar member before extraction,
   rejecting absolute paths, `..` path traversal, symlink escapes, and
   special file types such as device nodes and FIFOs. On Python 3.12+
   extraction also uses the standard library `filter="data"` defense.
-  (#57, #63)
+  (<gh-issue:57>, <gh-pr:63>)
 - Bundled archive package cache priming verifies package SHA-256
   hashes against `conda.lock` before copying archives into the local
-  conda package cache. (#57, #63, #71)
+  conda package cache. (<gh-issue:57>, <gh-pr:63>, <gh-pr:71>)
 
 ## 0.4.0 — 2026-04-29
 
@@ -94,10 +97,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   directory to scaffold a manifest, add the specs passed on the
   command line (`conda workspace quickstart python=3.14 numpy`),
   install the environment, and drop into an activated shell.
+  (<gh-issue:22>, <gh-pr:39>)
 - `conda workspace quickstart --copy` (alias `--clone`) copies an
   existing workspace's manifest from a directory or file instead of
   running `init`. `--no-shell` skips the final shell step (implied by
-  `--json`).
+  `--json`). (<gh-issue:22>, <gh-pr:39>)
 - New manifest-format exporter plugins for `conda workspace export`:
   `conda-toml`, `pixi-toml`, and `pyproject-toml`. Registered via the
   same `conda_environment_exporters` hook as `environment-yaml` and
@@ -105,13 +109,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   inference, and `--output` streaming carry over. Together with
   `conda workspace import`, `conda workspace` now translates in both
   directions across every supported manifest dialect.
+  (<gh-issue:14>, <gh-issue:41>, <gh-pr:37>, <gh-pr:44>)
 - The `pyproject-toml` exporter splices its content under
   `[tool.conda]` and preserves peer tables (`[project]`,
   `[build-system]`, `[tool.ruff]`, `[tool.pixi]`, ...) when the
-  target file already exists.
+  target file already exists. (<gh-issue:41>, <gh-pr:44>)
 - `conda workspace lock --output <path>` writes the lockfile to an
   arbitrary path (e.g. `conda.lock.linux-64`) so matrix CI runners
-  can each emit a per-platform fragment.
+  can each emit a per-platform fragment. (<gh-issue:34>, <gh-pr:38>)
 - `conda workspace lock --merge <glob>` (repeatable) stitches
   lockfile fragments back into a single `conda.lock` without
   re-solving. Validates schema version and per-environment channel
@@ -119,7 +124,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   (raising `LockfileMergeError`), and produces output byte-identical
   to a single-run `lock` over the same inputs. Mutually exclusive
   with `--environment`, `--platform`, `--skip-unsolvable`, and
-  `--output`.
+  `--output`. (<gh-issue:34>, <gh-pr:38>)
 - `conda workspace lock` now writes a single `conda.lock` covering
   every platform declared by each environment, not just the host
   platform. Solves run with `context._subdir` overridden so conda's
@@ -127,33 +132,37 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   `subdirs` resolution target the correct subdir.
   `CONDA_OVERRIDE_*` and `[system-requirements]` continue to pin
   constraints like `__glibc`, `__cuda`, or `__osx`.
+  (<gh-issue:4>, <gh-pr:31>)
 - `conda workspace lock --platform <subdir>` (repeatable) restricts
   the lock run to a subset of declared platforms. Unknown platforms
-  raise `PlatformError` before any solve runs.
+  raise `PlatformError` before any solve runs. (<gh-issue:4>, <gh-pr:31>)
 - `conda workspace lock --skip-unsolvable` keeps locking the
   remaining `(environment, platform)` pairs when one solve fails,
   printing a yellow `Skipping ...` line for each. Raises
   `AllTargetsUnsolvableError` if every pair fails, so CI never
   writes an empty lockfile. Non-solver errors still abort regardless.
+  (<gh-issue:33>, <gh-pr:31>)
 - `--json` is now accepted across every `conda workspace` and
   `conda task` subcommand. Side-effect-only commands (`init`,
   `activate`, `run`, `shell`) used to crash with
   `unrecognized arguments: --json` when CI wrappers passed the flag
   globally; they now accept it silently and rely on the exit code.
-  See the `--json contract` section in `AGENTS.md`.
+  See the `--json contract` section in `AGENTS.md`. (<gh-pr:46>)
 - `conda workspace info --json` exposes the reachable set of
   platforms as `known_platforms` (and a `Known Platforms` row in
   text output when features broaden the workspace-level set), via
   the new `conda_workspaces.resolver.known_platforms()` helper.
+  (<gh-issue:4>, <gh-pr:31>)
 - `SolveError` names the target platform when known, so
-  per-platform failures stand out in CI logs.
+  per-platform failures stand out in CI logs. (<gh-issue:4>, <gh-pr:31>)
 - Inside `conda workspace shell`, `add` / `remove` / `install`
   print a hint to re-spawn the shell when a newly installed package
   drops activation scripts into `$PREFIX/etc/conda/activate.d/`.
+  (<gh-issue:21>, <gh-pr:28>)
 - New `demos/multi-platform.{tape,gif,mp4}` recording for
   cross-platform locking and the `--platform` flag. The
   `demos/lockfile` recording was refreshed to show multi-platform
-  default output.
+  default output. (<gh-issue:4>, <gh-pr:31>, <gh-pr:45>)
 
 ### Changed
 
@@ -161,52 +170,54 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   the affected environment(s) and refresh `conda.lock` by default,
   matching `pixi add` / `pixi remove`. Use `--no-install`,
   `--no-lockfile-update`, `--force-reinstall`, or `--dry-run` to opt
-  out.
+  out. (<gh-issue:21>, <gh-pr:28>)
 - `conda workspace install` shares a single solve/install/lock
   pipeline with `add` and `remove`
-  (`conda_workspaces/cli/workspace/sync.py`).
+  (`conda_workspaces/cli/workspace/sync.py`). (<gh-pr:28>)
 - `conda_workspaces.parsers` renamed to `conda_workspaces.manifests`
   (named after the subject, not the verb). Class names like
   `CondaTomlParser` are unchanged; public re-exports preserved.
+  (<gh-pr:29>)
 - `conda_workspaces.env_spec` shrunk to the `conda.toml` env-spec
   plugin (`CondaWorkspaceSpec`). `CondaLockSpec` was replaced by
-  `conda_workspaces.lockfile.CondaLockLoader`.
+  `conda_workspaces.lockfile.CondaLockLoader`. (<gh-issue:4>, <gh-pr:29>)
 - Plugin metadata moved to module-level `FORMAT` / `ALIASES` /
   `DEFAULT_FILENAMES` constants. The canonical lockfile `FORMAT` is
   now `conda-workspaces-lock-v1`; `conda-workspaces-lock` and
   `workspace-lock` remain as aliases. See
-  `docs/reference/format-aliases.md`.
+  `docs/reference/format-aliases.md`. (<gh-pr:29>, <gh-pr:35>)
 - `generate_lockfile` now builds
   `conda.models.environment.Environment` objects and delegates YAML
   serialisation to the same `multiplatform_export` hook as
   `conda export --format=conda-workspaces-lock-v1`. `conda workspace
   lock` and `conda export` now produce byte-identical output.
+  (<gh-pr:35>)
 - `conda_workspaces.lockfile` owns both the write path and the
   `CondaEnvironmentSpecifier` plugin (`CondaLockLoader`), and
   delegates YAML→`Environment` conversion to
   `conda_lockfiles.rattler_lock.v6`. `conda.lock` is documented as a
   derivative of rattler-lock v6 (`pixi.lock`): same schema family,
-  distinct filename and on-disk version byte.
+  distinct filename and on-disk version byte. (<gh-issue:4>, <gh-pr:29>)
 - Bumped the optional `conda-spawn` dependency floor from `>=0.0.5` to
   `>=0.1.0` to pick up the new fish/csh/tcsh/xonsh shell support and
   the double-prompt / PowerShell `-NoExit` / `$CONDA_ROOT/condabin`
   fixes. The integration in `cli/workspace/shell.py` is unchanged
-  (`conda_spawn.main.spawn` is still the entry point).
+  (`conda_spawn.main.spawn` is still the entry point). (<gh-pr:49>)
 - `conda task run <task>` (and the `ct run` alias) now falls back to
   the workspace's `default` environment when the task doesn't declare
   a `default_environment`, instead of inheriting whichever conda env
   happened to be active at the call site. Pass `-e` explicitly to
-  override.
+  override. (<gh-issue:26>, <gh-pr:27>)
 
 ### Fixed
 
 - `conda workspace quickstart` crashed every invocation with
   `AttributeError: 'Namespace' object has no attribute 'verbose'`
-  after conda renamed the namespace dest to `verbosity`.
+  after conda renamed the namespace dest to `verbosity`. (<gh-pr:46>)
 - `conda workspace quickstart --json` no longer leaks Rich status
   lines from the sub-handlers (`init`, `add`, `install`) into stdout;
   the JSON payload is the only thing emitted on stdout, matching the
-  documented `--json contract`.
+  documented `--json contract`. (<gh-pr:46>)
 
 ## 0.3.0 — 2026-03-31
 
@@ -214,63 +225,77 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 - `conda workspace import` command to convert `environment.yml`,
   `anaconda-project.yml`, `conda-project.yml`, `pixi.toml`, and
-  `pyproject.toml` manifests to `conda.toml`
+  `pyproject.toml` manifests to `conda.toml` (<gh-issue:12>, <gh-pr:13>)
 - Progress output during import (reading, format detection, write status)
-- Syntax-highlighted TOML preview in `--dry-run` mode
+  (<gh-pr:13>)
+- Syntax-highlighted TOML preview in `--dry-run` mode (<gh-pr:13>)
 - `conda task add` and `conda task remove` support for `pixi.toml` and
-  `pyproject.toml` manifests
-- Codecov integration and coverage badge
-- CI, docs, PyPI, and conda-forge badges to README
+  `pyproject.toml` manifests (<gh-issue:8>, <gh-pr:9>, <gh-pr:10>)
+- Codecov integration and coverage badge (<gh-pr:15>)
+- CI, docs, PyPI, and conda-forge badges to README (<gh-pr:15>)
 - Documentation for `CONDA_PKGS_DIRS` hardlink optimization in CI/Docker
-- Diataxis-organized documentation sidebar
+  (<gh-issue:5>, <gh-pr:10>)
+- Diataxis-organized documentation sidebar (<gh-pr:11>)
 
 ### Changed
 
 - Import format detection uses human-readable labels instead of class names
+  (<gh-pr:13>)
 - Importers use `packaging.Requirement` for robust pip dependency parsing
+  (<gh-pr:13>)
 - Simplified importer registry to a single `find_importer` function
+  (<gh-pr:13>)
 - Unified installation docs (conda install and pixi global install)
+  (<gh-pr:15>)
 
 ### Fixed
 
 - `--dry-run` output no longer strips TOML section headers in non-terminal
-  environments
+  environments (<gh-pr:13>)
 - Trailing dot suppressed in import status when output is in the current
-  directory
+  directory (<gh-pr:13>)
 
 ## 0.2.0 — 2026-03-30
 
 ### Added
 
 - `conda task` subcommand with `run`, `list`, `add`, `remove`, and `export`
+  (<gh-pr:1>)
 - `conda workspace run` command for one-shot execution in environments
-- Task dependencies with topological ordering (`depends-on`)
-- Jinja2 template support in task commands (`{{ conda.platform }}`, conditionals)
-- Task output caching with input/output file declarations
-- Per-platform task overrides via `[target.<platform>.tasks]`
-- Task arguments with default values
+  (<gh-pr:1>)
+- Task dependencies with topological ordering (`depends-on`) (<gh-pr:1>)
+- Jinja2 template support in task commands (`{{ conda.platform }}`,
+  conditionals) (<gh-pr:1>)
+- Task output caching with input/output file declarations (<gh-pr:1>)
+- Per-platform task overrides via `[target.<platform>.tasks]` (<gh-pr:1>)
+- Task arguments with default values (<gh-pr:1>)
 - Rich terminal output for all CLI commands (tables, status, errors)
-- Structured error rendering with actionable hints
-- Integration tests for CLI workflows
-- Demo recordings for terminal screencasts
+  (<gh-pr:1>)
+- Structured error rendering with actionable hints (<gh-pr:1>)
+- Integration tests for CLI workflows (<gh-pr:1>)
+- Demo recordings for terminal screencasts (<gh-pr:1>)
 
 ### Changed
 
 - Verb-based status messages (Installing, Installed, etc.) replace
-  symbol-based markers
+  symbol-based markers (<gh-pr:1>)
 - All CLI output routed through Rich console for consistent formatting
+  (<gh-pr:1>)
 - Documentation standardized to use `conda workspace` / `conda task`
-  as primary CLI forms (`cw` / `ct` noted as aliases)
+  as primary CLI forms (`cw` / `ct` noted as aliases) (<gh-pr:1>)
 - Aligned parsers with pixi workspace semantics for broader manifest
-  compatibility
+  compatibility (<gh-pr:1>)
 - Exception hierarchy expanded with type annotations and actionable hints
+  (<gh-pr:1>)
 
 ### Fixed
 
 - JSON output in `conda task list --json` no longer includes ANSI escapes
+  (<gh-pr:1>)
 - Activation script handling on Windows uses correct path validation
-- Solver output noise suppressed during lockfile generation
-- Stdout flushed after conda solver and transaction API calls
+  (<gh-pr:1>)
+- Solver output noise suppressed during lockfile generation (<gh-pr:1>)
+- Stdout flushed after conda solver and transaction API calls (<gh-pr:1>)
 
 ## 0.1.1 — 2026-03-05
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,23 @@ myst_enable_extensions = [
     "tasklist",
 ]
 
+myst_url_schemes = {
+    "http": None,
+    "https": None,
+    "mailto": None,
+    "ftp": None,
+    "gh-issue": {
+        "url": ("https://github.com/conda-incubator/conda-workspaces/issues/{{path}}"),
+        "title": "Issue #{{path}}",
+        "classes": ["github"],
+    },
+    "gh-pr": {
+        "url": ("https://github.com/conda-incubator/conda-workspaces/pull/{{path}}"),
+        "title": "PR #{{path}}",
+        "classes": ["github"],
+    },
+}
+
 
 html_theme = "conda_sphinx_theme"
 


### PR DESCRIPTION
## Summary

- configure MyST `myst_url_schemes` for GitHub issue and pull request references
- convert the 0.5.0 changelog references to MyST angle-link syntax like `<gh-issue:53>` and `<gh-pr:54>`
- retroactively add issue and PR references to older changelog entries where the historical mapping is clear

## Notes

The root `CHANGELOG.md` is included by `docs/changelog.md`, so these MyST URL schemes render as proper links in the published docs without adding another Sphinx dependency. I used issue links for tracked issues and pull links for implementation PRs.

## Verification

- `pixi run -e docs docs`
- `pixi run -e dev check`
- `pixi run ruff check docs/conf.py`
- `pixi run ruff format --check docs/conf.py`
- `git diff --check`
- spot-checked `docs/_build/dirhtml/changelog/index.html` for generated GitHub issue and pull URLs
