### PR TITLE
Resolve target dependencies per platform during lock

### DIFF
--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -134,7 +134,7 @@ def execute_archive(
             style="bold blue",
             ellipsis=True,
         )
-        generate_lockfile(ctx, resolved_envs)
+        generate_lockfile(ctx, resolved_envs, config=config)
         status.message(console, "Updated", "lockfile", "conda.lock")
 
     cli_excludes = tuple(args.exclude or [])

--- a/conda_workspaces/cli/workspace/lock.py
+++ b/conda_workspaces/cli/workspace/lock.py
@@ -117,6 +117,7 @@ def execute_lock(args: argparse.Namespace, *, console: Console | None = None) ->
     generate_lockfile(
         ctx,
         resolved_envs,
+        config=config,
         platforms=platforms,
         progress=_progress,
         skip_unsolvable=skip_unsolvable,

--- a/conda_workspaces/cli/workspace/sync.py
+++ b/conda_workspaces/cli/workspace/sync.py
@@ -114,5 +114,5 @@ def sync_environments(
         console.print(
             "[bold blue]Updating[/bold blue] [bold]conda.lock[/bold][dim]...[/dim]"
         )
-        generate_lockfile(ctx, resolved_all)
+        generate_lockfile(ctx, resolved_all, config=config)
         console.print("[bold cyan]Updated[/bold cyan] [bold]conda.lock[/bold]")

--- a/conda_workspaces/lockfile.py
+++ b/conda_workspaces/lockfile.py
@@ -411,6 +411,7 @@ def generate_lockfile(
     ctx: WorkspaceContext,
     resolved_envs: dict[str, ResolvedEnvironment],
     *,
+    config: WorkspaceConfig | None = None,
     platforms: tuple[str, ...] | None = None,
     progress: Callable[[str, str], None] | None = None,
     skip_unsolvable: bool = False,
@@ -421,13 +422,16 @@ def generate_lockfile(
 
     Solves each environment in *resolved_envs* for every platform it
     declares (intersected with *platforms* when given) and writes the
-    results to ``<workspace>/conda.lock``.  Serialisation is delegated
-    to :func:`.export.multiplatform_export` so this function and
-    ``conda export --format=conda-workspaces-lock-v1`` produce
-    byte-identical output.  Solver chatter is silenced inside
-    :meth:`ResolvedEnvironment.solve_for_platform` itself, so the
-    caller is free to render status through the optional *progress*
-    callback without stdout bookkeeping.
+    results to ``<workspace>/conda.lock``.  When *config* is supplied,
+    each ``(environment, platform)`` pair is resolved from the manifest
+    just before solving so target-specific dependency tables only apply
+    to the platform they declare.  Serialisation is delegated to
+    :func:`.export.multiplatform_export` so this function and ``conda
+    export --format=conda-workspaces-lock-v1`` produce byte-identical
+    output.  Solver chatter is silenced inside
+    :meth:`ResolvedEnvironment.solve_for_platform` itself, so the caller
+    is free to render status through the optional *progress* callback
+    without stdout bookkeeping.
 
     Fails fast by default: the first unsolvable ``(environment,
     platform)`` pair raises :class:`SolveError` with the platform
@@ -449,6 +453,7 @@ def generate_lockfile(
     from conda.models.environment import Environment, EnvironmentConfig
 
     from .export import multiplatform_export
+    from .resolver import resolve_environment
 
     host_platform = ctx.platform
     envs: list[Environment] = []
@@ -462,13 +467,18 @@ def generate_lockfile(
         targets = sorted(declared if platforms is None else declared & set(platforms))
         if not targets:
             continue
-        channels = tuple(str(ch) for ch in resolved.channels)
         for target in targets:
             if progress is not None:
                 progress(name, target)
+            target_resolved = (
+                resolve_environment(config, name, target)
+                if config is not None
+                else resolved
+            )
+            channels = tuple(str(ch) for ch in target_resolved.channels)
             try:
-                records = resolved.solve_for_platform(
-                    target, prefix=ctx.env_prefix(resolved.name)
+                records = target_resolved.solve_for_platform(
+                    target, prefix=ctx.env_prefix(target_resolved.name)
                 )
             except SolveError as exc:
                 if not skip_unsolvable:

--- a/conda_workspaces/resolver.py
+++ b/conda_workspaces/resolver.py
@@ -274,24 +274,11 @@ def resolve_environment(
     and platform support is validated.
     """
     env = config.get_environment(env_name)
-
-    # Validate platform if provided
-    if platform and config.platforms and platform not in config.platforms:
-        raise PlatformError(platform, config.platforms)
-
-    resolved = ResolvedEnvironment(
-        name=env_name,
-        channel_priority=config.channel_priority,
-    )
-
-    # Merge dependencies
-    resolved.conda_dependencies = config.merged_conda_dependencies(env, platform)
-    resolved.pypi_dependencies = config.merged_pypi_dependencies(env, platform)
-    resolved.channels = config.merged_channels(env)
-
-    # Merge platforms: intersect feature platforms with workspace platforms
-    feature_platforms: set[str] = set()
     features = config.resolve_features(env)
+
+    # Merge platforms: intersect feature-declared platform sets, falling back
+    # to workspace-level platforms when no feature narrows or broadens support.
+    feature_platforms: set[str] = set()
     for feat in features:
         if feat.platforms:
             if not feature_platforms:
@@ -299,8 +286,9 @@ def resolve_environment(
             else:
                 feature_platforms &= set(feat.platforms)
 
+    resolved_platforms: list[str]
     if feature_platforms:
-        resolved.platforms = sorted(feature_platforms)
+        resolved_platforms = sorted(feature_platforms)
     else:
         if any(f.platforms for f in features):
             log.warning(
@@ -308,7 +296,21 @@ def resolve_environment(
                 "falling back to workspace platforms",
                 env_name,
             )
-        resolved.platforms = list(config.platforms)
+        resolved_platforms = list(config.platforms)
+
+    if platform and resolved_platforms and platform not in resolved_platforms:
+        raise PlatformError(platform, resolved_platforms)
+
+    resolved = ResolvedEnvironment(
+        name=env_name,
+        channel_priority=config.channel_priority,
+        platforms=resolved_platforms,
+    )
+
+    # Merge dependencies
+    resolved.conda_dependencies = config.merged_conda_dependencies(env, platform)
+    resolved.pypi_dependencies = config.merged_pypi_dependencies(env, platform)
+    resolved.channels = config.merged_channels(env)
 
     # Merge activation and system requirements
     for feat in features:

--- a/tests/cli/workspace/test_install.py
+++ b/tests/cli/workspace/test_install.py
@@ -31,7 +31,7 @@ def _stub_lockfile(monkeypatch: pytest.MonkeyPatch) -> None:
     """Stub generate_lockfile to a no-op for tests that don't care about it."""
     monkeypatch.setattr(
         "conda_workspaces.cli.workspace.sync.generate_lockfile",
-        lambda ctx, resolved_envs: None,
+        lambda ctx, resolved_envs, **kwargs: None,
     )
 
 
@@ -66,7 +66,7 @@ def test_install_envs(
     lock_calls: list[dict] = []
     monkeypatch.setattr(
         "conda_workspaces.cli.workspace.sync.generate_lockfile",
-        lambda ctx, resolved_envs: lock_calls.append(resolved_envs),
+        lambda ctx, resolved_envs, **kwargs: lock_calls.append(resolved_envs),
     )
 
     args = make_args(_DEFAULTS, environment=env_arg)
@@ -131,7 +131,7 @@ def test_install_dry_run_skips_lockfile(
     lock_calls: list[dict] = []
     monkeypatch.setattr(
         "conda_workspaces.cli.workspace.sync.generate_lockfile",
-        lambda ctx, resolved_envs: lock_calls.append(resolved_envs),
+        lambda ctx, resolved_envs, **kwargs: lock_calls.append(resolved_envs),
     )
 
     args = make_args(_DEFAULTS, environment="default", dry_run=True)
@@ -214,7 +214,7 @@ def test_install_default_uses_lockfile_when_satisfiable(
     )
     monkeypatch.setattr(
         "conda_workspaces.cli.workspace.sync.generate_lockfile",
-        lambda ctx, resolved_envs: None,
+        lambda ctx, resolved_envs, **kwargs: None,
     )
 
     args = make_args(_DEFAULTS)
@@ -252,7 +252,7 @@ def test_install_default_solves_when_not_satisfiable(
     )
     monkeypatch.setattr(
         "conda_workspaces.cli.workspace.sync.generate_lockfile",
-        lambda ctx, resolved_envs: None,
+        lambda ctx, resolved_envs, **kwargs: None,
     )
 
     args = make_args(_DEFAULTS)
@@ -276,7 +276,7 @@ def test_install_no_lock_forces_solve(
     )
     monkeypatch.setattr(
         "conda_workspaces.cli.workspace.sync.generate_lockfile",
-        lambda ctx, resolved_envs: None,
+        lambda ctx, resolved_envs, **kwargs: None,
     )
 
     args = make_args(_DEFAULTS, no_lock=True)

--- a/tests/cli/workspace/test_lock.py
+++ b/tests/cli/workspace/test_lock.py
@@ -37,6 +37,7 @@ def capture_generate_lockfile(monkeypatch: pytest.MonkeyPatch, pixi_workspace: P
         ctx,
         resolved_envs,
         *,
+        config=None,
         platforms=None,
         progress=None,
         skip_unsolvable=False,
@@ -46,6 +47,7 @@ def capture_generate_lockfile(monkeypatch: pytest.MonkeyPatch, pixi_workspace: P
         calls.append(
             {
                 "resolved_envs": resolved_envs,
+                "config": config,
                 "platforms": platforms,
                 "progress": progress,
                 "skip_unsolvable": skip_unsolvable,
@@ -84,6 +86,7 @@ def test_lock_envs(
     assert result == 0
     assert len(capture_generate_lockfile) == 1
     assert set(capture_generate_lockfile[0]["resolved_envs"].keys()) == expected_keys
+    assert capture_generate_lockfile[0]["config"] is not None
     assert capture_generate_lockfile[0]["platforms"] is None
     assert output_fragment in capsys.readouterr().out
 

--- a/tests/cli/workspace/test_sync.py
+++ b/tests/cli/workspace/test_sync.py
@@ -193,7 +193,7 @@ def test_sync_activate_d_hint_respects_conda_spawn(
     )
     monkeypatch.setattr(
         "conda_workspaces.cli.workspace.sync.generate_lockfile",
-        lambda ctx, resolved_envs: None,
+        lambda ctx, resolved_envs, **kwargs: None,
     )
     monkeypatch.setattr(
         "conda_workspaces.cli.workspace.sync.install_environment", fake_install

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -68,7 +68,7 @@ def test_workspace_install_dry_run(
     )
     monkeypatch.setattr(
         "conda_workspaces.cli.workspace.sync.generate_lockfile",
-        lambda ctx, envs: None,
+        lambda ctx, envs, **kwargs: None,
     )
 
     stdout, stderr, exit_code = conda_cli("workspace", "install", "--dry-run")
@@ -249,7 +249,7 @@ def test_rich_output_contains_status(
         )
         monkeypatch.setattr(
             "conda_workspaces.cli.workspace.sync.generate_lockfile",
-            lambda ctx, envs: None,
+            lambda ctx, envs, **kwargs: None,
         )
 
         stdout, _, _ = conda_cli("workspace", "install", "--dry-run")
@@ -322,7 +322,7 @@ def test_workspace_install_resolves_pypi_deps(
     )
     monkeypatch.setattr(
         "conda_workspaces.cli.workspace.sync.generate_lockfile",
-        lambda ctx, envs: None,
+        lambda ctx, envs, **kwargs: None,
     )
 
     stdout, stderr, exit_code = conda_cli("workspace", "install", "--dry-run")
@@ -388,7 +388,7 @@ def test_workspace_install_resolves_editable_deps(
     )
     monkeypatch.setattr(
         "conda_workspaces.cli.workspace.sync.generate_lockfile",
-        lambda ctx, envs: None,
+        lambda ctx, envs, **kwargs: None,
     )
 
     stdout, stderr, exit_code = conda_cli("workspace", "install", "--dry-run")

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -41,7 +41,7 @@ from conda_workspaces.models import (
     LockfileStatus,
     WorkspaceConfig,
 )
-from conda_workspaces.resolver import ResolvedEnvironment
+from conda_workspaces.resolver import ResolvedEnvironment, resolve_environment
 
 
 @pytest.fixture
@@ -404,6 +404,116 @@ def test_generate_lockfile_solves_expected_pairs(
     assert f"version: {LOCKFILE_VERSION}" in content
     for env_name, platform in expected_pairs:
         assert f"python-{env_name}-{platform}.conda" in content
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected_extra", "forbidden"),
+    [
+        pytest.param(
+            "linux-64",
+            frozenset(),
+            frozenset(
+                {
+                    "python.app",
+                    "anaconda_prompt",
+                    "anaconda_powershell_prompt",
+                }
+            ),
+            id="linux-64",
+        ),
+        pytest.param(
+            "linux-aarch64",
+            frozenset(),
+            frozenset(
+                {
+                    "python.app",
+                    "anaconda_prompt",
+                    "anaconda_powershell_prompt",
+                }
+            ),
+            id="linux-aarch64",
+        ),
+        pytest.param(
+            "osx-arm64",
+            frozenset({"python.app"}),
+            frozenset({"anaconda_prompt", "anaconda_powershell_prompt"}),
+            id="osx-arm64",
+        ),
+        pytest.param(
+            "win-64",
+            frozenset({"anaconda_prompt", "anaconda_powershell_prompt"}),
+            frozenset({"python.app"}),
+            id="win-64",
+        ),
+    ],
+)
+def test_generate_lockfile_resolves_target_dependencies_per_platform(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    platform: str,
+    expected_extra: frozenset[str],
+    forbidden: frozenset[str],
+) -> None:
+    """Target dependency tables are scoped to their matching platform."""
+    config = WorkspaceConfig(
+        name="target-dep-repro",
+        channels=[
+            Channel("https://repo.anaconda.com/pkgs/main"),
+            Channel("https://repo.anaconda.com/pkgs/msys2"),
+        ],
+        platforms=["linux-64", "linux-aarch64", "osx-arm64", "win-64"],
+        features={
+            "default": Feature(
+                name="default",
+                conda_dependencies={
+                    "python": MatchSpec("python=3.13"),
+                    "conda": MatchSpec("conda==26.5.2"),
+                    "menuinst": MatchSpec("menuinst"),
+                },
+                target_conda_dependencies={
+                    "osx-arm64": {"python.app": MatchSpec("python.app")},
+                    "win-64": {
+                        "anaconda_prompt": MatchSpec("anaconda_prompt"),
+                        "anaconda_powershell_prompt": MatchSpec(
+                            "anaconda_powershell_prompt"
+                        ),
+                    },
+                },
+            )
+        },
+        environments={"default": Environment(name="default")},
+        root=str(tmp_path),
+        manifest_path=str(tmp_path / "conda.toml"),
+    )
+    ctx = WorkspaceContext(config)
+    ctx._cache["platform"] = "osx-arm64"
+    resolved_envs = {
+        "default": resolve_environment(config, "default", platform=ctx.platform)
+    }
+    observed_deps: dict[str, set[str]] = {}
+
+    def fake_solve(self, platform, *, prefix):
+        observed_deps[platform] = set(self.conda_dependencies)
+        return [
+            _FakePkg(name, f"https://example.com/{name}-{platform}.conda")
+            for name in sorted(self.conda_dependencies)
+        ]
+
+    monkeypatch.setattr(ResolvedEnvironment, "solve_for_platform", fake_solve)
+
+    result = generate_lockfile(ctx, resolved_envs, config=config)
+
+    common = {"conda", "menuinst", "python"}
+    assert observed_deps[platform] == common | expected_extra
+
+    data = load_yaml(result)
+    package_refs = data["environments"]["default"]["packages"][platform]
+    locked_names = {
+        ref["conda"].rpartition("/")[2].removesuffix(f"-{platform}.conda")
+        for ref in package_refs
+    }
+    assert expected_extra <= locked_names
+    assert not forbidden & locked_names
 
 
 def test_generate_lockfile_progress_callback(


### PR DESCRIPTION
## Summary
- Resolve workspace environments again for each lock target platform so `[target.<platform>.dependencies]` only applies to that platform's solve.
- Thread the workspace config into lockfile generation from lock, sync, and archive flows.
- Add a parameterized regression test covering Linux, macOS, and Windows target-only dependencies.

## Root cause
- `conda workspace lock` resolved each environment once for the host platform, then reused that dependency map for every platform in the lock loop.

## Validation
- `pixi run -e test pytest`
- `pixi run ruff check`
- `pixi run ruff format --check conda_workspaces tests`

Fixes #86