### PR TITLE
Add workspace archive receipts

### DIFF
--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -12,10 +12,9 @@ import hashlib
 import importlib
 import shutil
 import subprocess
-import sys
 import tarfile
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
@@ -68,6 +67,44 @@ BUILTIN_EXCLUDE_DIRS: frozenset[str] = frozenset(
     }
 )
 """Directories excluded from archives regardless of user configuration."""
+
+
+def has_absolute_path_syntax(path: str) -> bool:
+    """Return whether *path* is absolute using POSIX or Windows syntax.
+
+    Workspace archives can be created and verified on a different OS than
+    the one that consumes them, so callers cannot rely on host-only path
+    parsing for archive metadata.
+    """
+    return PurePosixPath(path).is_absolute() or PureWindowsPath(path).is_absolute()
+
+
+def parse_relative_archive_path(
+    path: str,
+    *,
+    allow_parent: bool = False,
+) -> PurePosixPath:
+    """Return *path* as a validated POSIX archive path.
+
+    Tar members and receipt paths use POSIX separators regardless of the
+    host OS.  Keeping this policy in one helper lets extraction and receipt
+    verification reject the same ambiguous path syntax while raising their
+    own domain-specific errors.
+    """
+    posix_path = PurePosixPath(path)
+    windows_path = PureWindowsPath(path)
+    if (
+        not path
+        or "\0" in path
+        or "\\" in path
+        or posix_path.is_absolute()
+        or windows_path.drive
+        or not posix_path.parts
+        or posix_path.as_posix() != path
+        or (not allow_parent and any(part == ".." for part in posix_path.parts))
+    ):
+        raise ValueError(f"Invalid relative archive path: {path!r}")
+    return posix_path
 
 
 def is_git_repo(root: Path) -> bool:
@@ -252,7 +289,7 @@ def create_archive(
 def add_files_to_tar(tf: tarfile.TarFile, root: Path, files: list[Path]) -> None:
     """Add workspace *files* to the tar, using paths relative to *root*."""
     for path in files:
-        arcname = str(path.relative_to(root))
+        arcname = path.relative_to(root).as_posix()
         tf.add(str(path), arcname=arcname)
 
 
@@ -272,25 +309,29 @@ def validate_tar_member(member: tarfile.TarInfo, target: Path) -> None:
     if member.type not in ALLOWED_TAR_TYPES:
         raise ArchivePathTraversalError(member.name)
 
-    member_path = Path(member.name)
-
-    if member_path.is_absolute():
-        raise ArchivePathTraversalError(member.name)
+    try:
+        member_path = parse_relative_archive_path(member.name)
+    except ValueError:
+        raise ArchivePathTraversalError(member.name) from None
 
     try:
-        resolved = (target / member_path).resolve()
+        resolved = target.joinpath(*member_path.parts).resolve()
         resolved.relative_to(target.resolve())
     except ValueError:
         raise ArchivePathTraversalError(member.name)
 
-    if ".." in member_path.parts:
-        raise ArchivePathTraversalError(member.name)
-
     if member.issym() or member.islnk():
-        link_target = Path(member.linkname)
-        if link_target.is_absolute():
-            raise ArchivePathTraversalError(member.name)
-        resolved_link = (target / member_path.parent / link_target).resolve()
+        try:
+            link_target = parse_relative_archive_path(
+                member.linkname,
+                allow_parent=True,
+            )
+        except ValueError:
+            raise ArchivePathTraversalError(member.name) from None
+        resolved_link = target.joinpath(
+            *member_path.parent.parts,
+            *link_target.parts,
+        ).resolve()
         try:
             resolved_link.relative_to(target.resolve())
         except ValueError:
@@ -325,7 +366,7 @@ def extract_archive(archive_path: Path, target: Path) -> Path:
         members = tf.getmembers()
         for member in members:
             validate_tar_member(member, target)
-        if sys.version_info >= (3, 12):
+        if hasattr(tarfile, "data_filter"):
             tf.extractall(path=target, members=members, filter="data")
         else:
             tf.extractall(path=target, members=members)

--- a/conda_workspaces/cli/main.py
+++ b/conda_workspaces/cli/main.py
@@ -563,6 +563,18 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
         help="Additional exclude patterns (repeatable)."
         " Added to [workspace.archive] exclude.",
     )
