### PR TITLE
Support unarchive installs to explicit prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## Unreleased
 
+### Added
+
+- `conda workspace unarchive --install` can install a selected
+  environment to an explicit final prefix with `-e/--environment` and
+  `--prefix`. `--dest` stages files below a filesystem root while
+  preserving the requested runtime prefix inside the installed
+  environment. (<gh-issue:77>)
+
 ## 0.5.0 — 2026-06-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   environment to an explicit final prefix with `-e/--environment` and
   `--prefix`. `--dest` stages files below a filesystem root while
   preserving the requested runtime prefix inside the installed
-  environment. (<gh-issue:77>)
+  environment, and warns if installed files still reference the
+  staging prefix. (<gh-issue:77>)
 
 ## 0.5.0 — 2026-06-02
 

--- a/conda_workspaces/cli/main.py
+++ b/conda_workspaces/cli/main.py
@@ -589,6 +589,30 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
         help="Install environments from the lockfile after extraction.",
     )
     unarchive_parser.add_argument(
+        "-e",
+        "--environment",
+        default=None,
+        help="Install only this environment when used with --install.",
+    )
+    unarchive_parser.add_argument(
+        "--prefix",
+        type=Path,
+        default=None,
+        help=(
+            "Final runtime prefix for the selected environment."
+            " Requires --install and -e/--environment."
+        ),
+    )
+    unarchive_parser.add_argument(
+        "--dest",
+        type=Path,
+        default=None,
+        help=(
+            "Optional staging root. With --prefix, files are written below"
+            " DEST + PREFIX while preserving PREFIX as the runtime prefix."
+        ),
+    )
+    unarchive_parser.add_argument(
         "--no-install",
         action="store_true",
         default=False,

--- a/conda_workspaces/cli/main.py
+++ b/conda_workspaces/cli/main.py
@@ -596,7 +596,6 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
     )
     unarchive_parser.add_argument(
         "--prefix",
-        type=Path,
         default=None,
         help=(
             "Final runtime prefix for the selected environment."

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import argparse
-from pathlib import Path
+from os.path import expanduser
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 from rich.console import Console
 from rich.markup import escape
@@ -22,6 +23,21 @@ from ...lockfile import lockfile_path as _lockfile_path
 from ...models import ArchiveConfig
 from .. import status
 from . import workspace_context_from_args
+
+
+def is_absolute_runtime_prefix(prefix: str) -> bool:
+    """Return whether *prefix* is absolute as a POSIX or Windows path."""
+    return PurePosixPath(prefix).is_absolute() or PureWindowsPath(prefix).is_absolute()
+
+
+def runtime_prefix_relative_path(prefix: str) -> Path:
+    """Return *prefix* relative to its root using host path separators."""
+    posix_prefix = PurePosixPath(prefix)
+    if posix_prefix.is_absolute():
+        return Path(*posix_prefix.relative_to(posix_prefix.anchor).parts)
+
+    windows_prefix = PureWindowsPath(prefix)
+    return Path(*windows_prefix.relative_to(windows_prefix.anchor).parts)
 
 
 def file_contains_bytes(
@@ -70,7 +86,7 @@ def warn_staging_prefix_references(
     console: Console,
     *,
     install_prefix: Path,
-    runtime_prefix: Path,
+    runtime_prefix: str,
 ) -> None:
     """Warn when a staged install still contains the physical staging prefix."""
     matches, truncated = scan_prefix_references(install_prefix, install_prefix)
@@ -206,7 +222,8 @@ def execute_unarchive(
         )
 
     env_name = getattr(args, "environment", None)
-    final_prefix = getattr(args, "prefix", None)
+    final_prefix_arg = getattr(args, "prefix", None)
+    final_prefix = str(final_prefix_arg) if final_prefix_arg is not None else None
     dest = getattr(args, "dest", None)
 
     if final_prefix is not None and not args.install:
@@ -235,8 +252,8 @@ def execute_unarchive(
                 ],
             )
         if final_prefix is not None:
-            final_prefix = Path(final_prefix).expanduser()
-            if not final_prefix.is_absolute():
+            final_prefix = expanduser(final_prefix)
+            if not is_absolute_runtime_prefix(final_prefix):
                 raise ArchiveError(
                     "--prefix must be an absolute path.",
                     hints=["Pass an absolute runtime prefix such as /opt/runtime."],
@@ -272,13 +289,14 @@ def execute_unarchive(
                 )
 
     if args.install:
-        install_prefix = final_prefix
+        install_prefix = Path(final_prefix) if final_prefix is not None else None
         target_prefix_override = None
         if final_prefix is not None:
-            install_prefix = final_prefix
             if dest is not None:
                 dest = Path(dest).expanduser().resolve()
-                install_prefix = dest / final_prefix.relative_to(final_prefix.anchor)
+                install_prefix = dest / runtime_prefix_relative_path(final_prefix)
+                target_prefix_override = final_prefix
+            elif str(install_prefix) != final_prefix:
                 target_prefix_override = final_prefix
 
         from .install import execute_install

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -23,14 +23,6 @@ from .. import status
 from . import workspace_context_from_args
 
 
-def _prefix_under_dest(dest: Path, prefix: Path) -> Path:
-    """Return the physical install path for *prefix* staged below *dest*."""
-    parts = prefix.parts
-    if prefix.anchor and parts and parts[0] == prefix.anchor:
-        parts = parts[1:]
-    return dest.joinpath(*parts)
-
-
 def execute_archive(
     args: argparse.Namespace,
     *,
@@ -216,7 +208,7 @@ def execute_unarchive(
             install_prefix = final_prefix
             if dest is not None:
                 dest = Path(dest).expanduser().resolve()
-                install_prefix = _prefix_under_dest(dest, final_prefix)
+                install_prefix = dest / final_prefix.relative_to(final_prefix.anchor)
                 target_prefix_override = final_prefix
 
         from .install import execute_install

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -23,6 +23,14 @@ from .. import status
 from . import workspace_context_from_args
 
 
+def _prefix_under_dest(dest: Path, prefix: Path) -> Path:
+    """Return the physical install path for *prefix* staged below *dest*."""
+    parts = prefix.parts
+    if prefix.anchor and parts and parts[0] == prefix.anchor:
+        parts = parts[1:]
+    return dest.joinpath(*parts)
+
+
 def execute_archive(
     args: argparse.Namespace,
     *,
@@ -135,6 +143,43 @@ def execute_unarchive(
             hints=["This does not appear to be a conda workspace archive."],
         )
 
+    env_name = getattr(args, "environment", None)
+    final_prefix = getattr(args, "prefix", None)
+    dest = getattr(args, "dest", None)
+
+    if final_prefix is not None and not args.install:
+        raise ArchiveError(
+            "--prefix requires --install.",
+            hints=["Pass --install when installing to an explicit prefix."],
+        )
+    if dest is not None and not args.install:
+        raise ArchiveError(
+            "--dest requires --install.",
+            hints=["Pass --install when using a staging destination."],
+        )
+
+    if args.install:
+        if final_prefix is not None and not env_name:
+            raise ArchiveError(
+                "--prefix requires an explicit environment.",
+                hints=["Pass -e/--environment with --prefix."],
+            )
+        if dest is not None and final_prefix is None:
+            raise ArchiveError(
+                "--dest requires --prefix.",
+                hints=[
+                    "Pass --prefix to declare the final runtime prefix for"
+                    " the selected environment.",
+                ],
+            )
+        if final_prefix is not None:
+            final_prefix = Path(final_prefix).expanduser()
+            if not final_prefix.is_absolute():
+                raise ArchiveError(
+                    "--prefix must be an absolute path.",
+                    hints=["Pass an absolute runtime prefix such as /opt/runtime."],
+                )
+
     status.message(
         console,
         "Extracting",
@@ -165,16 +210,27 @@ def execute_unarchive(
                 )
 
     if args.install:
+        install_prefix = final_prefix
+        target_prefix_override = None
+        if final_prefix is not None:
+            install_prefix = final_prefix
+            if dest is not None:
+                dest = Path(dest).expanduser().resolve()
+                install_prefix = _prefix_under_dest(dest, final_prefix)
+                target_prefix_override = final_prefix
+
         from .install import execute_install
 
         install_args = argparse.Namespace(
             file=str(target),
-            environment=None,
+            environment=env_name,
             force_reinstall=False,
             locked=True,
             frozen=False,
             dry_run=False,
             json=False,
+            prefix=install_prefix,
+            target_prefix_override=target_prefix_override,
         )
         return execute_install(install_args, console=console)
 

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -6,6 +6,7 @@ import argparse
 from pathlib import Path
 
 from rich.console import Console
+from rich.markup import escape
 
 from ...archive import (
     ARCHIVE_SUFFIXES,
@@ -21,6 +22,75 @@ from ...lockfile import lockfile_path as _lockfile_path
 from ...models import ArchiveConfig
 from .. import status
 from . import workspace_context_from_args
+
+
+def file_contains_bytes(
+    path: Path, needle: bytes, *, chunk_size: int = 1024 * 1024
+) -> bool:
+    """Return whether *path* contains *needle* without loading it all at once."""
+    if not needle:
+        return False
+
+    overlap = b""
+    try:
+        with path.open("rb") as fh:
+            while chunk := fh.read(chunk_size):
+                data = overlap + chunk
+                if needle in data:
+                    return True
+                overlap = data[-(len(needle) - 1) :] if len(needle) > 1 else b""
+    except OSError:
+        return False
+    return False
+
+
+def scan_prefix_references(
+    root: Path,
+    prefix: Path,
+    *,
+    limit: int = 10,
+) -> tuple[list[Path], bool]:
+    """Find files below *root* that still contain *prefix* as bytes."""
+    if not root.is_dir():
+        return [], False
+
+    needle = str(prefix).encode()
+    matches: list[Path] = []
+    for path in root.rglob("*"):
+        if path.is_symlink() or not path.is_file():
+            continue
+        if file_contains_bytes(path, needle):
+            matches.append(path)
+            if len(matches) > limit:
+                return matches[:limit], True
+    return matches, False
+
+
+def warn_staging_prefix_references(
+    console: Console,
+    *,
+    install_prefix: Path,
+    runtime_prefix: Path,
+) -> None:
+    """Warn when a staged install still contains the physical staging prefix."""
+    matches, truncated = scan_prefix_references(install_prefix, install_prefix)
+    if not matches:
+        return
+
+    console.print(
+        "[bold yellow]Warning:[/bold yellow] "
+        "installed files still reference the staging prefix"
+    )
+    console.print(f"  [dim]staging prefix:[/dim] {escape(str(install_prefix))}")
+    console.print(f"  [dim]runtime prefix:[/dim] {escape(str(runtime_prefix))}")
+    for path in matches:
+        try:
+            display_path = path.relative_to(install_prefix)
+        except ValueError:
+            display_path = path
+        console.print(f"  [dim]- {escape(str(display_path))}[/dim]")
+    if truncated:
+        console.print("  [dim]additional matches omitted[/dim]")
 
 
 def execute_archive(
@@ -224,6 +294,17 @@ def execute_unarchive(
             prefix=install_prefix,
             target_prefix_override=target_prefix_override,
         )
-        return execute_install(install_args, console=console)
+        result = execute_install(install_args, console=console)
+        if (
+            result == 0
+            and install_prefix is not None
+            and target_prefix_override is not None
+        ):
+            warn_staging_prefix_references(
+                console,
+                install_prefix=install_prefix,
+                runtime_prefix=target_prefix_override,
+            )
+        return result
 
     return 0

--- a/conda_workspaces/cli/workspace/install.py
+++ b/conda_workspaces/cli/workspace/install.py
@@ -102,7 +102,7 @@ def install_from_lockfile_all(
     *,
     console: Console,
     prefix: Path | None = None,
-    target_prefix_override: Path | None = None,
+    target_prefix_override: str | Path | None = None,
 ) -> int:
     """Install environments from existing lockfiles (no solving)."""
     if (prefix is not None or target_prefix_override is not None) and not env_name:

--- a/conda_workspaces/cli/workspace/install.py
+++ b/conda_workspaces/cli/workspace/install.py
@@ -33,9 +33,18 @@ def execute_install(args: argparse.Namespace, *, console: Console | None = None)
     locked = getattr(args, "locked", False)
     frozen = getattr(args, "frozen", False)
     no_lock = getattr(args, "no_lock", False)
+    prefix = getattr(args, "prefix", None)
+    target_prefix_override = getattr(args, "target_prefix_override", None)
 
     if frozen:
-        return install_from_lockfile_all(ctx, config, env_name, console=console)
+        return install_from_lockfile_all(
+            ctx,
+            config,
+            env_name,
+            console=console,
+            prefix=prefix,
+            target_prefix_override=target_prefix_override,
+        )
 
     strict = locked or (ctx.is_ci and not no_lock)
     if strict:
@@ -48,12 +57,26 @@ def execute_install(args: argparse.Namespace, *, console: Console | None = None)
                 lockfile_path(ctx),
                 reason=lock.reason,
             )
-        return install_from_lockfile_all(ctx, config, env_name, console=console)
+        return install_from_lockfile_all(
+            ctx,
+            config,
+            env_name,
+            console=console,
+            prefix=prefix,
+            target_prefix_override=target_prefix_override,
+        )
 
     if not no_lock and not force:
         lock = lockfile_status(ctx, config)
         if lock.status == LockfileStatus.UP_TO_DATE:
-            return install_from_lockfile_all(ctx, config, env_name, console=console)
+            return install_from_lockfile_all(
+                ctx,
+                config,
+                env_name,
+                console=console,
+                prefix=prefix,
+                target_prefix_override=target_prefix_override,
+            )
         if lock.status == LockfileStatus.OUT_OF_DATE:
             console.print(
                 f"[bold yellow]Lockfile out of date[/bold yellow]:"
@@ -78,8 +101,18 @@ def install_from_lockfile_all(
     env_name: str | None,
     *,
     console: Console,
+    prefix: Path | None = None,
+    target_prefix_override: Path | None = None,
 ) -> int:
     """Install environments from existing lockfiles (no solving)."""
+    if (prefix is not None or target_prefix_override is not None) and not env_name:
+        from ...exceptions import CondaWorkspacesError
+
+        raise CondaWorkspacesError(
+            "Explicit prefix installation requires an environment name.",
+            hints=["Pass -e/--environment with --prefix."],
+        )
+
     if env_name:
         status.message(
             console,
@@ -89,7 +122,15 @@ def install_from_lockfile_all(
             style="bold blue",
             ellipsis=True,
         )
-        install_from_lockfile(ctx, env_name)
+        if prefix is None and target_prefix_override is None:
+            install_from_lockfile(ctx, env_name)
+        else:
+            install_from_lockfile(
+                ctx,
+                env_name,
+                prefix=prefix,
+                target_prefix_override=target_prefix_override,
+            )
         status.message(console, "Installed", "environment", env_name)
     else:
         env_names = list(config.environments)

--- a/conda_workspaces/lockfile.py
+++ b/conda_workspaces/lockfile.py
@@ -634,7 +634,7 @@ def install_from_lockfile(
     env_name: str,
     *,
     prefix: Path | None = None,
-    target_prefix_override: Path | None = None,
+    target_prefix_override: str | Path | None = None,
 ) -> None:
     """Install an environment from ``conda.lock``.
 

--- a/conda_workspaces/lockfile.py
+++ b/conda_workspaces/lockfile.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import io
 import sys
+from contextlib import nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -628,7 +629,13 @@ def merge_lockfiles(paths: Sequence[Path], ctx: WorkspaceContext) -> Path:
     return out_path
 
 
-def install_from_lockfile(ctx: WorkspaceContext, env_name: str) -> None:
+def install_from_lockfile(
+    ctx: WorkspaceContext,
+    env_name: str,
+    *,
+    prefix: Path | None = None,
+    target_prefix_override: Path | None = None,
+) -> None:
     """Install an environment from ``conda.lock``.
 
     Reads the lockfile via :class:`CondaLockLoader`, extracts the
@@ -639,6 +646,7 @@ def install_from_lockfile(ctx: WorkspaceContext, env_name: str) -> None:
     Raises ``LockfileNotFoundError`` if the lockfile is missing or does
     not contain the requested environment/platform.
     """
+    from conda.base.context import context as conda_context
     from conda.misc import (
         get_package_records_from_explicit,
         install_explicit_packages,
@@ -660,12 +668,22 @@ def install_from_lockfile(ctx: WorkspaceContext, env_name: str) -> None:
 
     urls = [ref["conda"] for ref in platform_pkgs if "conda" in ref]
 
-    prefix = ctx.env_prefix(env_name)
-    prefix.mkdir(parents=True, exist_ok=True)
+    install_prefix = prefix or ctx.env_prefix(env_name)
+    install_prefix.mkdir(parents=True, exist_ok=True)
 
-    records = get_package_records_from_explicit(urls)
-    install_explicit_packages(
-        package_cache_records=list(records),
-        prefix=str(prefix),
+    override = (
+        conda_context._override(
+            "target_prefix_override",
+            str(target_prefix_override),
+        )
+        if target_prefix_override is not None
+        else nullcontext()
     )
+
+    with override:
+        records = get_package_records_from_explicit(urls)
+        install_explicit_packages(
+            package_cache_records=list(records),
+            prefix=str(install_prefix),
+        )
     sys.stdout.flush()

--- a/docs/features.md
+++ b/docs/features.md
@@ -767,6 +767,17 @@ Extract an archive and install environments in one step:
 conda workspace unarchive my-project.tar.zst --target ./restored --install
 ```
 
+Install one archived environment to a final runtime prefix, optionally
+under a staged filesystem root:
+
+```bash
+conda workspace unarchive my-project.tar.zst \
+  --install \
+  --dest /tmp/rootfs \
+  -e runtime \
+  --prefix /opt/runtime
+```
+
 Pass `--lock` to solve and update the lockfile before archiving:
 
 ```bash

--- a/docs/features.md
+++ b/docs/features.md
@@ -778,6 +778,9 @@ conda workspace unarchive my-project.tar.zst \
   --prefix /opt/runtime
 ```
 
+When `--dest` is used, `unarchive` warns if installed files still
+reference the physical staging prefix.
+
 Pass `--lock` to solve and update the lockfile before archiving:
 
 ```bash

--- a/docs/tutorials/archives.md
+++ b/docs/tutorials/archives.md
@@ -128,6 +128,8 @@ conda workspace unarchive my-project.tar.zst \
 
 With `--dest`, files are written under `/tmp/rootfs/opt/runtime`, but
 the environment's final runtime prefix remains `/opt/runtime`.
+`unarchive` warns if any installed files still reference the physical
+staging prefix.
 
 ## Lock before archiving
 

--- a/docs/tutorials/archives.md
+++ b/docs/tutorials/archives.md
@@ -99,6 +99,36 @@ conda workspace unarchive my-project.tar.zst --target /path/to/destination --ins
 This is equivalent to extracting, changing into the directory, and
 running `conda workspace install --locked`, but without the extra steps.
 
+## Install an environment to an explicit prefix
+
+Use `-e/--environment` with `--prefix` to install one archived workspace
+environment to a final runtime prefix:
+
+```bash
+conda workspace unarchive my-project.tar.zst \
+  --target /tmp/workspace \
+  --install \
+  -e runtime \
+  --prefix /opt/runtime
+```
+
+This extracts the workspace into `/tmp/workspace` and installs the
+`runtime` environment from the lockfile directly at `/opt/runtime`.
+
+For image builders or staged filesystem roots, add `--dest`:
+
+```bash
+conda workspace unarchive my-project.tar.zst \
+  --target /tmp/workspace \
+  --install \
+  --dest /tmp/rootfs \
+  -e runtime \
+  --prefix /opt/runtime
+```
+
+With `--dest`, files are written under `/tmp/rootfs/opt/runtime`, but
+the environment's final runtime prefix remains `/opt/runtime`.
+
 ## Lock before archiving
 
 If your lockfile is out of date or does not exist yet, pass `--lock`

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -311,5 +311,5 @@ def test_unarchive_subparser_registered() -> None:
     assert str(ns.archive_path) == "project.tar.gz"
     assert ns.install is True
     assert ns.environment == "runtime"
-    assert str(ns.prefix) == "/opt/runtime"
+    assert ns.prefix == "/opt/runtime"
     assert str(ns.dest) == "/tmp/rootfs"

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import importlib
+from pathlib import Path
 
 import pytest
 
@@ -312,4 +313,4 @@ def test_unarchive_subparser_registered() -> None:
     assert ns.install is True
     assert ns.environment == "runtime"
     assert ns.prefix == "/opt/runtime"
-    assert str(ns.dest) == "/tmp/rootfs"
+    assert ns.dest == Path("/tmp/rootfs")

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -294,6 +294,22 @@ def test_archive_subparser_registered() -> None:
 
 def test_unarchive_subparser_registered() -> None:
     parser = generate_workspace_parser()
-    ns = parser.parse_args(["unarchive", "project.tar.gz"])
+    ns = parser.parse_args(
+        [
+            "unarchive",
+            "project.tar.gz",
+            "--install",
+            "-e",
+            "runtime",
+            "--prefix",
+            "/opt/runtime",
+            "--dest",
+            "/tmp/rootfs",
+        ]
+    )
     assert ns.subcmd == "unarchive"
     assert str(ns.archive_path) == "project.tar.gz"
+    assert ns.install is True
+    assert ns.environment == "runtime"
+    assert str(ns.prefix) == "/opt/runtime"
+    assert str(ns.dest) == "/tmp/rootfs"

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -271,6 +271,53 @@ def test_execute_unarchive_install_explicit_prefix_under_dest(
     assert install_args.target_prefix_override == prefix
 
 
+def test_execute_unarchive_install_under_dest_warns_on_staging_prefix_reference(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    stream = StringIO()
+    console = Console(file=stream, width=200, highlight=False)
+
+    args_a = make_args(_ARCHIVE_DEFAULTS, output=archive)
+    execute_archive(args_a, console=console)
+
+    def fake_execute_install(args, *, console=None):
+        script = args.prefix / "bin" / "tool"
+        script.parent.mkdir(parents=True)
+        script.write_text(f"#!{args.prefix}/bin/python\n", encoding="utf-8")
+        return 0
+
+    monkeypatch.setattr(
+        "conda_workspaces.cli.workspace.install.execute_install",
+        fake_execute_install,
+    )
+
+    target = tmp_path / "extracted"
+    dest = tmp_path / "rootfs"
+    prefix = Path("/opt/runtime")
+    args_u = make_args(
+        _UNARCHIVE_DEFAULTS,
+        archive_path=archive,
+        target=target,
+        install=True,
+        environment="runtime",
+        prefix=prefix,
+        dest=dest,
+    )
+    result = execute_unarchive(args_u, console=console)
+
+    assert result == 0
+    output = stream.getvalue()
+    assert "Warning:" in output
+    assert "installed files still reference the staging prefix" in output
+    assert str(dest / "opt" / "runtime") in output
+    assert "/opt/runtime" in output
+    assert "bin/tool" in output
+
+
 def test_execute_unarchive_prefix_requires_install(
     archive_workspace: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -4,17 +4,15 @@ from __future__ import annotations
 
 import tarfile
 from io import StringIO
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 from rich.console import Console
 
 from conda_workspaces.cli.workspace.archive import execute_archive, execute_unarchive
+from conda_workspaces.exceptions import ArchiveError
 
 from ..conftest import make_args
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 _ARCHIVE_DEFAULTS = {
     "file": None,
@@ -32,6 +30,9 @@ _UNARCHIVE_DEFAULTS = {
     "target": None,
     "install": False,
     "no_install": False,
+    "environment": None,
+    "prefix": None,
+    "dest": None,
     "dry_run": False,
     "json": False,
 }
@@ -179,3 +180,186 @@ def test_execute_unarchive_no_unsigned_warning(
     lower = output.lower()
     assert "not signed" not in lower
     assert "unsigned" not in lower
+
+
+def test_execute_unarchive_install_explicit_prefix(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    args_a = make_args(_ARCHIVE_DEFAULTS, output=archive)
+    execute_archive(args_a, console=console)
+
+    install_calls: list[object] = []
+
+    def fake_execute_install(args, *, console=None):
+        install_calls.append(args)
+        return 0
+
+    monkeypatch.setattr(
+        "conda_workspaces.cli.workspace.install.execute_install",
+        fake_execute_install,
+    )
+
+    target = tmp_path / "extracted"
+    prefix = Path("/opt/runtime")
+    args_u = make_args(
+        _UNARCHIVE_DEFAULTS,
+        archive_path=archive,
+        target=target,
+        install=True,
+        environment="runtime",
+        prefix=prefix,
+    )
+    result = execute_unarchive(args_u, console=console)
+
+    assert result == 0
+    assert len(install_calls) == 1
+    install_args = install_calls[0]
+    assert install_args.file == str(target)
+    assert install_args.environment == "runtime"
+    assert install_args.locked is True
+    assert install_args.prefix == prefix
+    assert install_args.target_prefix_override is None
+
+
+def test_execute_unarchive_install_explicit_prefix_under_dest(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    args_a = make_args(_ARCHIVE_DEFAULTS, output=archive)
+    execute_archive(args_a, console=console)
+
+    install_calls: list[object] = []
+
+    def fake_execute_install(args, *, console=None):
+        install_calls.append(args)
+        return 0
+
+    monkeypatch.setattr(
+        "conda_workspaces.cli.workspace.install.execute_install",
+        fake_execute_install,
+    )
+
+    target = tmp_path / "extracted"
+    dest = tmp_path / "rootfs"
+    prefix = Path("/opt/runtime")
+    args_u = make_args(
+        _UNARCHIVE_DEFAULTS,
+        archive_path=archive,
+        target=target,
+        install=True,
+        environment="runtime",
+        prefix=prefix,
+        dest=dest,
+    )
+    result = execute_unarchive(args_u, console=console)
+
+    assert result == 0
+    assert len(install_calls) == 1
+    install_args = install_calls[0]
+    assert install_args.prefix == dest / "opt" / "runtime"
+    assert install_args.target_prefix_override == prefix
+
+
+def test_execute_unarchive_prefix_requires_install(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    args_a = make_args(_ARCHIVE_DEFAULTS, output=archive)
+    execute_archive(args_a, console=console)
+
+    args_u = make_args(
+        _UNARCHIVE_DEFAULTS,
+        archive_path=archive,
+        target=tmp_path / "extracted",
+        environment="runtime",
+        prefix=Path("/opt/runtime"),
+    )
+    with pytest.raises(ArchiveError, match="--prefix requires --install"):
+        execute_unarchive(args_u, console=console)
+
+
+def test_execute_unarchive_prefix_requires_environment(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    args_a = make_args(_ARCHIVE_DEFAULTS, output=archive)
+    execute_archive(args_a, console=console)
+
+    args_u = make_args(
+        _UNARCHIVE_DEFAULTS,
+        archive_path=archive,
+        target=tmp_path / "extracted",
+        install=True,
+        prefix=Path("/opt/runtime"),
+    )
+    with pytest.raises(ArchiveError, match="--prefix requires an explicit"):
+        execute_unarchive(args_u, console=console)
+
+
+def test_execute_unarchive_dest_requires_prefix(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    args_a = make_args(_ARCHIVE_DEFAULTS, output=archive)
+    execute_archive(args_a, console=console)
+
+    args_u = make_args(
+        _UNARCHIVE_DEFAULTS,
+        archive_path=archive,
+        target=tmp_path / "extracted",
+        install=True,
+        environment="runtime",
+        dest=tmp_path / "rootfs",
+    )
+    with pytest.raises(ArchiveError, match="--dest requires --prefix"):
+        execute_unarchive(args_u, console=console)
+
+
+def test_execute_unarchive_prefix_must_be_absolute(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    args_a = make_args(_ARCHIVE_DEFAULTS, output=archive)
+    execute_archive(args_a, console=console)
+
+    args_u = make_args(
+        _UNARCHIVE_DEFAULTS,
+        archive_path=archive,
+        target=tmp_path / "extracted",
+        install=True,
+        environment="runtime",
+        prefix=Path("relative/prefix"),
+    )
+    with pytest.raises(ArchiveError, match="--prefix must be an absolute path"):
+        execute_unarchive(args_u, console=console)

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -9,7 +9,14 @@ from pathlib import Path
 import pytest
 from rich.console import Console
 
-from conda_workspaces.cli.workspace.archive import execute_archive, execute_unarchive
+from conda_workspaces.cli.workspace.archive import (
+    execute_archive,
+    execute_unarchive,
+    file_contains_bytes,
+    is_absolute_runtime_prefix,
+    runtime_prefix_relative_path,
+    scan_prefix_references,
+)
 from conda_workspaces.exceptions import ArchiveError
 
 from ..conftest import make_args
@@ -36,6 +43,68 @@ _UNARCHIVE_DEFAULTS = {
     "dry_run": False,
     "json": False,
 }
+
+
+@pytest.mark.parametrize(
+    ("prefix", "expected"),
+    [
+        ("/opt/runtime", True),
+        ("/usr/local/vela", True),
+        ("C:/vela/runtime", True),
+        ("C:\\vela\\runtime", True),
+        ("relative/prefix", False),
+        ("runtime", False),
+    ],
+)
+def test_is_absolute_runtime_prefix(prefix: str, expected: bool) -> None:
+    assert is_absolute_runtime_prefix(prefix) is expected
+
+
+@pytest.mark.parametrize(
+    ("prefix", "expected"),
+    [
+        ("/opt/runtime", Path("opt") / "runtime"),
+        ("/usr/local/vela", Path("usr") / "local" / "vela"),
+        ("C:/vela/runtime", Path("vela") / "runtime"),
+        ("C:\\vela\\runtime", Path("vela") / "runtime"),
+    ],
+)
+def test_runtime_prefix_relative_path(prefix: str, expected: Path) -> None:
+    assert runtime_prefix_relative_path(prefix) == expected
+
+
+@pytest.mark.parametrize(
+    ("needle", "expected"),
+    [
+        (b"cde", True),
+        (b"missing", False),
+        (b"", False),
+    ],
+)
+def test_file_contains_bytes(
+    tmp_path: Path,
+    needle: bytes,
+    expected: bool,
+) -> None:
+    path = tmp_path / "payload.bin"
+    path.write_bytes(b"abcde")
+
+    assert file_contains_bytes(path, needle, chunk_size=2) is expected
+
+
+def test_scan_prefix_references_limits_matches(tmp_path: Path) -> None:
+    prefix = tmp_path / "rootfs" / "opt" / "runtime"
+    prefix.mkdir(parents=True)
+    for index in range(3):
+        (prefix / f"match-{index}.txt").write_text(str(prefix), encoding="utf-8")
+    (prefix / "clean.txt").write_text("/opt/runtime", encoding="utf-8")
+    (prefix / "nested").mkdir()
+
+    matches, truncated = scan_prefix_references(prefix, prefix, limit=2)
+
+    assert len(matches) == 2
+    assert truncated is True
+    assert all(path.name.startswith("match-") for path in matches)
 
 
 @pytest.fixture
@@ -228,10 +297,19 @@ def test_execute_unarchive_install_explicit_prefix(
     assert install_args.target_prefix_override == expected_override
 
 
+@pytest.mark.parametrize(
+    ("prefix", "expected_install_suffix"),
+    [
+        ("/opt/runtime", Path("opt") / "runtime"),
+        ("C:/vela/runtime", Path("vela") / "runtime"),
+    ],
+)
 def test_execute_unarchive_install_explicit_prefix_under_dest(
     archive_workspace: Path,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    prefix: str,
+    expected_install_suffix: Path,
 ) -> None:
     monkeypatch.chdir(archive_workspace)
     archive = tmp_path / "test.tar.gz"
@@ -253,7 +331,6 @@ def test_execute_unarchive_install_explicit_prefix_under_dest(
 
     target = tmp_path / "extracted"
     dest = tmp_path / "rootfs"
-    prefix = "/opt/runtime"
     args_u = make_args(
         _UNARCHIVE_DEFAULTS,
         archive_path=archive,
@@ -268,7 +345,7 @@ def test_execute_unarchive_install_explicit_prefix_under_dest(
     assert result == 0
     assert len(install_calls) == 1
     install_args = install_calls[0]
-    assert install_args.prefix == dest / "opt" / "runtime"
+    assert install_args.prefix == dest / expected_install_suffix
     assert install_args.target_prefix_override == prefix
 
 
@@ -317,6 +394,48 @@ def test_execute_unarchive_install_under_dest_warns_on_staging_prefix_reference(
     assert str(dest / "opt" / "runtime") in output
     assert "/opt/runtime" in output
     assert "bin/tool" in output.replace("\\", "/")
+
+
+def test_execute_unarchive_install_under_dest_without_staging_prefix_reference(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    stream = StringIO()
+    console = Console(file=stream, width=200, highlight=False)
+
+    args_a = make_args(_ARCHIVE_DEFAULTS, output=archive)
+    execute_archive(args_a, console=console)
+
+    def fake_execute_install(args, *, console=None):
+        script = args.prefix / "bin" / "tool"
+        script.parent.mkdir(parents=True)
+        script.write_text(
+            f"#!{args.target_prefix_override}/bin/python\n",
+            encoding="utf-8",
+        )
+        return 0
+
+    monkeypatch.setattr(
+        "conda_workspaces.cli.workspace.install.execute_install",
+        fake_execute_install,
+    )
+
+    args_u = make_args(
+        _UNARCHIVE_DEFAULTS,
+        archive_path=archive,
+        target=tmp_path / "extracted",
+        install=True,
+        environment="runtime",
+        prefix="/opt/runtime",
+        dest=tmp_path / "rootfs",
+    )
+    result = execute_unarchive(args_u, console=console)
+
+    assert result == 0
+    assert "Warning:" not in stream.getvalue()
 
 
 def test_execute_unarchive_prefix_requires_install(

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -206,7 +206,7 @@ def test_execute_unarchive_install_explicit_prefix(
     )
 
     target = tmp_path / "extracted"
-    prefix = Path("/opt/runtime")
+    prefix = "/opt/runtime"
     args_u = make_args(
         _UNARCHIVE_DEFAULTS,
         archive_path=archive,
@@ -223,8 +223,9 @@ def test_execute_unarchive_install_explicit_prefix(
     assert install_args.file == str(target)
     assert install_args.environment == "runtime"
     assert install_args.locked is True
-    assert install_args.prefix == prefix
-    assert install_args.target_prefix_override is None
+    assert install_args.prefix == Path(prefix)
+    expected_override = None if str(Path(prefix)) == prefix else prefix
+    assert install_args.target_prefix_override == expected_override
 
 
 def test_execute_unarchive_install_explicit_prefix_under_dest(
@@ -252,7 +253,7 @@ def test_execute_unarchive_install_explicit_prefix_under_dest(
 
     target = tmp_path / "extracted"
     dest = tmp_path / "rootfs"
-    prefix = Path("/opt/runtime")
+    prefix = "/opt/runtime"
     args_u = make_args(
         _UNARCHIVE_DEFAULTS,
         archive_path=archive,
@@ -297,7 +298,7 @@ def test_execute_unarchive_install_under_dest_warns_on_staging_prefix_reference(
 
     target = tmp_path / "extracted"
     dest = tmp_path / "rootfs"
-    prefix = Path("/opt/runtime")
+    prefix = "/opt/runtime"
     args_u = make_args(
         _UNARCHIVE_DEFAULTS,
         archive_path=archive,
@@ -315,7 +316,7 @@ def test_execute_unarchive_install_under_dest_warns_on_staging_prefix_reference(
     assert "installed files still reference the staging prefix" in output
     assert str(dest / "opt" / "runtime") in output
     assert "/opt/runtime" in output
-    assert "bin/tool" in output
+    assert "bin/tool" in output.replace("\\", "/")
 
 
 def test_execute_unarchive_prefix_requires_install(
@@ -335,7 +336,7 @@ def test_execute_unarchive_prefix_requires_install(
         archive_path=archive,
         target=tmp_path / "extracted",
         environment="runtime",
-        prefix=Path("/opt/runtime"),
+        prefix="/opt/runtime",
     )
     with pytest.raises(ArchiveError, match="--prefix requires --install"):
         execute_unarchive(args_u, console=console)
@@ -358,7 +359,7 @@ def test_execute_unarchive_prefix_requires_environment(
         archive_path=archive,
         target=tmp_path / "extracted",
         install=True,
-        prefix=Path("/opt/runtime"),
+        prefix="/opt/runtime",
     )
     with pytest.raises(ArchiveError, match="--prefix requires an explicit"):
         execute_unarchive(args_u, console=console)

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -600,6 +600,73 @@ def test_install_from_lockfile(
     assert install_calls[0]["prefix"] == str(ctx.env_prefix("default"))
 
 
+def test_install_from_lockfile_explicit_prefix_override(
+    tmp_path: Path,
+    workspace_ctx_factory: Callable[..., WorkspaceContext],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """install_from_lockfile can install elsewhere while embedding a final prefix."""
+    ctx = workspace_ctx_factory()
+
+    lockfile = tmp_path / LOCKFILE_NAME
+    lockfile.write_text(
+        "version: 1\n"
+        "environments:\n"
+        "  default:\n"
+        "    channels:\n"
+        "    - url: conda-forge\n"
+        "    packages:\n"
+        "      linux-64:\n"
+        "      - conda: https://example.com/python.conda\n"
+        "packages:\n"
+        "- conda: https://example.com/python.conda\n"
+        "  sha256: aaa\n",
+        encoding="utf-8",
+    )
+
+    records_sentinel = [object()]
+
+    def fake_get_records(lines):
+        assert lines == ["https://example.com/python.conda"]
+        return records_sentinel
+
+    monkeypatch.setattr(
+        "conda.misc.get_package_records_from_explicit",
+        fake_get_records,
+    )
+
+    install_prefix = tmp_path / "rootfs" / "opt" / "runtime"
+    final_prefix = tmp_path / "final" / "runtime"
+    install_calls: list[dict] = []
+
+    def fake_install(*, package_cache_records, prefix):
+        install_calls.append(
+            {
+                "records": package_cache_records,
+                "prefix": prefix,
+                "target_prefix_override": conda_context.target_prefix_override,
+            }
+        )
+
+    monkeypatch.setattr(
+        "conda.misc.install_explicit_packages",
+        fake_install,
+    )
+
+    install_from_lockfile(
+        ctx,
+        "default",
+        prefix=install_prefix,
+        target_prefix_override=final_prefix,
+    )
+
+    assert len(install_calls) == 1
+    assert install_calls[0]["records"] == records_sentinel
+    assert install_calls[0]["prefix"] == str(install_prefix)
+    assert install_calls[0]["target_prefix_override"] == str(final_prefix)
+    assert conda_context.target_prefix_override == ""
+
+
 @pytest.mark.parametrize(
     ("host", "target", "expected"),
     [


### PR DESCRIPTION
## Summary

- Add `conda workspace unarchive --install -e ENV --prefix PREFIX` for installing one archived environment to an explicit final runtime prefix.
- Add `--dest ROOT` staging support so files can be written below `ROOT + PREFIX` while preserving `PREFIX` as the runtime prefix.
- Thread the prefix through lockfile installation using Conda native `target_prefix_override` behavior, without adding `conda-pack`.
- Document the workflow and add changelog coverage.

## Validation

- `git diff --check`
- `pixi run -e test pytest tests/cli/workspace/test_archive.py tests/test_lockfile.py::test_install_from_lockfile tests/test_lockfile.py::test_install_from_lockfile_explicit_prefix_override tests/cli/test_main.py::test_unarchive_subparser_registered`
- `pixi run lint`
- `pixi run format-check`
- `pixi run typecheck`
- `pixi run test` (`988 passed, 1 skipped`)

Closes #77
