### PR TITLE
Support workspace dependency inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   preserving the requested runtime prefix inside the installed
   environment, and warns if installed files still reference the
   staging prefix. (<gh-issue:77>)
+- Added `[workspace.dependencies]` inheritance for conda, pixi, and
+  pyproject manifests, matching the workspace dependency feature added
+  in pixi 0.70.0. (<gh-issue:80>, <gh-pr:79>)
 
 ## 0.5.0 — 2026-06-02
 

--- a/conda_workspaces/manifests/base.py
+++ b/conda_workspaces/manifests/base.py
@@ -328,7 +328,7 @@ class ManifestParser(ABC):
         channels = list(envs[0].config.channels)
 
         # Per-platform specs as ``{name: suffix}`` dicts symmetric with
-        # ``toml._parse_conda_deps`` / ``toml._parse_pypi_deps`` — a
+        # ``WorkspaceDependencyResolver`` / ``toml.parse_pypi_dependencies`` — a
         # name-only MatchSpec round-trips as ``"*"``, versioned
         # MatchSpecs keep their ``conda_build_form`` suffix, PyPI
         # entries keep their ``Requirement.specifier`` string.  When

--- a/conda_workspaces/manifests/pixi_toml.py
+++ b/conda_workspaces/manifests/pixi_toml.py
@@ -15,7 +15,7 @@ from ..exceptions import TaskNotFoundError, TaskParseError, WorkspaceParseError
 from ..models import WorkspaceConfig
 from .base import ManifestParser
 from .normalize import parse_feature_tasks, parse_tasks_and_targets
-from .toml import _parse_channels, _parse_features_and_envs, parse_archive_config
+from .toml import parse_archive_config, parse_channels, parse_features_and_envs
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -61,7 +61,7 @@ class PixiTomlParser(ManifestParser):
             name=ws.get("name"),
             version=ws.get("version"),
             description=ws.get("description"),
-            channels=_parse_channels(ws.get("channels", [])),
+            channels=parse_channels(ws.get("channels", [])),
             platforms=list(ws.get("platforms", [])),
             root=root,
             manifest_path=str(path),
@@ -69,7 +69,7 @@ class PixiTomlParser(ManifestParser):
             archive=parse_archive_config(ws),
         )
 
-        _parse_features_and_envs(data, config, path)
+        parse_features_and_envs(data, config, path)
         return config
 
     def has_tasks(self, path: Path) -> bool:

--- a/conda_workspaces/manifests/pyproject_toml.py
+++ b/conda_workspaces/manifests/pyproject_toml.py
@@ -22,7 +22,7 @@ from ..exceptions import (
 from ..models import WorkspaceConfig
 from .base import ManifestParser
 from .normalize import parse_feature_tasks, parse_tasks_and_targets
-from .toml import _parse_channels, _parse_features_and_envs, parse_archive_config
+from .toml import parse_archive_config, parse_channels, parse_features_and_envs
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -180,7 +180,7 @@ class PyprojectTomlParser(ManifestParser):
             name=ws.get("name") or data.get("project", {}).get("name"),
             version=ws.get("version") or data.get("project", {}).get("version"),
             description=data.get("project", {}).get("description"),
-            channels=_parse_channels(ws.get("channels", [])),
+            channels=parse_channels(ws.get("channels", [])),
             platforms=list(ws.get("platforms", [])),
             root=root,
             manifest_path=str(path),
@@ -188,7 +188,7 @@ class PyprojectTomlParser(ManifestParser):
             archive=parse_archive_config(ws),
         )
 
-        _parse_features_and_envs(source, config, path)
+        parse_features_and_envs(source, config, path)
         return config
 
     def has_tasks(self, path: Path) -> bool:

--- a/conda_workspaces/manifests/toml.py
+++ b/conda_workspaces/manifests/toml.py
@@ -3,9 +3,8 @@
 The ``CondaTomlParser`` handles ``conda.toml`` — the conda-native
 manifest format for both workspace configuration and task definitions.
 
