### PR TITLE
Fix release distribution build command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
       - name: Build sdist and wheel
-        run: pipx run build
+        run: pipx run --spec build==1.5.0 pyproject-build
 
       - name: Upload distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -40,7 +41,7 @@ jobs:
     environment: pypi
 
     permissions:
-      id-token: write
+      id-token: write # Required for PyPI trusted publishing.
 
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -58,7 +59,7 @@ jobs:
     needs: [publish-pypi]
 
     permissions:
-      contents: write
+      contents: write # Required to upload built distributions to the published GitHub Release.
 
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## Summary

- replace the release workflow's failing `pipx run build` call with the actual PyPA build frontend executable
- pin the build frontend used during release publishing to `build==1.5.0`
- harden the release workflow checkout and document write/OIDC permissions for `zizmor`

## Verification

- `pipx run build --outdir /tmp/conda-workspaces-release-dist` fails locally because the `build` package does not provide a `build` executable
- `pipx run --spec build==1.5.0 pyproject-build --outdir /tmp/conda-workspaces-release-dist`
- `zizmor --persona auditor .github/workflows/release.yml`
- `git diff --check`