+    archive_parser.add_argument(
+        "--receipt",
+        nargs="?",
+        const=True,
+        default=None,
+        type=Path,
+        metavar="PATH",
+        help=(
+            "Write an external in-toto receipt JSON file."
+            " Defaults to <archive>.receipt.json when PATH is omitted."
+        ),
+    )
 
     unarchive_parser = sub.add_parser(
         "unarchive",
@@ -616,6 +628,24 @@ def configure_workspace_parser(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         default=False,
         help="Skip cache priming for bundled packages.",
+    )
+    unarchive_parser.add_argument(
+        "--receipt",
+        nargs="?",
+        const=True,
+        default=None,
+        type=Path,
+        metavar="PATH",
+        help=(
+            "Verify an external in-toto receipt JSON file."
+            " Defaults to <archive>.receipt.json when PATH is omitted."
+        ),
+    )
+    unarchive_parser.add_argument(
+        "--require-sha256",
+        action="store_true",
+        default=False,
+        help="Require package records verified by --receipt to include SHA-256.",
     )
 
     quickstart_parser = sub.add_parser(

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -143,7 +143,7 @@ def receipt_environment_prefixes(
         try:
             prefixes[name] = prefix.relative_to(ctx_root).as_posix()
         except ValueError:
-            prefixes[name] = str(prefix)
+            prefixes[name] = prefix.as_posix()
     return prefixes
 
 

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -14,6 +14,7 @@ from rich.markup import escape
 
 from ...archive import (
     ARCHIVE_SUFFIXES,
+    collect_archive_files,
     collect_bundle_packages,
     create_archive,
     extract_archive,
@@ -237,19 +238,67 @@ def execute_archive(
         )
         output = ctx.root / f"{name}{ext}"
 
+    receipt_path = resolve_receipt_path(
+        output.resolve(), getattr(args, "receipt", None)
+    )
+    manifest_path = Path(config.manifest_path)
+    lockfile_path = _lockfile_path(ctx)
+    if receipt_path is not None:
+        if receipt_path.resolve() == output.resolve():
+            raise ArchiveError(
+                "Receipt path cannot be the archive path.",
+                hints=["Choose a separate JSON path for --receipt."],
+            )
+        if not manifest_path.is_file():
+            raise ArchiveError(
+                "Cannot write receipt: workspace manifest was not found."
+            )
+        if not lockfile_path.is_file():
+            raise ArchiveError(
+                "Cannot write receipt: no conda.lock found.",
+                hints=["Run 'conda workspace lock' first."],
+            )
+
+        archive_members = {
+            path.relative_to(ctx.root).as_posix()
+            for path in collect_archive_files(ctx.root, archive_config)
+            if path.resolve() != output.resolve()
+        }
+        required_members: dict[str, Path] = {
+            "workspace manifest": manifest_path,
+            "workspace lockfile": lockfile_path,
+        }
+        missing = []
+        for label, path in required_members.items():
+            try:
+                archive_name = path.relative_to(ctx.root).as_posix()
+            except ValueError:
+                missing.append(label)
+                continue
+            if archive_name not in archive_members:
+                missing.append(f"{label} ({archive_name})")
+        if missing:
+            raise ArchiveError(
+                f"Cannot write receipt: archive would not include {missing[0]}.",
+                hints=[
+                    "Receipt verification requires the workspace manifest and"
+                    " conda.lock to be included in the archive.",
+                    "Remove matching include/exclude filters or run without --receipt.",
+                ],
+            )
+
     bundle_packages = None
     if args.bundle:
         from conda.base.context import context as conda_context
 
-        lockfile = _lockfile_path(ctx)
-        if not lockfile.is_file():
+        if not lockfile_path.is_file():
             raise ArchiveError(
                 "Cannot bundle packages: no conda.lock found.",
                 hints=["Run 'conda workspace lock' first."],
             )
         cache_dirs = [Path(d) for d in conda_context.pkgs_dirs]
-        bundle_packages = collect_bundle_packages(lockfile, cache_dirs)
-        verify_package_hashes(bundle_packages, lockfile)
+        bundle_packages = collect_bundle_packages(lockfile_path, cache_dirs)
+        verify_package_hashes(bundle_packages, lockfile_path)
 
         status.message(
             console,
@@ -278,19 +327,13 @@ def execute_archive(
 
     status.message(console, "Created", "archive", str(output))
 
-    receipt_path = resolve_receipt_path(output, getattr(args, "receipt", None))
     if receipt_path is not None:
-        if receipt_path.resolve() == output.resolve():
-            raise ArchiveError(
-                "Receipt path cannot be the archive path.",
-                hints=["Choose a separate JSON path for --receipt."],
-            )
         receipt = ArchiveReceipt.build(
             root=ctx.root,
             archive_path=output,
             archive_config=archive_config,
-            manifest_path=Path(config.manifest_path),
-            lockfile_path=_lockfile_path(ctx),
+            manifest_path=manifest_path,
+            lockfile_path=lockfile_path,
             environment_prefixes=receipt_environment_prefixes(
                 config_environments=list(config.environments),
                 ctx_root=ctx.root,

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import shutil
+import tempfile
 from os.path import expanduser
 from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import TYPE_CHECKING
 
 from rich.console import Console
 from rich.markup import escape
@@ -14,6 +17,7 @@ from ...archive import (
     collect_bundle_packages,
     create_archive,
     extract_archive,
+    has_absolute_path_syntax,
     inspect_archive,
     prime_package_cache,
     verify_package_hashes,
@@ -21,13 +25,17 @@ from ...archive import (
 from ...exceptions import ArchiveError
 from ...lockfile import lockfile_path as _lockfile_path
 from ...models import ArchiveConfig
+from ...receipts import ArchiveReceipt
 from .. import status
 from . import workspace_context_from_args
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def is_absolute_runtime_prefix(prefix: str) -> bool:
     """Return whether *prefix* is absolute as a POSIX or Windows path."""
-    return PurePosixPath(prefix).is_absolute() or PureWindowsPath(prefix).is_absolute()
+    return has_absolute_path_syntax(prefix)
 
 
 def runtime_prefix_relative_path(prefix: str) -> Path:
@@ -109,6 +117,82 @@ def warn_staging_prefix_references(
         console.print("  [dim]additional matches omitted[/dim]")
 
 
+def resolve_receipt_path(archive_path: Path, receipt: object) -> Path | None:
+    """Resolve the optional ``--receipt [PATH]`` argparse value."""
+    if receipt in (None, False):
+        return None
+    if receipt is True:
+        return ArchiveReceipt.default_path(archive_path)
+    if isinstance(receipt, Path):
+        return receipt
+    if isinstance(receipt, str):
+        return Path(receipt)
+    raise ArchiveError("Invalid --receipt value.")
+
+
+def receipt_environment_prefixes(
+    *,
+    config_environments: list[str],
+    ctx_root: Path,
+    env_prefix: Callable[[str], Path],
+) -> dict[str, str]:
+    """Return environment prefixes to record in a receipt predicate."""
+    prefixes: dict[str, str] = {}
+    for name in config_environments:
+        prefix = env_prefix(name)
+        try:
+            prefixes[name] = prefix.relative_to(ctx_root).as_posix()
+        except ValueError:
+            prefixes[name] = str(prefix)
+    return prefixes
+
+
+def ensure_verified_target_empty(target: Path) -> None:
+    """Reject verified extraction into non-empty or unsafe targets."""
+    if not target.exists():
+        return
+    if target.is_symlink():
+        raise ArchiveError("Cannot verify receipt into an existing symlink target.")
+    if not target.is_dir():
+        raise ArchiveError(
+            "Cannot verify receipt into an existing non-directory target."
+        )
+    try:
+        target_has_files = any(target.iterdir())
+    except OSError as exc:
+        raise ArchiveError(
+            f"Cannot inspect target before verified extraction: {target}"
+        ) from exc
+    if target_has_files:
+        raise ArchiveError(
+            "Cannot verify receipt into a non-empty target.",
+            hints=["Choose an empty target directory or remove existing files first."],
+        )
+
+
+def extract_verified_archive(
+    archive_path: Path,
+    target: Path,
+    receipt: ArchiveReceipt,
+    *,
+    require_sha256: bool = False,
+) -> None:
+    """Extract to a staging directory, verify, then move into *target*."""
+    target = target.resolve()
+    ensure_verified_target_empty(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    staged = Path(tempfile.mkdtemp(prefix=f".{target.name}.verify-", dir=target.parent))
+    try:
+        extract_archive(archive_path, staged)
+        receipt.verify_extracted(staged, require_sha256=require_sha256)
+        if target.exists():
+            target.rmdir()
+        staged.rename(target)
+    except BaseException:
+        shutil.rmtree(staged, ignore_errors=True)
+        raise
+
+
 def execute_archive(
     args: argparse.Namespace,
     *,
@@ -185,9 +269,43 @@ def execute_archive(
         ellipsis=True,
     )
 
-    create_archive(ctx.root, output, archive_config, bundle_packages=bundle_packages)
+    output = create_archive(
+        ctx.root,
+        output,
+        archive_config,
+        bundle_packages=bundle_packages,
+    )
 
     status.message(console, "Created", "archive", str(output))
+
+    receipt_path = resolve_receipt_path(output, getattr(args, "receipt", None))
+    if receipt_path is not None:
+        if receipt_path.resolve() == output.resolve():
+            raise ArchiveError(
+                "Receipt path cannot be the archive path.",
+                hints=["Choose a separate JSON path for --receipt."],
+            )
+        receipt = ArchiveReceipt.build(
+            root=ctx.root,
+            archive_path=output,
+            archive_config=archive_config,
+            manifest_path=Path(config.manifest_path),
+            lockfile_path=_lockfile_path(ctx),
+            environment_prefixes=receipt_environment_prefixes(
+                config_environments=list(config.environments),
+                ctx_root=ctx.root,
+                env_prefix=ctx.env_prefix,
+            ),
+            options={
+                "bundle": bool(args.bundle),
+                "lock": bool(args.lock),
+                "include": list(archive_config.include),
+                "exclude": list(archive_config.exclude),
+                "compressionLevel": archive_config.compression_level,
+            },
+        )
+        receipt.write(receipt_path)
+        status.message(console, "Created", "receipt", str(receipt_path))
     return 0
 
 
@@ -204,6 +322,16 @@ def execute_unarchive(
     if not archive_path.is_file():
         raise ArchiveError(f"Archive not found: {archive_path}")
 
+    receipt_path = resolve_receipt_path(archive_path, getattr(args, "receipt", None))
+    if getattr(args, "require_sha256", False) and receipt_path is None:
+        raise ArchiveError("--require-sha256 requires --receipt.")
+
+    receipt = None
+    if receipt_path is not None:
+        receipt = ArchiveReceipt.load(receipt_path)
+        receipt.verify_archive(archive_path)
+        status.message(console, "Verified", "archive", str(archive_path.name))
+
     target: Path | None = args.target
     if target is None:
         stem = archive_path.name
@@ -212,6 +340,7 @@ def execute_unarchive(
                 stem = stem[: -len(suffix)]
                 break
         target = Path.cwd() / stem
+    target = target.resolve()
 
     info = inspect_archive(archive_path)
 
@@ -268,9 +397,19 @@ def execute_unarchive(
         ellipsis=True,
     )
 
-    extract_archive(archive_path, target)
+    if receipt is None:
+        extract_archive(archive_path, target)
+    else:
+        extract_verified_archive(
+            archive_path,
+            target,
+            receipt,
+            require_sha256=getattr(args, "require_sha256", False),
+        )
 
     status.message(console, "Extracted", "archive", str(target))
+    if receipt is not None:
+        status.message(console, "Verified", "receipt", str(receipt_path))
 
     if info["has_packages"]:
         console.print(f"  Archive includes {info['package_count']} bundled packages")

--- a/conda_workspaces/receipts.py
+++ b/conda_workspaces/receipts.py
@@ -1,0 +1,687 @@
+"""Small in-toto Statement receipts for workspace archives."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+from urllib.parse import urlsplit
+
+from conda_lockfiles.load_yaml import load_yaml
+
+from .archive import (
+    file_sha256,
+    has_absolute_path_syntax,
+    parse_relative_archive_path,
+    url_to_filename,
+)
+from .exceptions import ArchiveError, ArchiveHashMismatchError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+    from typing import Any
+
+    from .models import ArchiveConfig
+
+IN_TOTO_STATEMENT_TYPE = "https://in-toto.io/Statement/v1"
+ARCHIVE_RECEIPT_PREDICATE_TYPE = (
+    "https://conda-incubator.github.io/conda-workspaces/"
+    "workspace-archive-receipt-1.schema.json"
+)
+ARCHIVE_RECEIPT_FORMAT_VERSION = 1
+
+PACKAGE_RECORD_FIELDS = (
+    "name",
+    "version",
+    "build",
+    "build_number",
+    "subdir",
+    "channel",
+    "url",
+    "fn",
+    "sha256",
+    "md5",
+)
+
+
+@dataclass(frozen=True)
+class ArchiveReceipt:
+    """Unsigned receipt that binds an archive to workspace lockfile metadata."""
+
+    statement: dict[str, Any]
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        root: Path,
+        archive_path: Path,
+        archive_config: ArchiveConfig,
+        manifest_path: Path,
+        lockfile_path: Path,
+        environment_prefixes: Mapping[str, str | Path],
+        options: dict[str, object],
+    ) -> ArchiveReceipt:
+        """Build a receipt for *archive_path* and the selected environments."""
+        root = root.resolve()
+        archive_path = archive_path.resolve()
+        manifest_path = manifest_path.resolve()
+        lockfile_path = lockfile_path.resolve()
+
+        if not manifest_path.is_file():
+            raise ArchiveError(
+                "Cannot write receipt: workspace manifest was not found."
+            )
+        if not lockfile_path.is_file():
+            raise ArchiveError(
+                "Cannot write receipt: no conda.lock found.",
+                hints=["Run 'conda workspace lock' first."],
+            )
+
+        archive_options = dict(options)
+        archive_options.setdefault("include", list(archive_config.include))
+        archive_options.setdefault("exclude", list(archive_config.exclude))
+        archive_options.setdefault("compressionLevel", archive_config.compression_level)
+
+        manifest_name = cls.archive_name(root, manifest_path)
+        lockfile_name = cls.archive_name(root, lockfile_path)
+        receipt = cls(
+            {
+                "_type": IN_TOTO_STATEMENT_TYPE,
+                "subject": [
+                    cls.file_subject(archive_path.name, archive_path),
+                    cls.file_subject(manifest_name, manifest_path),
+                    cls.file_subject(lockfile_name, lockfile_path),
+                ],
+                "predicateType": ARCHIVE_RECEIPT_PREDICATE_TYPE,
+                "predicate": {
+                    "archive": {
+                        "formatVersion": ARCHIVE_RECEIPT_FORMAT_VERSION,
+                        "options": archive_options,
+                    },
+                    "workspace": {
+                        "manifest": manifest_name,
+                        "lockfile": lockfile_name,
+                    },
+                    "environments": ReceiptInventory.from_lockfile(
+                        lockfile_path,
+                        environment_prefixes=environment_prefixes,
+                    ).data,
+                },
+            }
+        )
+        receipt.validate()
+        return receipt
+
+    @classmethod
+    def load(cls, path: Path) -> ArchiveReceipt:
+        """Load a receipt JSON file, rejecting ambiguous duplicate keys."""
+
+        def unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+            result: dict[str, object] = {}
+            for key, value in pairs:
+                if key in result:
+                    raise ArchiveError(f"Invalid receipt: duplicate JSON key '{key}'.")
+                result[key] = value
+            return result
+
+        try:
+            data = json.loads(
+                path.read_text(encoding="utf-8"),
+                object_pairs_hook=unique_object,
+            )
+        except OSError as exc:
+            raise ArchiveError(f"Receipt not found: {path}") from exc
+        except json.JSONDecodeError as exc:
+            raise ArchiveError(f"Invalid receipt JSON: {path}") from exc
+
+        if not isinstance(data, dict):
+            raise ArchiveError("Invalid receipt: expected a JSON object.")
+
+        receipt = cls(cast("dict[str, Any]", data))
+        receipt.validate()
+        return receipt
+
+    @staticmethod
+    def default_path(archive_path: Path) -> Path:
+        """Return the default external receipt path for *archive_path*."""
+        return archive_path.with_name(f"{archive_path.name}.receipt.json")
+
+    @staticmethod
+    def archive_name(root: Path, path: Path) -> str:
+        """Return *path* as a POSIX path relative to *root* when possible."""
+        try:
+            return path.relative_to(root).as_posix()
+        except ValueError:
+            return path.name
+
+    @staticmethod
+    def file_subject(name: str, path: Path) -> dict[str, object]:
+        """Return an in-toto subject for a file."""
+        return {"name": name, "digest": {"sha256": file_sha256(path)}}
+
+    def write(self, path: Path) -> Path:
+        """Write the receipt as stable JSON."""
+        self.validate()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(self.statement, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def validate(self) -> None:
+        """Validate only the receipt fields used by integrity verification."""
+        if self.statement.get("_type") != IN_TOTO_STATEMENT_TYPE:
+            raise ArchiveError("Invalid receipt: unsupported in-toto statement type.")
+        if self.statement.get("predicateType") != ARCHIVE_RECEIPT_PREDICATE_TYPE:
+            raise ArchiveError("Invalid receipt: unsupported predicate type.")
+        self.subject_digests
+        self.workspace_paths
+        self.format_version
+        self.inventory
+
+    @property
+    def predicate(self) -> Mapping[str, object]:
+        """Return the Statement predicate object."""
+        value = self.statement.get("predicate")
+        if not isinstance(value, dict):
+            raise ArchiveError("Invalid receipt: predicate must be an object.")
+        return cast("Mapping[str, object]", value)
+
+    @property
+    def format_version(self) -> int:
+        """Return the supported predicate format version."""
+        archive = self.predicate.get("archive")
+        if not isinstance(archive, dict):
+            raise ArchiveError("Invalid receipt: predicate.archive must be an object.")
+        archive_data = cast("Mapping[str, object]", archive)
+        value = archive_data.get("formatVersion")
+        if (
+            not isinstance(value, int)
+            or isinstance(value, bool)
+            or value != ARCHIVE_RECEIPT_FORMAT_VERSION
+        ):
+            raise ArchiveError("Invalid receipt: unsupported archive format version.")
+        return value
+
+    @property
+    def workspace_paths(self) -> tuple[str, str]:
+        """Return validated archive-relative manifest and lockfile paths."""
+        workspace = self.predicate.get("workspace")
+        if not isinstance(workspace, dict):
+            raise ArchiveError(
+                "Invalid receipt: predicate.workspace must be an object."
+            )
+        workspace_data = cast("Mapping[str, object]", workspace)
+        manifest = workspace_data.get("manifest")
+        lockfile = workspace_data.get("lockfile")
+        if not isinstance(manifest, str) or not isinstance(lockfile, str):
+            raise ArchiveError("Invalid receipt: workspace paths are missing.")
+        return (
+            self.relative_archive_path(manifest, "workspace manifest"),
+            self.relative_archive_path(lockfile, "workspace lockfile"),
+        )
+
+    @property
+    def subject_digests(self) -> dict[str, str]:
+        """Return receipt subjects keyed by name."""
+        subjects = self.statement.get("subject")
+        if not isinstance(subjects, list) or not subjects:
+            raise ArchiveError("Invalid receipt: subject must be a non-empty list.")
+
+        result: dict[str, str] = {}
+        for subject in subjects:
+            if not isinstance(subject, dict):
+                raise ArchiveError("Invalid receipt: subject entries must be objects.")
+            subject_data = cast("Mapping[str, object]", subject)
+            name = subject_data.get("name")
+            digest = subject_data.get("digest")
+            if not isinstance(name, str) or not name:
+                raise ArchiveError("Invalid receipt: subject entry is missing a name.")
+            if name in result:
+                raise ArchiveError("Invalid receipt: duplicate subject name.")
+            if not isinstance(digest, dict):
+                raise ArchiveError(
+                    "Invalid receipt: subject entry is missing a sha256 digest."
+                )
+            digest_data = cast("Mapping[str, object]", digest)
+            if not isinstance(digest_data.get("sha256"), str):
+                raise ArchiveError(
+                    "Invalid receipt: subject entry is missing a sha256 digest."
+                )
+            result[name] = self.sha256_digest(str(digest_data["sha256"]))
+        return result
+
+    @property
+    def inventory(self) -> ReceiptInventory:
+        """Return package inventory recorded in the predicate."""
+        environments = self.predicate.get("environments")
+        if not isinstance(environments, list):
+            raise ArchiveError("Invalid receipt: environments must be a list.")
+
+        records: list[dict[str, object]] = []
+        for index, value in enumerate(environments):
+            records.append(self.environment_record(value, index))
+        inventory = ReceiptInventory(records)
+        for env_name, env in inventory.index_environments().items():
+            ReceiptInventory.index_packages(env, env_name)
+        return inventory
+
+    @classmethod
+    def environment_record(cls, value: object, index: int) -> dict[str, object]:
+        """Parse one receipt environment record."""
+        if not isinstance(value, dict):
+            raise ArchiveError(
+                f"Invalid receipt: environment entry {index} is malformed."
+            )
+        env = cast("Mapping[str, object]", value)
+        name = env.get("name")
+        packages = env.get("packages")
+        if not isinstance(name, str) or not name or not isinstance(packages, list):
+            raise ArchiveError("Invalid receipt: environment entry is malformed.")
+
+        result: dict[str, object] = {
+            "name": name,
+            "packages": [
+                ReceiptPackageRecord.parse(package).data for package in packages
+            ],
+        }
+        prefix = env.get("prefix")
+        if prefix is not None:
+            if not isinstance(prefix, str):
+                raise ArchiveError("Invalid receipt: environment prefix is malformed.")
+            if prefix and not has_absolute_path_syntax(prefix):
+                prefix = cls.relative_archive_path(prefix, f"environment '{name}'")
+            result["prefix"] = prefix
+        return result
+
+    @classmethod
+    def relative_archive_path(cls, path: str, field: str) -> str:
+        """Return a validated relative POSIX archive path."""
+        try:
+            parse_relative_archive_path(path)
+        except ValueError:
+            raise ArchiveError(
+                f"Invalid receipt: {field} path must be a relative archive path."
+            ) from None
+        return path
+
+    @classmethod
+    def path_under(cls, root: Path, path: str, field: str) -> Path:
+        """Resolve receipt path *path* under *root*, rejecting symlink escapes."""
+        try:
+            relative = parse_relative_archive_path(path)
+        except ValueError:
+            raise ArchiveError(
+                f"Invalid receipt: {field} path must be a relative archive path."
+            ) from None
+        root = root.resolve()
+        candidate = root.joinpath(*relative.parts).resolve()
+        try:
+            candidate.relative_to(root)
+        except ValueError:
+            raise ArchiveError(
+                f"Invalid receipt: {field} path escapes the extraction target."
+            )
+        return candidate
+
+    @staticmethod
+    def sha256_digest(value: str) -> str:
+        """Return a lowercase SHA-256 digest string."""
+        try:
+            digest = bytes.fromhex(value)
+        except ValueError:
+            raise ArchiveError("Invalid receipt: invalid sha256 digest.") from None
+        if len(value) != 64 or len(digest) != 32:
+            raise ArchiveError("Invalid receipt: invalid sha256 digest.")
+        return value.lower()
+
+    def verify_subject_file(self, name: str, path: Path) -> None:
+        """Verify *path* against the named receipt subject."""
+        try:
+            expected = self.subject_digests[name]
+        except KeyError:
+            raise ArchiveError(f"Receipt subject not found: {name}") from None
+        try:
+            actual = file_sha256(path)
+        except OSError as exc:
+            raise ArchiveError(f"Receipt subject file cannot be read: {name}") from exc
+        if actual != expected:
+            raise ArchiveHashMismatchError(name, expected=expected, actual=actual)
+
+    def verify_archive(self, archive_path: Path) -> None:
+        """Verify the archive digest before extraction."""
+        self.verify_subject_file(archive_path.name, archive_path)
+
+    def verify_extracted(
+        self,
+        extracted_dir: Path,
+        *,
+        require_sha256: bool = False,
+    ) -> None:
+        """Verify extracted manifest, lockfile, and lockfile package records."""
+        manifest_name, lockfile_name = self.workspace_paths
+        manifest_path = self.path_under(
+            extracted_dir,
+            manifest_name,
+            "workspace manifest",
+        )
+        lockfile_path = self.path_under(
+            extracted_dir,
+            lockfile_name,
+            "workspace lockfile",
+        )
+
+        self.verify_subject_file(manifest_name, manifest_path)
+        self.verify_subject_file(lockfile_name, lockfile_path)
+
+        expected = self.inventory
+        actual = ReceiptInventory.from_lockfile(
+            lockfile_path,
+            environment_prefixes=expected.environment_names(),
+        )
+        expected.compare(actual, require_sha256=require_sha256)
+
+
+@dataclass(frozen=True)
+class ReceiptInventory:
+    """Package records grouped by workspace environment."""
+
+    data: list[dict[str, object]]
+
+    @classmethod
+    def from_lockfile(
+        cls,
+        lockfile_path: Path,
+        *,
+        environment_prefixes: Mapping[str, str | Path] | None = None,
+    ) -> ReceiptInventory:
+        """Return receipt-ready package inventory from ``conda.lock``."""
+        data = load_yaml(lockfile_path)
+        if not isinstance(data, dict):
+            raise ArchiveError("Invalid lockfile: expected a mapping.")
+        lockfile_envs = data.get("environments") or {}
+        if not isinstance(lockfile_envs, dict):
+            raise ArchiveError("Invalid lockfile: environments must be a mapping.")
+        packages_by_url = cls.packages_by_url(data.get("packages", []) or [])
+        env_names = list(environment_prefixes or lockfile_envs)
+
+        result: list[dict[str, object]] = []
+        for env_name in env_names:
+            env_data = lockfile_envs.get(env_name, {}) or {}
+            if not isinstance(env_data, dict):
+                raise ArchiveError("Invalid lockfile: environment must be a mapping.")
+            platform_packages = env_data.get("packages", {}) or {}
+            if not isinstance(platform_packages, dict):
+                raise ArchiveError(
+                    "Invalid lockfile: environment packages must be a mapping."
+                )
+            packages: list[dict[str, object]] = []
+            for platform in sorted(platform_packages):
+                refs = platform_packages[platform] or []
+                if not isinstance(refs, list):
+                    raise ArchiveError("Invalid lockfile package references.")
+                for ref in refs:
+                    if not isinstance(ref, dict):
+                        raise ArchiveError("Invalid lockfile package reference.")
+                    url = ReceiptPackageRecord.package_url(ref)
+                    source = packages_by_url.get(url, ref)
+                    packages.append(
+                        ReceiptPackageRecord.from_record(
+                            source,
+                            fallback_url=url,
+                            platform=platform,
+                        ).data
+                    )
+
+            env: dict[str, object] = {
+                "name": str(env_name),
+                "packages": sorted(
+                    packages,
+                    key=lambda record: ReceiptPackageRecord(record).identity,
+                ),
+            }
+            if environment_prefixes and env_name in environment_prefixes:
+                env["prefix"] = str(environment_prefixes[env_name])
+            result.append(env)
+
+        inventory = cls(result)
+        inventory.index_environments()
+        return inventory
+
+    @staticmethod
+    def packages_by_url(records: object) -> dict[str, dict[str, object]]:
+        """Return top-level lockfile package records keyed by package URL."""
+        result: dict[str, dict[str, object]] = {}
+        if not isinstance(records, list):
+            return result
+        for record in records:
+            if not isinstance(record, dict):
+                continue
+            record_data = cast("dict[str, object]", record)
+            url = ReceiptPackageRecord.package_url(record_data)
+            if not url:
+                continue
+            if url in result:
+                raise ArchiveError(f"Duplicate package URL in lockfile: {url}")
+            result[url] = record_data
+        return result
+
+    def environment_names(self) -> dict[str, str]:
+        """Return environment names as a mapping for lockfile inventory loading."""
+        return {str(env["name"]): "" for env in self.data}
+
+    def index_environments(self) -> dict[str, dict[str, object]]:
+        """Return environments keyed by name, rejecting duplicate names."""
+        result: dict[str, dict[str, object]] = {}
+        for env in self.data:
+            name = env.get("name")
+            if not isinstance(name, str) or not name:
+                raise ArchiveError("Invalid receipt: environment entry is malformed.")
+            if name in result:
+                raise ArchiveError(f"Duplicate environment record: {name}")
+            result[name] = env
+        return result
+
+    def compare(
+        self,
+        actual: ReceiptInventory,
+        *,
+        require_sha256: bool = False,
+    ) -> None:
+        """Raise if *actual* does not match this inventory."""
+        expected_envs = self.index_environments()
+        actual_envs = actual.index_environments()
+        if missing := sorted(set(expected_envs) - set(actual_envs)):
+            raise ArchiveError(f"Missing environment record: {missing[0]}")
+        if unexpected := sorted(set(actual_envs) - set(expected_envs)):
+            raise ArchiveError(f"Unexpected environment record: {unexpected[0]}")
+
+        for env_name in sorted(expected_envs):
+            expected = self.index_packages(expected_envs[env_name], env_name)
+            found = self.index_packages(actual_envs[env_name], env_name)
+            if missing := sorted(set(expected) - set(found)):
+                raise ArchiveError(
+                    f"Missing package record for environment '{env_name}': {missing[0]}"
+                )
+            if unexpected := sorted(set(found) - set(expected)):
+                raise ArchiveError(
+                    f"Unexpected package record for environment"
+                    f" '{env_name}': {unexpected[0]}"
+                )
+            for identity in sorted(expected):
+                if require_sha256 and (
+                    not expected[identity].get("sha256")
+                    or not found[identity].get("sha256")
+                ):
+                    raise ArchiveError(
+                        f"Package record '{identity}' in environment"
+                        f" '{env_name}' lacks sha256."
+                    )
+                if expected[identity] != found[identity]:
+                    raise ArchiveError(
+                        f"Package record mismatch for environment"
+                        f" '{env_name}': {identity}"
+                    )
+
+    @staticmethod
+    def index_packages(
+        env: dict[str, object],
+        env_name: str,
+    ) -> dict[str, dict[str, object]]:
+        """Return package records keyed by identity, rejecting duplicates."""
+        packages = env.get("packages")
+        if not isinstance(packages, list):
+            raise ArchiveError(
+                f"Invalid package inventory for environment '{env_name}'."
+            )
+        result: dict[str, dict[str, object]] = {}
+        for package in packages:
+            if not isinstance(package, dict):
+                raise ArchiveError(
+                    f"Invalid package inventory for environment '{env_name}'."
+                )
+            record = ReceiptPackageRecord(cast("dict[str, object]", package))
+            identity = record.identity
+            if not identity:
+                raise ArchiveError(
+                    f"Invalid package inventory for environment '{env_name}'."
+                )
+            if identity in result:
+                raise ArchiveError(
+                    f"Duplicate package record for environment '{env_name}': {identity}"
+                )
+            result[identity] = record.data
+        return result
+
+
+@dataclass(frozen=True)
+class ReceiptPackageRecord:
+    """Receipt-ready view of a lockfile package record."""
+
+    data: dict[str, object]
+
+    @classmethod
+    def parse(cls, value: object) -> ReceiptPackageRecord:
+        """Parse a package record from receipt JSON."""
+        if not isinstance(value, dict):
+            raise ArchiveError("Invalid receipt: package record must be an object.")
+        source = cast("Mapping[str, object]", value)
+        record = {
+            field: source[field]
+            for field in PACKAGE_RECORD_FIELDS
+            if field in source and source[field] is not None
+        }
+        for field, field_value in record.items():
+            if field == "build_number":
+                if not (
+                    isinstance(field_value, str)
+                    or (
+                        isinstance(field_value, int)
+                        and not isinstance(field_value, bool)
+                    )
+                ):
+                    raise ArchiveError(
+                        "Invalid receipt: package build_number is malformed."
+                    )
+            elif not isinstance(field_value, str):
+                raise ArchiveError(f"Invalid receipt: package {field} is malformed.")
+        for field, length in (("sha256", 64), ("md5", 32)):
+            if field in record:
+                cls.hex_digest(str(record[field]), length, field)
+                record[field] = str(record[field]).lower()
+
+        package = cls(record)
+        if not package.identity:
+            raise ArchiveError("Invalid receipt: package record lacks an identity.")
+        return package
+
+    @classmethod
+    def from_record(
+        cls,
+        record: Mapping[str, object],
+        *,
+        fallback_url: str = "",
+        platform: str = "",
+    ) -> ReceiptPackageRecord:
+        """Normalize a lockfile package record for receipts."""
+        result = {
+            field: record[field]
+            for field in PACKAGE_RECORD_FIELDS
+            if field in record and record[field] is not None
+        }
+        url = cls.package_url(record) or fallback_url
+        if url:
+            result["url"] = cls.redact_url(url)
+            result.setdefault("fn", url_to_filename(url))
+        if platform:
+            result.setdefault("subdir", platform)
+
+        channel = result.get("channel")
+        if isinstance(channel, str) and channel:
+            result["channel"] = cls.redact_url(channel)
+        elif url and isinstance(result.get("fn"), str):
+            result["channel"] = cls.channel_url(
+                str(result["url"]),
+                str(result.get("subdir", "")),
+                str(result["fn"]),
+            )
+        return cls.parse(result)
+
+    @staticmethod
+    def package_url(record: Mapping[str, object]) -> str:
+        """Return a lockfile package URL."""
+        value = record.get("conda") or record.get("url")
+        return value if isinstance(value, str) else ""
+
+    @staticmethod
+    def redact_url(url: str) -> str:
+        """Return *url* without credentials, tokens, query, or fragment."""
+        from conda.common.url import remove_auth, split_anaconda_token
+
+        redacted, _ = split_anaconda_token(url)
+        redacted = remove_auth(redacted)
+        parts = urlsplit(redacted)
+        return parts._replace(query="", fragment="").geturl()
+
+    @staticmethod
+    def channel_url(url: str, subdir: str, filename: str) -> str:
+        """Derive a channel URL from a package artifact URL."""
+        parts = urlsplit(url)
+        path = parts.path
+        suffix = f"/{subdir}/{filename}"
+        if subdir and filename and path.endswith(suffix):
+            path = path[: -len(suffix)]
+        elif filename and path.endswith(f"/{filename}"):
+            path = path[: -(len(filename) + 1)]
+        return parts._replace(path=path).geturl()
+
+    @staticmethod
+    def hex_digest(value: str, length: int, field: str) -> None:
+        """Validate a lowercase hex digest."""
+        try:
+            digest = bytes.fromhex(value)
+        except ValueError:
+            raise ArchiveError(
+                f"Invalid receipt: package {field} is malformed."
+            ) from None
+        if len(value) != length or len(digest) != length // 2:
+            raise ArchiveError(f"Invalid receipt: package {field} is malformed.")
+
+    @property
+    def identity(self) -> str:
+        """Return the comparison identity for this package record."""
+        if url := self.data.get("url"):
+            return str(url)
+        if filename := self.data.get("fn"):
+            subdir = str(self.data.get("subdir", ""))
+            return f"{subdir}/{filename}" if subdir else str(filename)
+        parts = [
+            str(self.data.get("name", "")),
+            str(self.data.get("version", "")),
+            str(self.data.get("build", "")),
+            str(self.data.get("channel", "")),
+        ]
+        return "|".join(parts) if any(parts) else ""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ html_context = {
 }
 
 html_static_path = ["_static"]
-html_extra_path = ["../demos"]
+html_extra_path = ["../demos", "../schema"]
 html_css_files = ["css/custom.css"]
 
 html_baseurl = "https://conda-incubator.github.io/conda-workspaces/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ source = "vcs"
 [tool.hatch.build.hooks.vcs]
 version-file = "conda_workspaces/_version.py"
 
+[tool.hatch.build.targets.wheel.force-include]
+"schema" = "schema"
+
 [project.scripts]
 cw = "conda_workspaces.__main__:main"
 ct = "conda_workspaces.__main__:main_task"

--- a/schema/workspace-archive-receipt-1.schema.json
+++ b/schema/workspace-archive-receipt-1.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://conda-incubator.github.io/conda-workspaces/workspace-archive-receipt-1.schema.json",
+  "title": "conda-workspaces archive receipt v1",
+  "type": "object",
+  "required": ["_type", "subject", "predicateType", "predicate"],
+  "properties": {
+    "_type": {
+      "const": "https://in-toto.io/Statement/v1"
+    },
+    "subject": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "digest"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "digest": {
+            "type": "object",
+            "required": ["sha256"],
+            "properties": {
+              "sha256": {
+                "type": "string",
+                "pattern": "^[0-9a-fA-F]{64}$"
+              }
+            }
+          }
+        }
+      }
+    },
+    "predicateType": {
+      "const": "https://conda-incubator.github.io/conda-workspaces/workspace-archive-receipt-1.schema.json"
+    },
+    "predicate": {
+      "type": "object",
+      "required": ["archive", "workspace", "environments"],
+      "properties": {
+        "archive": {
+          "type": "object",
+          "required": ["formatVersion"],
+          "properties": {
+            "formatVersion": {
+              "const": 1
+            },
+            "options": {
+              "type": "object"
+            }
+          }
+        },
+        "workspace": {
+          "type": "object",
+          "required": ["manifest", "lockfile"],
+          "properties": {
+            "manifest": {
+              "type": "string",
+              "minLength": 1
+            },
+            "lockfile": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "packages"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "prefix": {
+                "type": "string"
+              },
+              "packages": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": { "type": "string" },
+                    "version": { "type": "string" },
+                    "build": { "type": "string" },
+                    "build_number": {
+                      "type": ["integer", "string"]
+                    },
+                    "subdir": { "type": "string" },
+                    "channel": { "type": "string" },
+                    "url": { "type": "string" },
+                    "fn": { "type": "string" },
+                    "sha256": {
+                      "type": "string",
+                      "pattern": "^[0-9a-fA-F]{64}$"
+                    },
+                    "md5": {
+                      "type": "string",
+                      "pattern": "^[0-9a-fA-F]{32}$"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -293,6 +293,20 @@ def test_archive_subparser_registered() -> None:
     assert str(ns.output) == "out.tar.gz"
 
 
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        (["archive", "-o", "out.tar.gz", "--receipt"], True),
+        (["archive", "-o", "out.tar.gz", "--receipt", "r.json"], Path("r.json")),
+    ],
+    ids=["default", "path"],
+)
+def test_archive_subparser_receipt(args: list[str], expected: object) -> None:
+    parser = generate_workspace_parser()
+    ns = parser.parse_args(args)
+    assert ns.receipt == expected
+
+
 def test_unarchive_subparser_registered() -> None:
     parser = generate_workspace_parser()
     ns = parser.parse_args(
@@ -314,3 +328,19 @@ def test_unarchive_subparser_registered() -> None:
     assert ns.environment == "runtime"
     assert ns.prefix == "/opt/runtime"
     assert ns.dest == Path("/tmp/rootfs")
+
+
+def test_unarchive_subparser_receipt() -> None:
+    parser = generate_workspace_parser()
+    ns = parser.parse_args(
+        [
+            "unarchive",
+            "project.tar.gz",
+            "--receipt",
+            "project.receipt.json",
+            "--require-sha256",
+        ]
+    )
+
+    assert ns.receipt == Path("project.receipt.json")
+    assert ns.require_sha256 is True

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -303,6 +303,38 @@ def test_execute_archive_receipt_path_cannot_be_archive_path(
         execute_archive(args, console=console)
 
 
+@pytest.mark.parametrize(
+    ("exclude", "match"),
+    [
+        ("conda.toml", "workspace manifest"),
+        ("conda.lock", "workspace lockfile"),
+    ],
+    ids=["manifest", "lockfile"],
+)
+def test_execute_archive_receipt_requires_bound_files_in_archive(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    exclude: str,
+    match: str,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    args = make_args(
+        _ARCHIVE_DEFAULTS,
+        output=archive,
+        exclude=[exclude],
+        receipt=True,
+    )
+    with pytest.raises(ArchiveError, match=match):
+        execute_archive(args, console=console)
+
+    assert not archive.exists()
+    assert not ArchiveReceipt.default_path(archive).exists()
+
+
 def test_execute_unarchive_basic(
     archive_workspace: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import tarfile
 from io import StringIO
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 from rich.console import Console
@@ -165,6 +165,16 @@ def test_receipt_environment_prefixes_records_external_prefix(tmp_path: Path) ->
         "default": ".conda/envs/default",
         "runtime": "/opt/runtime",
     }
+
+
+def test_receipt_environment_prefixes_normalizes_windows_external_prefix() -> None:
+    prefixes = receipt_environment_prefixes(
+        config_environments=["runtime"],
+        ctx_root=PureWindowsPath("C:/workspace"),
+        env_prefix=lambda name: PureWindowsPath("D:/runtime"),
+    )
+
+    assert prefixes == {"runtime": "D:/runtime"}
 
 
 @pytest.fixture

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import tarfile
 from io import StringIO
 from pathlib import Path
@@ -12,12 +13,16 @@ from rich.console import Console
 from conda_workspaces.cli.workspace.archive import (
     execute_archive,
     execute_unarchive,
+    extract_verified_archive,
     file_contains_bytes,
     is_absolute_runtime_prefix,
+    receipt_environment_prefixes,
+    resolve_receipt_path,
     runtime_prefix_relative_path,
     scan_prefix_references,
 )
 from conda_workspaces.exceptions import ArchiveError
+from conda_workspaces.receipts import ArchiveReceipt
 
 from ..conftest import make_args
 
@@ -27,6 +32,7 @@ _ARCHIVE_DEFAULTS = {
     "bundle": False,
     "lock": False,
     "exclude": None,
+    "receipt": None,
     "dry_run": False,
     "json": False,
 }
@@ -40,6 +46,8 @@ _UNARCHIVE_DEFAULTS = {
     "environment": None,
     "prefix": None,
     "dest": None,
+    "receipt": None,
+    "require_sha256": False,
     "dry_run": False,
     "json": False,
 }
@@ -105,6 +113,58 @@ def test_scan_prefix_references_limits_matches(tmp_path: Path) -> None:
     assert len(matches) == 2
     assert truncated is True
     assert all(path.name.startswith("match-") for path in matches)
+
+
+@pytest.mark.parametrize(
+    ("receipt", "expected"),
+    [
+        (None, None),
+        (False, None),
+        (True, "workspace.tar.gz.receipt.json"),
+        (Path("custom.json"), "custom.json"),
+        ("string.json", "string.json"),
+    ],
+    ids=["none", "false", "default", "path", "string"],
+)
+def test_resolve_receipt_path(
+    tmp_path: Path,
+    receipt: object,
+    expected: str | None,
+) -> None:
+    archive_path = tmp_path / "workspace.tar.gz"
+    result = resolve_receipt_path(archive_path, receipt)
+
+    if expected is None:
+        assert result is None
+    elif receipt is True:
+        assert result == tmp_path / expected
+    else:
+        assert result == Path(expected)
+
+
+def test_resolve_receipt_path_rejects_invalid_value(tmp_path: Path) -> None:
+    with pytest.raises(ArchiveError, match="Invalid --receipt value"):
+        resolve_receipt_path(tmp_path / "workspace.tar.gz", object())
+
+
+def test_receipt_environment_prefixes_records_external_prefix(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+
+    prefixes = receipt_environment_prefixes(
+        config_environments=["default", "runtime"],
+        ctx_root=root,
+        env_prefix=lambda name: (
+            root / ".conda" / "envs" / name
+            if name == "default"
+            else Path("/opt/runtime")
+        ),
+    )
+
+    assert prefixes == {
+        "default": ".conda/envs/default",
+        "runtime": "/opt/runtime",
+    }
 
 
 @pytest.fixture
@@ -185,6 +245,54 @@ def test_execute_archive_exclude(
     assert "src/app.py" not in names
 
 
+@pytest.mark.parametrize(
+    ("receipt", "expected_name"),
+    [
+        (True, "test.tar.gz.receipt.json"),
+        ("custom-receipt.json", "custom-receipt.json"),
+    ],
+    ids=["default-path", "explicit-path"],
+)
+def test_execute_archive_receipt_path(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    receipt: object,
+    expected_name: str,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+    receipt_arg = tmp_path / receipt if isinstance(receipt, str) else receipt
+
+    args = make_args(_ARCHIVE_DEFAULTS, output=archive, receipt=receipt_arg)
+    result = execute_archive(args, console=console)
+
+    assert result == 0
+    receipt_path = tmp_path / expected_name
+    data = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert data["_type"] == "https://in-toto.io/Statement/v1"
+    assert data["subject"][0]["name"] == "test.tar.gz"
+    assert data["predicate"]["workspace"] == {
+        "manifest": "conda.toml",
+        "lockfile": "conda.lock",
+    }
+
+
+def test_execute_archive_receipt_path_cannot_be_archive_path(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    args = make_args(_ARCHIVE_DEFAULTS, output=archive, receipt=archive)
+    with pytest.raises(ArchiveError, match="Receipt path cannot be the archive path"):
+        execute_archive(args, console=console)
+
+
 def test_execute_unarchive_basic(
     archive_workspace: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -205,6 +313,150 @@ def test_execute_unarchive_basic(
     assert (target / "conda.toml").is_file()
     assert (target / "conda.lock").is_file()
     assert (target / "src" / "app.py").is_file()
+
+
+def test_execute_unarchive_receipt_default_path(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    execute_archive(
+        make_args(_ARCHIVE_DEFAULTS, output=archive, receipt=True),
+        console=console,
+    )
+
+    target = tmp_path / "extracted"
+    result = execute_unarchive(
+        make_args(
+            _UNARCHIVE_DEFAULTS,
+            archive_path=archive,
+            target=target,
+            receipt=True,
+        ),
+        console=console,
+    )
+
+    assert result == 0
+    assert (target / "conda.toml").is_file()
+    assert "Verified" in console.file.getvalue()
+
+
+def test_execute_unarchive_receipt_detects_tampered_archive(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    execute_archive(
+        make_args(_ARCHIVE_DEFAULTS, output=archive, receipt=True),
+        console=console,
+    )
+    archive.write_bytes(archive.read_bytes() + b"tamper")
+
+    with pytest.raises(ArchiveError, match="Hash mismatch"):
+        execute_unarchive(
+            make_args(
+                _UNARCHIVE_DEFAULTS,
+                archive_path=archive,
+                target=tmp_path / "extracted",
+                receipt=True,
+            ),
+            console=console,
+        )
+
+
+@pytest.mark.parametrize(
+    "target_setup",
+    ["non-empty", "file-target", "symlink-target"],
+    ids=["non-empty", "file-target", "symlink-target"],
+)
+def test_execute_unarchive_receipt_rejects_existing_target(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    target_setup: str,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    execute_archive(
+        make_args(_ARCHIVE_DEFAULTS, output=archive, receipt=True),
+        console=console,
+    )
+    target = tmp_path / "extracted"
+    if target_setup == "non-empty":
+        target.mkdir()
+        (target / "existing.txt").write_text("x", encoding="utf-8")
+    elif target_setup == "file-target":
+        target.write_text("x", encoding="utf-8")
+    else:
+        target.symlink_to(tmp_path)
+
+    with pytest.raises(ArchiveError, match="Cannot verify receipt"):
+        execute_unarchive(
+            make_args(
+                _UNARCHIVE_DEFAULTS,
+                archive_path=archive,
+                target=target,
+                receipt=True,
+            ),
+            console=console,
+        )
+
+
+def test_execute_unarchive_require_sha256_requires_receipt(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(archive_workspace)
+    archive = tmp_path / "test.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    execute_archive(make_args(_ARCHIVE_DEFAULTS, output=archive), console=console)
+
+    with pytest.raises(ArchiveError, match="--require-sha256 requires --receipt"):
+        execute_unarchive(
+            make_args(
+                _UNARCHIVE_DEFAULTS,
+                archive_path=archive,
+                target=tmp_path / "extracted",
+                require_sha256=True,
+            ),
+            console=console,
+        )
+
+
+def test_extract_verified_archive_cleans_failed_staging(
+    archive_workspace: Path,
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "test.tar.gz"
+    receipt_path = tmp_path / "test.tar.gz.receipt.json"
+    create_console = Console(file=StringIO(), width=200, highlight=False)
+
+    args = make_args(_ARCHIVE_DEFAULTS, output=archive, receipt=receipt_path)
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.chdir(archive_workspace)
+        execute_archive(args, console=create_console)
+
+    receipt = ArchiveReceipt.load(receipt_path)
+    receipt.statement["predicate"]["workspace"]["lockfile"] = "../conda.lock"
+    target = tmp_path / "target"
+
+    with pytest.raises(ArchiveError, match="relative archive path"):
+        extract_verified_archive(archive, target, receipt)
+
+    assert not target.exists()
+    assert not list(tmp_path.glob(".target.verify-*"))
 
 
 def test_execute_unarchive_default_target(

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -4,18 +4,21 @@ import hashlib
 import io
 import subprocess
 import tarfile
+from pathlib import PureWindowsPath
 from typing import TYPE_CHECKING
 
 import pytest
 
 from conda_workspaces.archive import (
     ALLOWED_TAR_TYPES,
+    add_files_to_tar,
     collect_archive_files,
     collect_bundle_packages,
     create_archive,
     extract_archive,
     inspect_archive,
     open_tar,
+    parse_relative_archive_path,
     prime_package_cache,
     url_to_filename,
     validate_tar_member,
@@ -229,6 +232,25 @@ def test_create_archive_output_dir_created(project_dir: Path, tmp_path: Path) ->
     assert output.is_file()
 
 
+def test_add_files_to_tar_writes_posix_member_names() -> None:
+    class RecordingTar:
+        def __init__(self) -> None:
+            self.arcnames: list[str] = []
+
+        def add(self, name: str, arcname: str) -> None:
+            self.arcnames.append(arcname)
+
+    tf = RecordingTar()
+
+    add_files_to_tar(
+        tf,
+        PureWindowsPath("C:/workspace"),
+        [PureWindowsPath("C:/workspace/src/main.py")],
+    )
+
+    assert tf.arcnames == ["src/main.py"]
+
+
 def test_extract_archive_basic(project_dir: Path, tmp_path: Path) -> None:
     archive_path = tmp_path / "test.tar.gz"
     config = ArchiveConfig()
@@ -248,6 +270,8 @@ def test_extract_archive_basic(project_dir: Path, tmp_path: Path) -> None:
     [
         pytest.param("../../../etc/passwd", None, None, id="dotdot-traversal"),
         pytest.param("/tmp/evil_file", None, None, id="absolute-path"),
+        pytest.param("C:/tmp/evil_file", None, None, id="windows-drive"),
+        pytest.param("dir\\evil_file", None, None, id="windows-backslash"),
         pytest.param("escape", tarfile.SYMTYPE, "../../../etc", id="symlink-escape"),
     ],
 )
@@ -270,6 +294,55 @@ def test_extract_archive_path_traversal_blocked(
     target = tmp_path / "safe"
     with pytest.raises(ArchivePathTraversalError):
         extract_archive(evil_archive, target)
+
+
+@pytest.mark.parametrize(
+    ("path", "allow_parent"),
+    [
+        ("conda.toml", False),
+        ("envs/default/conda-meta/history", False),
+        ("../target", True),
+    ],
+    ids=["file", "nested", "link-parent"],
+)
+def test_parse_relative_archive_path_allows_valid_paths(
+    path: str,
+    allow_parent: bool,
+) -> None:
+    assert parse_relative_archive_path(path, allow_parent=allow_parent).as_posix()
+
+
+@pytest.mark.parametrize(
+    ("path", "allow_parent"),
+    [
+        ("", False),
+        ("/tmp/evil", False),
+        ("C:/tmp/evil", False),
+        ("dir\\evil", False),
+        ("dir/../evil", False),
+        ("dir/./evil", False),
+        ("dir//evil", False),
+        ("bad\0path", False),
+        ("C:evil", True),
+    ],
+    ids=[
+        "empty",
+        "absolute",
+        "windows-drive",
+        "backslash",
+        "parent",
+        "current-dir",
+        "double-slash",
+        "nul",
+        "drive-relative-link",
+    ],
+)
+def test_parse_relative_archive_path_rejects_unsafe_paths(
+    path: str,
+    allow_parent: bool,
+) -> None:
+    with pytest.raises(ValueError):
+        parse_relative_archive_path(path, allow_parent=allow_parent)
 
 
 def test_extract_archive_zst(project_dir: Path, tmp_path: Path) -> None:
@@ -583,6 +656,8 @@ def test_validate_tar_member_allows_regular_types(tmp_path: Path) -> None:
     for file_type in ALLOWED_TAR_TYPES:
         member = tarfile.TarInfo(name="normal_file")
         member.type = file_type
+        if file_type in {tarfile.LNKTYPE, tarfile.SYMTYPE}:
+            member.linkname = "normal_target"
         validate_tar_member(member, tmp_path)
 
 

--- a/tests/test_receipts.py
+++ b/tests/test_receipts.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from conda_workspaces.archive import create_archive, extract_archive
+from conda_workspaces.exceptions import ArchiveError
+from conda_workspaces.models import ArchiveConfig
+from conda_workspaces.receipts import (
+    ARCHIVE_RECEIPT_PREDICATE_TYPE,
+    IN_TOTO_STATEMENT_TYPE,
+    ArchiveReceipt,
+    ReceiptInventory,
+    ReceiptPackageRecord,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+    from typing import Any
+
+
+def write_lockfile(root: Path, *, sha256: bool = True) -> None:
+    sha256_line = (
+        "    sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        if sha256
+        else ""
+    )
+    root.joinpath("conda.lock").write_text(
+        f"""\
+version: 1
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+        - conda: https://user:pass@conda.anaconda.org/t/token/conda-forge/linux-64/zlib-1.2.13-h4dc568a_6.conda?token=query
+packages:
+  - conda: https://user:pass@conda.anaconda.org/t/token/conda-forge/linux-64/zlib-1.2.13-h4dc568a_6.conda?token=query
+{sha256_line}    md5: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    name: zlib
+    version: 1.2.13
+    build: h4dc568a_6
+    subdir: linux-64
+    depends: []
+""",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def receipt_workspace(tmp_path: Path) -> Path:
+    tmp_path.joinpath("conda.toml").write_text(
+        "[workspace]\nname = 'receipt-test'\n",
+        encoding="utf-8",
+    )
+    write_lockfile(tmp_path)
+    tmp_path.joinpath("src").mkdir()
+    tmp_path.joinpath("src", "app.py").write_text("print('hi')\n", encoding="utf-8")
+    return tmp_path
+
+
+def build_receipt(root: Path, archive_path: Path) -> ArchiveReceipt:
+    return ArchiveReceipt.build(
+        root=root,
+        archive_path=archive_path,
+        archive_config=ArchiveConfig(),
+        manifest_path=root / "conda.toml",
+        lockfile_path=root / "conda.lock",
+        environment_prefixes={"default": ".conda/envs/default"},
+        options={"bundle": False, "lock": False},
+    )
+
+
+def copied_statement(receipt: ArchiveReceipt) -> dict[str, Any]:
+    return json.loads(json.dumps(receipt.statement))
+
+
+def test_archive_receipt_roundtrip(receipt_workspace: Path, tmp_path: Path) -> None:
+    archive_path = tmp_path / "workspace.tar.gz"
+    create_archive(receipt_workspace, archive_path, ArchiveConfig())
+    receipt_path = ArchiveReceipt.default_path(archive_path)
+
+    receipt = build_receipt(receipt_workspace, archive_path)
+    receipt.write(receipt_path)
+
+    loaded = ArchiveReceipt.load(receipt_path)
+    loaded.verify_archive(archive_path)
+    target = tmp_path / "extracted"
+    extract_archive(archive_path, target)
+    loaded.verify_extracted(target)
+
+    assert loaded.statement["_type"] == IN_TOTO_STATEMENT_TYPE
+    assert loaded.statement["predicateType"] == ARCHIVE_RECEIPT_PREDICATE_TYPE
+    package = loaded.statement["predicate"]["environments"][0]["packages"][0]
+    assert package["url"] == (
+        "https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h4dc568a_6.conda"
+    )
+    assert "user:pass" not in json.dumps(loaded.statement)
+    assert "/t/token/" not in json.dumps(loaded.statement)
+
+
+@pytest.mark.parametrize(
+    ("content", "match"),
+    [
+        ("", "Invalid receipt JSON"),
+        ("[]", "expected a JSON object"),
+        (
+            '{"_type":"https://in-toto.io/Statement/v1","_type":"x"}',
+            "duplicate JSON key",
+        ),
+    ],
+    ids=["empty", "non-object", "duplicate-key"],
+)
+def test_archive_receipt_load_rejects_invalid_json(
+    tmp_path: Path,
+    content: str,
+    match: str,
+) -> None:
+    receipt_path = tmp_path / "receipt.json"
+    receipt_path.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ArchiveError, match=match):
+        ArchiveReceipt.load(receipt_path)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (
+            lambda statement: statement.__setitem__("_type", "wrong"),
+            "statement type",
+        ),
+        (
+            lambda statement: statement.__setitem__("predicateType", "wrong"),
+            "predicate type",
+        ),
+        (
+            lambda statement: statement["predicate"]["workspace"].__setitem__(
+                "lockfile", "../conda.lock"
+            ),
+            "relative archive path",
+        ),
+        (
+            lambda statement: statement["subject"].append(statement["subject"][0]),
+            "duplicate subject",
+        ),
+        (
+            lambda statement: statement["predicate"]["environments"].append(
+                statement["predicate"]["environments"][0]
+            ),
+            "Duplicate environment",
+        ),
+        (
+            lambda statement: statement["predicate"]["environments"][0][
+                "packages"
+            ].append(statement["predicate"]["environments"][0]["packages"][0]),
+            "Duplicate package",
+        ),
+    ],
+    ids=[
+        "statement-type",
+        "predicate-type",
+        "unsafe-lockfile-path",
+        "duplicate-subject",
+        "duplicate-environment",
+        "duplicate-package",
+    ],
+)
+def test_archive_receipt_validate_rejects_ambiguous_or_unsafe_records(
+    receipt_workspace: Path,
+    tmp_path: Path,
+    mutate: Callable[[dict[str, Any]], None],
+    match: str,
+) -> None:
+    archive_path = tmp_path / "workspace.tar.gz"
+    create_archive(receipt_workspace, archive_path, ArchiveConfig())
+    statement = copied_statement(build_receipt(receipt_workspace, archive_path))
+    mutate(statement)
+
+    with pytest.raises(ArchiveError, match=match):
+        ArchiveReceipt(statement).validate()
+
+
+def test_archive_receipt_detects_tampered_archive(
+    receipt_workspace: Path,
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / "workspace.tar.gz"
+    create_archive(receipt_workspace, archive_path, ArchiveConfig())
+    receipt = build_receipt(receipt_workspace, archive_path)
+
+    archive_path.write_bytes(archive_path.read_bytes() + b"tamper")
+
+    with pytest.raises(ArchiveError, match="Hash mismatch"):
+        receipt.verify_archive(archive_path)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (
+            lambda target: (target / "conda.lock").write_text(
+                "version: 1\n",
+                encoding="utf-8",
+            ),
+            "Hash mismatch",
+        ),
+        (
+            lambda target: (target / "conda.lock").unlink(),
+            "subject file cannot be read",
+        ),
+    ],
+    ids=["tampered", "missing"],
+)
+def test_archive_receipt_detects_invalid_extracted_lockfile(
+    receipt_workspace: Path,
+    tmp_path: Path,
+    mutate: Callable[[Path], object],
+    match: str,
+) -> None:
+    archive_path = tmp_path / "workspace.tar.gz"
+    create_archive(receipt_workspace, archive_path, ArchiveConfig())
+    receipt = build_receipt(receipt_workspace, archive_path)
+    target = tmp_path / "extracted"
+    extract_archive(archive_path, target)
+    mutate(target)
+
+    with pytest.raises(ArchiveError, match=match):
+        receipt.verify_extracted(target)
+
+
+@pytest.mark.parametrize(
+    ("packages", "match"),
+    [
+        ([], "Unexpected package record"),
+        (
+            [
+                {
+                    "url": "https://example.com/missing.conda",
+                    "sha256": "0" * 64,
+                }
+            ],
+            "Missing package record",
+        ),
+    ],
+    ids=["unexpected-actual", "missing-actual"],
+)
+def test_archive_receipt_validates_package_inventory(
+    receipt_workspace: Path,
+    tmp_path: Path,
+    packages: list[dict[str, object]],
+    match: str,
+) -> None:
+    archive_path = tmp_path / "workspace.tar.gz"
+    create_archive(receipt_workspace, archive_path, ArchiveConfig())
+    receipt = build_receipt(receipt_workspace, archive_path)
+    statement = copied_statement(receipt)
+    statement["predicate"]["environments"][0]["packages"] = packages
+    target = tmp_path / "extracted"
+    extract_archive(archive_path, target)
+
+    with pytest.raises(ArchiveError, match=match):
+        ArchiveReceipt(statement).verify_extracted(target)
+
+
+def test_archive_receipt_require_sha256_rejects_md5_only_record(
+    tmp_path: Path,
+) -> None:
+    tmp_path.joinpath("conda.toml").write_text("[workspace]\nname = 'test'\n")
+    write_lockfile(tmp_path, sha256=False)
+    archive_path = tmp_path / "workspace.tar.gz"
+    create_archive(tmp_path, archive_path, ArchiveConfig())
+    receipt = build_receipt(tmp_path, archive_path)
+    target = tmp_path / "extracted"
+    extract_archive(archive_path, target)
+
+    receipt.verify_extracted(target)
+    with pytest.raises(ArchiveError, match="lacks sha256"):
+        receipt.verify_extracted(target, require_sha256=True)
+
+
+def test_receipt_inventory_compare_rejects_duplicate_package_identity() -> None:
+    env = {
+        "name": "default",
+        "packages": [
+            {"url": "https://example.com/pkg.conda"},
+            {"url": "https://example.com/pkg.conda"},
+        ],
+    }
+
+    with pytest.raises(ArchiveError, match="Duplicate package record"):
+        ReceiptInventory([env]).compare(ReceiptInventory([env]))
+
+
+def test_receipt_package_record_identity_fallbacks() -> None:
+    assert ReceiptPackageRecord({"fn": "pkg-1.0-h0.conda"}).identity == (
+        "pkg-1.0-h0.conda"
+    )
+    assert (
+        ReceiptPackageRecord(
+            {
+                "name": "pkg",
+                "version": "1.0",
+                "build": "h0",
+                "channel": "https://conda.anaconda.org/conda-forge/",
+            }
+        ).identity
+        == "pkg|1.0|h0|https://conda.anaconda.org/conda-forge/"
+    )


### PR DESCRIPTION
## Summary

Closes #83.

- Add a small `conda_workspaces.receipts` module for unsigned in-toto Statement archive receipts.
- Add `conda workspace archive --receipt [PATH]` to write an external receipt after the archive is created; bare `--receipt` writes `<archive>.receipt.json`.
- Add `conda workspace unarchive --receipt [PATH]` to verify the archive digest before extraction, extract into a staging directory, verify the extracted manifest, lockfile, and selected-environment lockfile package inventory, then move the verified tree into place.
- Add `--require-sha256` for stricter package inventory verification, credential-redacted package URLs/channels, duplicate JSON-key and duplicate inventory rejection, and POSIX-only archive path checks.
- Add the receipt predicate schema under the existing root `schema/` directory and publish root schemas through the docs build instead of using `schemas.conda.org`.

## Design Notes

This is intentionally the #83 integrity layer only, not the #62 provenance/signature layer. The receipt is an in-toto Statement-shaped JSON document, not a DSSE envelope, and the runtime parser validates only the fields used for integrity verification while allowing future/unknown Statement fields. No `jsonschema` runtime dependency is added.

The receipt binds the archive, workspace manifest, lockfile, archive options, selected environment names/prefixes, and normalized lockfile package records. Verification rejects ambiguous receipts, checks the archive digest before extraction, verifies extracted files after staging, compares package inventory, and only installs/moves forward after the staged tree passes.

## Validation

- `pixi run -e test pytest`
- `pixi run -e test test-cov`
- `pixi run ruff check`
- `pixi run typecheck`
- `pixi run -e docs docs`
- `pixi run -e test python -m json.tool schema/workspace-archive-receipt-1.schema.json >/dev/null && git diff --check`
- `pixi run ruff format --check docs/conf.py conda_workspaces/receipts.py conda_workspaces/archive.py conda_workspaces/cli/main.py conda_workspaces/cli/workspace/archive.py tests/test_receipts.py tests/test_archive.py tests/cli/workspace/test_archive.py tests/cli/test_main.py`

`pixi run ruff format --check` for the whole working tree currently reports only the unrelated untracked local file `demos/generate-voiceover.py`; that file is not part of this PR.