-Helper functions for parsing channels, dependencies, environments,
-and target overrides are shared with ``pixi_toml.py`` and
-``pyproject_toml.py``.
+Public helpers for parsing shared TOML workspace tables are reused by
+``pixi_toml.py`` and ``pyproject_toml.py``.
 """
 
 from __future__ import annotations
@@ -29,7 +28,7 @@ from .normalize import parse_tasks_and_targets
 
 if TYPE_CHECKING:
     from pathlib import Path
-    from typing import Any
+    from typing import Any, ClassVar, NoReturn
 
     from tomlkit.items import InlineTable
 
@@ -163,7 +162,7 @@ def parse_archive_config(ws: dict[str, Any]) -> ArchiveConfig:
     )
 
 
-def _parse_channels(raw: list[Any]) -> list[Channel]:
+def parse_channels(raw: list[Any]) -> list[Channel]:
     """Parse a channels list, handling both strings and dicts."""
     channels: list[Channel] = []
     for item in raw:
@@ -181,27 +180,186 @@ def _parse_channels(raw: list[Any]) -> list[Channel]:
     return channels
 
 
-def _parse_conda_deps(raw: dict[str, Any]) -> dict[str, MatchSpec]:
-    """Parse conda dependency specs into MatchSpec objects."""
-    deps: dict[str, MatchSpec] = {}
-    for name, spec in raw.items():
+class WorkspaceDependencyResolver:
+    """Resolve conda dependency tables with workspace inheritance.
+
+    ``[workspace.dependencies]`` is a root-level pool. Entries in regular
+    dependency tables opt in with ``{ workspace = true }``; after parsing,
+    downstream code only sees concrete ``MatchSpec`` objects.
+    """
+
+    spec_field_aliases: ClassVar[dict[str, str]] = {
+        "version": "version",
+        "build": "build",
+        "build-number": "build_number",
+        "build_number": "build_number",
+        "channel": "channel",
+        "subdir": "subdir",
+        "md5": "md5",
+        "sha256": "sha256",
+        "url": "url",
+        "fn": "fn",
+        "file-name": "fn",
+        "license": "license",
+        "license-family": "license_family",
+        "license_family": "license_family",
+        "features": "features",
+        "track-features": "track_features",
+        "track_features": "track_features",
+    }
+    source_spec_fields: ClassVar[set[str]] = {
+        "branch",
+        "extras",
+        "flags",
+        "git",
+        "path",
+        "rev",
+        "subdirectory",
+        "tag",
+    }
+
+    def __init__(
+        self,
+        *,
+        workspace_dependencies: dict[str, Any] | None = None,
+        path: Path | None = None,
+    ) -> None:
+        self.workspace_dependencies_raw = workspace_dependencies or {}
+        self.path = path
+        self.workspace_dependencies = self.parse_dependency_table(
+            self.workspace_dependencies_raw,
+            allow_inheritance=False,
+            table_name="[workspace.dependencies]",
+        )
+
+    def parse_dependency_table(
+        self,
+        raw: dict[str, Any],
+        *,
+        allow_inheritance: bool = True,
+        table_name: str = "[dependencies]",
+    ) -> dict[str, MatchSpec]:
+        """Parse a dependency table into ``MatchSpec`` objects."""
+        deps: dict[str, MatchSpec] = {}
+        for name, spec in raw.items():
+            deps[name] = self.parse_dependency(
+                name,
+                spec,
+                allow_inheritance=allow_inheritance,
+                table_name=table_name,
+            )
+        return deps
+
+    def parse_dependency(
+        self,
+        name: str,
+        spec: Any,
+        *,
+        allow_inheritance: bool,
+        table_name: str,
+    ) -> MatchSpec:
+        """Parse one dependency entry."""
         if isinstance(spec, str):
-            deps[name] = MatchSpec(f"{name} {spec}".strip())
-        elif isinstance(spec, dict):
-            version = spec.get("version", "")
-            build = spec.get("build", "")
-            parts = [name]
-            if version:
-                parts.append(version)
-            if build:
-                parts.append(build)
-            deps[name] = MatchSpec(" ".join(parts))
-        else:
-            deps[name] = MatchSpec(f"{name} {spec}")
-    return deps
+            return MatchSpec(f"{name} {spec}".strip())
+        if not isinstance(spec, dict):
+            return MatchSpec(f"{name} {spec}")
+
+        if "workspace" not in spec:
+            fields = self.spec_fields(name, spec, strict_unsupported=False)
+            return self.match_spec_from_fields(name, fields)
+
+        if not allow_inheritance:
+            self.error(f"{table_name}.{name} cannot use `workspace = true`.")
+
+        workspace = spec["workspace"]
+        if workspace is not True:
+            self.error(
+                f"{table_name}.{name} sets `workspace = {workspace!r}`; "
+                "`workspace` can only be true."
+            )
+        if "version" in spec:
+            self.error(
+                f"{table_name}.{name} cannot set both `workspace = true` and `version`."
+            )
+        if name not in self.workspace_dependencies_raw:
+            self.error(
+                f"{table_name}.{name} inherits from [workspace.dependencies], "
+                f"but no workspace dependency named '{name}' exists."
+            )
+
+        base_spec = self.workspace_dependencies_raw[name]
+        self.reject_source_fields(name, base_spec, "[workspace.dependencies]")
+        self.reject_source_fields(name, spec, table_name)
+
+        base_fields = self.spec_fields(name, base_spec, strict_unsupported=True)
+        override_fields = self.spec_fields(
+            name,
+            {k: v for k, v in spec.items() if k != "workspace"},
+            strict_unsupported=True,
+        )
+        fields = {**base_fields, **override_fields}
+        return self.match_spec_from_fields(name, fields)
+
+    def spec_fields(
+        self,
+        name: str,
+        spec: Any,
+        *,
+        strict_unsupported: bool,
+    ) -> dict[str, Any]:
+        """Return conda ``MatchSpec`` keyword fields for one TOML dependency."""
+        if isinstance(spec, str):
+            return {"version": spec}
+        if not isinstance(spec, dict):
+            return {"version": str(spec)}
+
+        unsupported = set(spec) - set(self.spec_field_aliases) - {"workspace"}
+        if strict_unsupported and unsupported:
+            fields = ", ".join(sorted(unsupported))
+            self.error(
+                f"Conda dependency '{name}' uses unsupported field(s): {fields}."
+            )
+
+        fields: dict[str, Any] = {}
+        for raw_key, value in spec.items():
+            key = self.spec_field_aliases.get(raw_key)
+            if key is None:
+                continue
+            if value is None or value == "":
+                continue
+            if isinstance(value, list):
+                value = tuple(value)
+            fields[key] = value
+        return fields
+
+    def reject_source_fields(self, name: str, spec: Any, table_name: str) -> None:
+        """Reject pixi source-package fields when inheritance would consume them."""
+        if not isinstance(spec, dict):
+            return
+        unsupported = sorted(set(spec) & self.source_spec_fields)
+        if not unsupported:
+            return
+        fields = ", ".join(unsupported)
+        self.error(
+            f"{table_name}.{name} uses source dependency field(s) unsupported by "
+            f"conda-workspaces inheritance: {fields}."
+        )
+
+    def match_spec_from_fields(self, name: str, fields: dict[str, Any]) -> MatchSpec:
+        """Construct a ``MatchSpec`` and wrap parse errors with manifest context."""
+        try:
+            return MatchSpec(name=name, **fields)
+        except Exception as exc:
+            self.error(f"Invalid conda dependency '{name}': {exc}")
+
+    def error(self, message: str) -> NoReturn:
+        """Raise a manifest parse error when a path is available."""
+        if self.path is not None:
+            raise WorkspaceParseError(self.path, message)
+        raise ValueError(message)
 
 
-def _parse_pypi_deps(raw: dict[str, Any]) -> dict[str, PyPIDependency]:
+def parse_pypi_dependencies(raw: dict[str, Any]) -> dict[str, PyPIDependency]:
     """Parse PyPI dependency specs."""
     deps: dict[str, PyPIDependency] = {}
     for name, spec in raw.items():
@@ -223,7 +381,7 @@ def _parse_pypi_deps(raw: dict[str, Any]) -> dict[str, PyPIDependency]:
     return deps
 
 
-def _parse_environment(name: str, raw: Any, path: Path) -> Environment:
+def parse_environment(name: str, raw: Any, path: Path) -> Environment:
     """Parse a single environment entry.
 
     Environments can be specified as:
