### PR TITLE
Prepare changelog for 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## Unreleased
 
+## 0.6.0 — 2026-06-05
+
 ### Added
 
 - `conda workspace unarchive --install` can install a selected
@@ -13,7 +15,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
   `--prefix`. `--dest` stages files below a filesystem root while
   preserving the requested runtime prefix inside the installed
   environment, and warns if installed files still reference the
-  staging prefix. (<gh-issue:77>)
+  staging prefix. (<gh-issue:77>, <gh-pr:78>)
 - Added `[workspace.dependencies]` inheritance for conda, pixi, and
   pyproject manifests, matching the workspace dependency feature added
   in pixi 0.70.0. (<gh-issue:80>, <gh-pr:79>)


### PR DESCRIPTION
## Summary
- Move the current Unreleased changelog entries into a `0.6.0 — 2026-06-05` section based on what is now merged to `main`.
- Add the missing PR reference for #78 while keeping the #79 entry tied to the pixi 0.70.0 workspace dependency inheritance work.

## Validation
- `git diff --check`
- `pixi run -e docs docs`