### PR TITLE
Run docs workflow for changelog updates

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,12 +6,14 @@ on:
       - main
     paths:
       - ".github/workflows/docs.yml"
+      - "CHANGELOG.md"
       - "conda_workspaces/**"
       - "docs/**"
       - "pyproject.toml"
   pull_request:
     paths:
       - ".github/workflows/docs.yml"
+      - "CHANGELOG.md"
       - "docs/**"
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` to the Docs workflow path filters for pushes and pull requests.
- This ensures release-prep PRs that only move changelog entries into a versioned section still build and deploy the published changelog page.

## Validation
- `git diff --check`
- Manually dispatched Docs on `main` after 0.6.0 and verified https://conda-incubator.github.io/conda-workspaces/changelog/ now shows `0.6.0 — 2026-06-05`.