@@ -245,28 +403,51 @@ def _parse_environment(name: str, raw: Any, path: Path) -> Environment:
     )
 
 
-def _parse_target_overrides(target_data: dict[str, Any], feature: Feature) -> None:
+def parse_target_overrides(
+    target_data: dict[str, Any],
+    feature: Feature,
+    resolver: WorkspaceDependencyResolver | None = None,
+) -> None:
     """Parse ``[target.<platform>]`` dep overrides into a feature."""
+    resolver = resolver or WorkspaceDependencyResolver()
     for platform, tdata in target_data.items():
-        conda = _parse_conda_deps(tdata.get("dependencies", {}))
+        conda = resolver.parse_dependency_table(
+            tdata.get("dependencies", {}),
+            table_name=f"[target.{platform}.dependencies]",
+        )
         if conda:
             feature.target_conda_dependencies[platform] = conda
 
-        pypi = _parse_pypi_deps(tdata.get("pypi-dependencies", {}))
+        pypi = parse_pypi_dependencies(tdata.get("pypi-dependencies", {}))
         if pypi:
             feature.target_pypi_dependencies[platform] = pypi
 
 
-def _parse_feature(name: str, feat_data: dict[str, Any]) -> Feature:
+def parse_feature(
+    name: str,
+    feat_data: dict[str, Any],
+    resolver: WorkspaceDependencyResolver | None = None,
+) -> Feature:
     """Parse a single ``[feature.<name>]`` table into a Feature.
 
     Shared by ``PixiTomlParser`` and ``PyprojectTomlParser`` — the
     per-feature logic is identical once the data dict is resolved.
     """
+    resolver = resolver or WorkspaceDependencyResolver()
     feature = Feature(name=name)
-    feature.conda_dependencies = _parse_conda_deps(feat_data.get("dependencies", {}))
-    feature.pypi_dependencies = _parse_pypi_deps(feat_data.get("pypi-dependencies", {}))
-    feature.channels = _parse_channels(feat_data.get("channels", []))
+    table_name = (
+        "[dependencies]"
+        if name == Feature.DEFAULT_NAME
+        else f"[feature.{name}.dependencies]"
+    )
+    feature.conda_dependencies = resolver.parse_dependency_table(
+        feat_data.get("dependencies", {}),
+        table_name=table_name,
+    )
+    feature.pypi_dependencies = parse_pypi_dependencies(
+        feat_data.get("pypi-dependencies", {})
+    )
+    feature.channels = parse_channels(feat_data.get("channels", []))
     feature.platforms = list(feat_data.get("platforms", []))
 
     sysreq = feat_data.get("system-requirements", {})
@@ -278,11 +459,11 @@ def _parse_feature(name: str, feat_data: dict[str, Any]) -> Feature:
         feature.activation_scripts = list(activation.get("scripts", []))
         feature.activation_env = dict(activation.get("env", {}))
 
-    _parse_target_overrides(feat_data.get("target", {}), feature)
+    parse_target_overrides(feat_data.get("target", {}), feature, resolver)
     return feature
 
 
-def _parse_features_and_envs(
+def parse_features_and_envs(
     source: dict[str, Any],
     config: WorkspaceConfig,
     path: Path,
@@ -293,15 +474,24 @@ def _parse_features_and_envs(
     all named features, and all environments.  Shared by
     ``PixiTomlParser`` and ``PyprojectTomlParser``.
     """
-    config.features[Feature.DEFAULT_NAME] = _parse_feature(Feature.DEFAULT_NAME, source)
+    resolver = WorkspaceDependencyResolver(
+        workspace_dependencies=source.get("workspace", {}).get("dependencies", {}),
+        path=path,
+    )
+    config.workspace_dependencies = resolver.workspace_dependencies
+    config.features[Feature.DEFAULT_NAME] = parse_feature(
+        Feature.DEFAULT_NAME,
+        source,
+        resolver,
+    )
 
     for feat_name, feat_data in source.get("feature", {}).items():
-        config.features[feat_name] = _parse_feature(feat_name, feat_data)
+        config.features[feat_name] = parse_feature(feat_name, feat_data, resolver)
 
     envs_data = source.get("environments", {})
     if envs_data:
         for env_name, env_val in envs_data.items():
-            config.environments[env_name] = _parse_environment(env_name, env_val, path)
+            config.environments[env_name] = parse_environment(env_name, env_val, path)
     else:
         config.environments[Environment.DEFAULT_NAME] = Environment(
             name=Environment.DEFAULT_NAME

--- a/conda_workspaces/models.py
+++ b/conda_workspaces/models.py
@@ -164,6 +164,10 @@ class WorkspaceConfig:
     channels: list[Channel] = field(default_factory=list)
     platforms: list[str] = field(default_factory=list)
 
+    # Root-level dependency pool from [workspace.dependencies].
+    # Concrete feature dependencies may opt in with { workspace = true }.
+    workspace_dependencies: dict[str, MatchSpec] = field(default_factory=dict)
+
     # Features keyed by name; always includes "default"
     features: dict[str, Feature] = field(default_factory=dict)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -270,6 +270,25 @@ scipy = "*"          # any version
 cuda-toolkit = { version = ">=12", build = "*cuda*" }
 ```
 
+Shared conda specs can live under `[workspace.dependencies]`. Any conda
+dependency table can opt into a shared spec with `{ workspace = true }`;
+the consuming entry may add non-version fields such as `build` or
+`channel`. This matches the workspace dependency inheritance syntax
+that pixi added in 0.70.0.
+
+```toml
+[workspace.dependencies]
+numpy = "1.*"
+cmake = { version = ">=3.28", channel = "conda-forge" }
+
+[dependencies]
+python = ">=3.12"
+numpy = { workspace = true }
+
+[feature.build.dependencies]
+cmake = { workspace = true, build = "h*" }
+```
+
 ## Feature table
 
 Each `[feature.<name>]` table can contain:

--- a/docs/features.md
+++ b/docs/features.md
@@ -270,6 +270,31 @@ myst-parser = ">=3.0"
 When an environment includes multiple features, dependencies are merged
 in order. Later features override earlier ones for the same package name.
 
+### Workspace dependency inheritance
+
+Use `[workspace.dependencies]` to centralize conda specs that multiple
+dependency tables should share. A table entry opts in explicitly with
+`{ workspace = true }`. Pixi added the same workspace dependency
+inheritance syntax in 0.70.0, and conda-workspaces reads it from
+`conda.toml`, `pixi.toml`, and supported `pyproject.toml` tables.
+
+```toml
+[workspace.dependencies]
+numpy = "1.*"
+cmake = { version = ">=3.28", channel = "conda-forge" }
+
+[dependencies]
+numpy = { workspace = true }
+
+[feature.build.dependencies]
+cmake = { workspace = true, build = "h*" }
+```
+
+The root spec supplies the version and any other base match fields. The
+consuming entry may add non-version fields such as `build`, `channel`,
+or `subdir`; restating `version` alongside `workspace = true` is an
+error.
+
 ## Channels
 
 Channels are specified at the workspace level and can be overridden per

--- a/docs/reference/conda-toml-spec.md
+++ b/docs/reference/conda-toml-spec.md
@@ -94,6 +94,7 @@ Workspace metadata.
 | `platforms` | array of *platform* | **yes** | Platforms the workspace targets.  Used to drive multi-platform solves. |
 | `channel-priority` | string | no | One of `"strict"`, `"flexible"`, `"disabled"`.  Maps to conda's solver setting. |
 | `envs-dir` | string | no | Where per-env prefixes live, relative to the workspace root.  Default: `.conda/envs`. |
+| `dependencies` | conda deps | no | Root-level dependency pool used by `{ workspace = true }` entries in dependency tables. |
 
 A *channel* is either:
 
@@ -106,11 +107,40 @@ A *platform* is a conda subdir string from the closed enum defined in
 the [JSON schema][schema] under `$defs.platform` (e.g. `linux-64`,
 `osx-arm64`, `win-64`, `noarch`).
 
+### `[workspace.dependencies]`
+
+Reusable conda package specs keyed by package name. Regular dependency
+tables can opt into a root spec with `{ workspace = true }`, which keeps
+shared versions in one place while preserving explicit package membership
+in each feature or target table. This follows the workspace dependency
+inheritance syntax that pixi added in 0.70.0.
+
+```toml
+[workspace.dependencies]
+numpy = "1.*"
+cmake = { version = ">=3.28", channel = "conda-forge" }
+
+[dependencies]
+python = ">=3.12"
+numpy = { workspace = true }
+
+[feature.build.dependencies]
+cmake = { workspace = true, build = "h*" }
+```
+
+The inherited entry uses the root spec as a base. Non-version fields such
+as `build`, `channel`, `subdir`, `md5`, `sha256`, `url`, `file-name`,
+`license`, `license-family`, `features`, and `track-features` may be
+set on the consuming dependency to layer on top. `version` is owned by
+the workspace entry; setting both `workspace = true` and `version` is an
+error. `workspace = false` is also rejected.
+
 ### `[dependencies]`
 
 Conda packages that belong to the *default feature*.  Keys are package
 names; values are either a version constraint string or a *detailed
-dependency spec*.
+dependency spec*. Detailed specs may also inherit from
+`[workspace.dependencies]` with `{ workspace = true }`.
 
 ```toml
 [dependencies]
@@ -126,6 +156,15 @@ A detailed conda dependency accepts:
 |---|---|---|
 | `version` | string | Version constraint (e.g. `">=12"`). |
 | `build` | string | Build-string glob (e.g. `"*cuda*"`). |
+| `build-number` | string | Build number constraint. |
+| `channel` | string | Channel name or URL for this package. |
+| `subdir` | platform | Platform/subdir constraint. |
+| `md5` / `sha256` | string | Exact package hash. |
+| `url` | string | Exact package URL. |
+| `file-name` | string | Exact package filename. |
+| `license` / `license-family` | string | License constraints. |
+| `features` / `track-features` | array of strings | Feature constraints. |
+| `workspace` | boolean | Must be `true`; inherit from `[workspace.dependencies]`. Mutually exclusive with `version`. |
 
 ### `[pypi-dependencies]`
 

--- a/schema/conda-toml-1.schema.json
+++ b/schema/conda-toml-1.schema.json
@@ -114,6 +114,10 @@
         "envs-dir": {
           "type": "string",
           "description": "Where per-environment prefixes are written, relative to the workspace root.  Default: '.conda/envs'."
+        },
+        "dependencies": {
+          "$ref": "#/$defs/workspaceCondaDependencies",
+          "description": "Root-level conda dependency pool. Dependency tables may opt into these specs with { workspace = true }."
         }
       },
       "required": ["channels", "platforms"],
@@ -147,27 +151,129 @@
           "description": "Version constraint string (e.g. '>=3.10', '>=1.24,<2', '*')."
         },
         {
-          "type": "object",
-          "description": "Detailed dependency specification with version and optional build string.",
-          "properties": {
-            "version": {
-              "type": "string",
-              "description": "Version constraint (e.g. '>=12')."
-            },
-            "build": {
-              "type": "string",
-              "description": "Build string glob pattern (e.g. '*cuda*')."
-            }
-          },
-          "additionalProperties": false
+          "$ref": "#/$defs/condaDetailedDependencySpec"
+        },
+        {
+          "$ref": "#/$defs/condaInheritedDependencySpec"
         }
       ]
+    },
+    "workspaceCondaDependencySpec": {
+      "description": "A concrete conda dependency specification for [workspace.dependencies].",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Version constraint string (e.g. '>=3.10', '>=1.24,<2', '*')."
+        },
+        {
+          "$ref": "#/$defs/condaDetailedDependencySpec"
+        }
+      ]
+    },
+    "condaDetailedDependencySpec": {
+      "type": "object",
+      "description": "Detailed dependency specification with conda MatchSpec fields.",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "Version constraint (e.g. '>=12')."
+        },
+        "build": {
+          "type": "string",
+          "description": "Build string glob pattern (e.g. '*cuda*')."
+        },
+        "build-number": {
+          "type": "string",
+          "description": "Build number constraint."
+        },
+        "channel": {
+          "type": "string",
+          "description": "Channel name or URL for this package."
+        },
+        "subdir": {
+          "$ref": "#/$defs/platform",
+          "description": "Platform/subdir constraint for this package."
+        },
+        "md5": {
+          "type": "string",
+          "description": "Exact package MD5 hash."
+        },
+        "sha256": {
+          "type": "string",
+          "description": "Exact package SHA256 hash."
+        },
+        "url": {
+          "type": "string",
+          "description": "Exact package URL."
+        },
+        "file-name": {
+          "type": "string",
+          "description": "Exact package filename."
+        },
+        "license": {
+          "type": "string",
+          "description": "Package license constraint."
+        },
+        "license-family": {
+          "type": "string",
+          "description": "Package license family constraint."
+        },
+        "features": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Required package features."
+        },
+        "track-features": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Required package track features."
+        }
+      },
+      "additionalProperties": false
+    },
+    "condaInheritedDependencySpec": {
+      "type": "object",
+      "description": "Dependency specification inherited from [workspace.dependencies].",
+      "properties": {
+        "workspace": {
+          "type": "boolean",
+          "const": true,
+          "description": "Inherit the spec from [workspace.dependencies]."
+        },
+        "build": { "type": "string" },
+        "build-number": { "type": "string" },
+        "channel": { "type": "string" },
+        "subdir": { "$ref": "#/$defs/platform" },
+        "md5": { "type": "string" },
+        "sha256": { "type": "string" },
+        "url": { "type": "string" },
+        "file-name": { "type": "string" },
+        "license": { "type": "string" },
+        "license-family": { "type": "string" },
+        "features": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "track-features": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "required": ["workspace"],
+      "additionalProperties": false
     },
     "condaDependencies": {
       "type": "object",
       "description": "Conda package dependencies keyed by package name.",
       "additionalProperties": {
         "$ref": "#/$defs/condaDependencySpec"
+      }
+    },
+    "workspaceCondaDependencies": {
+      "type": "object",
+      "description": "Conda package dependency pool keyed by package name.",
+      "additionalProperties": {
+        "$ref": "#/$defs/workspaceCondaDependencySpec"
       }
     },
     "pypiDependencySpec": {

--- a/tests/manifests/test_pixi_toml.py
+++ b/tests/manifests/test_pixi_toml.py
@@ -64,6 +64,40 @@ def test_parse_default_dependencies(parser, sample_pixi_toml):
     assert "numpy" in default.conda_dependencies
 
 
+def test_parse_workspace_dependency_inheritance(tmp_path: Path):
+    content = """\
+[workspace]
+name = "workspace-deps"
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+[workspace.dependencies]
+numpy = "1.*"
+cmake = { version = ">=3.28", channel = "conda-forge" }
+
+[dependencies]
+python = ">=3.12"
+numpy = { workspace = true }
+
+[feature.build.dependencies]
+cmake = { workspace = true, build = "h*" }
+"""
+    path = tmp_path / "pixi.toml"
+    path.write_text(content, encoding="utf-8")
+
+    config = PixiTomlParser().parse(path)
+    assert str(config.workspace_dependencies["numpy"].version) == "1.*"
+
+    default = config.features["default"]
+    assert str(default.conda_dependencies["numpy"].version) == "1.*"
+
+    build = config.features["build"]
+    cmake = build.conda_dependencies["cmake"]
+    assert str(cmake.version) == ">=3.28"
+    assert cmake.get_raw_value("channel") == "https://conda.anaconda.org/conda-forge"
+    assert cmake.get_raw_value("build") == "h*"
+
+
 def test_parse_features(parser, sample_pixi_toml):
     config = parser.parse(sample_pixi_toml)
     assert "test" in config.features

--- a/tests/manifests/test_pyproject_toml.py
+++ b/tests/manifests/test_pyproject_toml.py
@@ -61,6 +61,29 @@ def test_parse_dependencies(parser, sample_pyproject_toml):
     assert str(default.conda_dependencies["python"].version) == ">=3.11"
 
 
+def test_parse_workspace_dependency_inheritance(parser, tmp_path: Path):
+    content = """\
+[project]
+name = "workspace-deps"
+
+[tool.conda.workspace]
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+[tool.conda.workspace.dependencies]
+numpy = "1.*"
+
+[tool.conda.dependencies]
+numpy = { workspace = true }
+"""
+    path = tmp_path / "pyproject.toml"
+    path.write_text(content, encoding="utf-8")
+
+    config = parser.parse(path)
+    assert str(config.workspace_dependencies["numpy"].version) == "1.*"
+    assert str(config.features["default"].conda_dependencies["numpy"].version) == "1.*"
+
+
 def test_parse_features(parser, sample_pyproject_toml):
     config = parser.parse(sample_pyproject_toml)
     assert "test" in config.features

--- a/tests/manifests/test_toml.py
+++ b/tests/manifests/test_toml.py
@@ -9,11 +9,11 @@ import pytest
 from conda_workspaces.exceptions import WorkspaceParseError
 from conda_workspaces.manifests.toml import (
     CondaTomlParser,
-    _parse_channels,
-    _parse_conda_deps,
-    _parse_environment,
-    _parse_pypi_deps,
-    _parse_target_overrides,
+    WorkspaceDependencyResolver,
+    parse_channels,
+    parse_environment,
+    parse_pypi_dependencies,
+    parse_target_overrides,
 )
 from conda_workspaces.models import Feature, MatchSpec
 
@@ -90,6 +90,52 @@ python = ">=3.10"
 
 
 @pytest.mark.parametrize(
+    "table, feature_name, platform, expected_build",
+    [
+        ("dependencies", "default", None, None),
+        ("feature.build.dependencies", "build", None, "h*"),
+        ("target.linux-64.dependencies", "default", "linux-64", "py*"),
+        ("feature.build.target.linux-64.dependencies", "build", "linux-64", "h*"),
+    ],
+    ids=["default", "feature", "target", "feature-target"],
+)
+def test_parse_workspace_dependency_inheritance_tables(
+    tmp_path,
+    table,
+    feature_name,
+    platform,
+    expected_build,
+):
+    build_part = f', build = "{expected_build}"' if expected_build else ""
+    content = f"""\
+[workspace]
+name = "workspace-deps"
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+[workspace.dependencies]
+numpy = {{ version = "1.*", channel = "conda-forge" }}
+
+[{table}]
+numpy = {{ workspace = true{build_part} }}
+"""
+    path = tmp_path / "conda.toml"
+    path.write_text(content, encoding="utf-8")
+
+    config = CondaTomlParser().parse(path)
+    assert str(config.workspace_dependencies["numpy"].version) == "1.*"
+
+    feature = config.features[feature_name]
+    if platform is None:
+        dep = feature.conda_dependencies["numpy"]
+    else:
+        dep = feature.target_conda_dependencies[platform]["numpy"]
+    assert str(dep.version) == "1.*"
+    assert dep.get_raw_value("channel") == "https://conda.anaconda.org/conda-forge"
+    assert dep.get_raw_value("build") == expected_build
+
+
+@pytest.mark.parametrize(
     "raw, expected_names",
     [
         (["conda-forge"], ["conda-forge"]),
@@ -101,7 +147,7 @@ python = ">=3.10"
     ids=["single-str", "two-strs", "single-dict", "mixed", "empty"],
 )
 def test_parse_channels(raw, expected_names):
-    channels = _parse_channels(raw)
+    channels = parse_channels(raw)
     assert [ch.canonical_name for ch in channels] == expected_names
 
 
@@ -116,18 +162,165 @@ def test_parse_channels(raw, expected_names):
     ids=["str-spec", "dict-version", "dict-version-build", "other-type"],
 )
 def test_parse_conda_deps(raw, expected_name):
-    deps = _parse_conda_deps(raw)
+    deps = WorkspaceDependencyResolver().parse_dependency_table(raw)
     assert expected_name in deps
     assert isinstance(deps[expected_name], MatchSpec)
 
 
 @pytest.mark.parametrize(
-    "func",
-    [_parse_conda_deps, _parse_pypi_deps],
-    ids=["conda", "pypi"],
+    "root_spec, inherited_spec, raw_field, expected_value",
+    [
+        ("1.*", {"workspace": True}, "version", "1.*"),
+        (
+            {"version": ">=24", "channel": "conda-forge"},
+            {"workspace": True},
+            "channel",
+            "https://conda.anaconda.org/conda-forge",
+        ),
+        ({"version": ">=24"}, {"workspace": True, "build": "py*"}, "build", "py*"),
+        (
+            {"version": ">=24"},
+            {"workspace": True, "build-number": ">=2"},
+            "build_number",
+            ">=2",
+        ),
+        (
+            {"version": ">=24"},
+            {"workspace": True, "subdir": "linux-64"},
+            "subdir",
+            "linux-64",
+        ),
+        (
+            {"version": ">=24"},
+            {"workspace": True, "file-name": "pkg-1.0-0.tar.bz2"},
+            "fn",
+            "pkg-1.0-0.tar.bz2",
+        ),
+        (
+            {"version": ">=24"},
+            {"workspace": True, "license-family": "BSD"},
+            "license_family",
+            "bsd",
+        ),
+        (
+            {"version": ">=24"},
+            {"workspace": True, "features": ["feature-a", "feature-b"]},
+            "features",
+            {"feature-a", "feature-b"},
+        ),
+        (
+            {"version": ">=24"},
+            {"workspace": True, "track-features": ["accelerated"]},
+            "track_features",
+            {"accelerated"},
+        ),
+    ],
+    ids=[
+        "string-root",
+        "root-channel",
+        "override-build",
+        "override-build-number",
+        "override-subdir",
+        "override-file-name",
+        "override-license-family",
+        "override-features",
+        "override-track-features",
+    ],
 )
-def test_parse_deps_empty(func):
-    assert func({}) == {}
+def test_parse_conda_deps_with_workspace_inheritance(
+    tmp_path,
+    root_spec,
+    inherited_spec,
+    raw_field,
+    expected_value,
+):
+    resolver = WorkspaceDependencyResolver(
+        workspace_dependencies={"pkg": root_spec},
+        path=tmp_path / "conda.toml",
+    )
+    deps = resolver.parse_dependency_table({"pkg": inherited_spec})
+    value = deps["pkg"].get_raw_value(raw_field)
+
+    if isinstance(value, frozenset):
+        value = set(value)
+    assert value == expected_value
+
+
+@pytest.mark.parametrize(
+    "raw, workspace_dependencies, match",
+    [
+        (
+            {"numpy": {"workspace": True}},
+            {},
+            "no workspace dependency named 'numpy'",
+        ),
+        (
+            {"numpy": {"workspace": False}},
+            {"numpy": "1.*"},
+            "`workspace` can only be true",
+        ),
+        (
+            {"numpy": {"workspace": True, "version": ">=2"}},
+            {"numpy": "1.*"},
+            "cannot set both `workspace = true` and `version`",
+        ),
+        (
+            {"numpy": {"workspace": True, "path": "../numpy"}},
+            {"numpy": "1.*"},
+            "unsupported by conda-workspaces inheritance: path",
+        ),
+        (
+            {"numpy": {"workspace": True, "unsupported": "value"}},
+            {"numpy": "1.*"},
+            "unsupported field\\(s\\): unsupported",
+        ),
+        (
+            {"numpy": {"workspace": True}},
+            {"numpy": {"version": "1.*", "path": "../numpy"}},
+            "unsupported by conda-workspaces inheritance: path",
+        ),
+        (
+            {"numpy": {"workspace": True}},
+            {"numpy": {"version": "1.*", "unsupported": "value"}},
+            "unsupported field\\(s\\): unsupported",
+        ),
+        (
+            {"numpy": {"workspace": True}},
+            {"numpy": {"workspace": True}},
+            "\\[workspace.dependencies\\].numpy cannot use `workspace = true`",
+        ),
+    ],
+    ids=[
+        "missing-root",
+        "workspace-false",
+        "version-restated",
+        "source-field",
+        "unsupported-field",
+        "root-source-field",
+        "root-unsupported-field",
+        "root-workspace-inheritance",
+    ],
+)
+def test_parse_conda_deps_workspace_inheritance_errors(
+    tmp_path,
+    raw,
+    workspace_dependencies,
+    match,
+):
+    with pytest.raises(WorkspaceParseError, match=match):
+        resolver = WorkspaceDependencyResolver(
+            workspace_dependencies=workspace_dependencies,
+            path=tmp_path / "conda.toml",
+        )
+        resolver.parse_dependency_table(raw)
+
+
+def test_parse_conda_deps_empty():
+    assert WorkspaceDependencyResolver().parse_dependency_table({}) == {}
+
+
+def test_parse_pypi_deps_empty():
+    assert parse_pypi_dependencies({}) == {}
 
 
 @pytest.mark.parametrize(
@@ -140,7 +333,7 @@ def test_parse_deps_empty(func):
     ids=["str-spec", "dict-version", "other-type"],
 )
 def test_parse_pypi_deps(raw, key):
-    deps = _parse_pypi_deps(raw)
+    deps = parse_pypi_dependencies(raw)
     assert key in deps
     assert deps[key].name == key
 
@@ -154,7 +347,7 @@ def test_parse_pypi_deps(raw, key):
     ids=["list", "dict-features"],
 )
 def test_parse_environment(tmp_path, raw, expected_features):
-    env = _parse_environment("myenv", raw, tmp_path / "conda.toml")
+    env = parse_environment("myenv", raw, tmp_path / "conda.toml")
     assert env.name == "myenv"
     assert env.features == expected_features
 
@@ -162,11 +355,11 @@ def test_parse_environment(tmp_path, raw, expected_features):
 def test_parse_environment_invalid_type(tmp_path):
     path = tmp_path / "conda.toml"
     with pytest.raises(WorkspaceParseError, match="expected list or dict, got str"):
-        _parse_environment("myenv", "unexpected", path)
+        parse_environment("myenv", "unexpected", path)
 
 
 def test_parse_environment_no_default_feature(tmp_path):
-    env = _parse_environment(
+    env = parse_environment(
         "e", {"no-default-feature": True, "features": ["x"]}, tmp_path / "conda.toml"
     )
     assert env.no_default_feature is True
@@ -184,7 +377,7 @@ def test_parse_target_overrides(platform, dep_key, attr, pkg):
     feature = Feature(name="default")
     version = ">=12" if dep_key == "dependencies" else ">=2.0"
     target_data = {platform: {dep_key: {pkg: version}}}
-    _parse_target_overrides(target_data, feature)
+    parse_target_overrides(target_data, feature)
     result = getattr(feature, attr)
     assert platform in result
     assert pkg in result[platform]
@@ -192,7 +385,7 @@ def test_parse_target_overrides(platform, dep_key, attr, pkg):
 
 def test_parse_target_overrides_empty():
     feature = Feature(name="default")
-    _parse_target_overrides({}, feature)
+    parse_target_overrides({}, feature)
     assert feature.target_conda_dependencies == {}
     assert feature.target_pypi_dependencies == {}
 
@@ -229,7 +422,7 @@ def test_parse_target_overrides_empty():
     ids=["extras", "path", "editable", "git", "url"],
 )
 def test_parse_pypi_deps_dict_fields(raw, field_name, expected_value):
-    deps = _parse_pypi_deps(raw)
+    deps = parse_pypi_dependencies(raw)
     assert "pkg" in deps
     assert getattr(deps["pkg"], field_name) == expected_value
 
@@ -245,4 +438,4 @@ def test_parse_pypi_deps_dict_fields(raw, field_name, expected_value):
 def test_parse_environment_rejects_invalid_types(tmp_path, raw, type_name):
     path = tmp_path / "conda.toml"
     with pytest.raises(WorkspaceParseError, match=f"got {type_name}"):
-        _parse_environment("badenv", raw, path)
+        parse_environment("badenv", raw, path)


### PR DESCRIPTION
## Summary
- Port the workspace dependency inheritance syntax added in pixi 0.70.0 by reading `[workspace.dependencies]` and `{ workspace = true }` entries in conda, pixi, and pyproject manifests.
- Store the root dependency pool on `WorkspaceConfig` and resolve inherited entries into concrete `MatchSpec` values for default, feature, and target dependency tables.
- Keep conda dependency parsing on `WorkspaceDependencyResolver`, remove the obsolete `_parse_conda_deps` wrapper, and promote the shared TOML table parsers to explicit public helper names.
- Update the conda TOML schema, changelog, and docs to cover inherited dependency specs and validation rules.
- Add parser tests for conda, pixi, and pyproject manifest forms, including parameterized resolver coverage for inherited fields, validation errors, and default/feature/target tables.

## Issue Relationship
- Closes #80.
- Related to #3, but does not close it: #3 tracks full multi-package workspace support with members, `[package]` manifests, path dependencies, member-scoped tasks, and build integration; this PR only implements the shared dependency pool/inheritance slice.

## Validation
- `pixi run -e test pytest` (`1028 passed, 1 skipped`)
- `pixi run ruff check`
- `pixi run ruff format --check`
- `pixi run ty check conda_workspaces`
- `pixi run -e test python -m json.tool schema/conda-toml-1.schema.json >/dev/null`