### PR TITLE
Support Pixi rich platform system requirements

### DIFF
--- a/conda_workspaces/importers/serialize.py
+++ b/conda_workspaces/importers/serialize.py
@@ -33,7 +33,7 @@ def config_to_toml(
     if config.channels:
         ws.add("channels", [ch.canonical_name for ch in config.channels])
     if config.platforms:
-        ws.add("platforms", list(config.platforms))
+        ws.add("platforms", config.platforms_for_toml())
     if config.channel_priority:
         ws.add("channel-priority", config.channel_priority)
     doc.add("workspace", ws)
@@ -68,7 +68,7 @@ def config_to_toml(
         )
 
     if default_feature and default_feature.target_conda_dependencies:
-        _add_target_deps(doc, default_feature)
+        _add_target_overrides(doc, default_feature)
 
     for feat_name, feature in config.features.items():
         if feature.is_default:
@@ -140,28 +140,30 @@ def _add_feature(doc: tomlkit.TOMLDocument, feature: Feature) -> None:
 
     if feature.target_conda_dependencies:
         target_tbl = tomlkit.table(is_super_table=True)
-        for platform, platform_deps in feature.target_conda_dependencies.items():
+        for platform in sorted(feature.target_conda_dependencies):
             plat_tbl = tomlkit.table()
-            plat_deps: dict[str, str] = {}
-            for name, ms in platform_deps.items():
-                plat_deps[name] = str(ms.version) if ms.version else "*"
-            plat_tbl.add("dependencies", plat_deps)
+            if platform_deps := feature.target_conda_dependencies.get(platform):
+                plat_deps: dict[str, str] = {}
+                for name, ms in platform_deps.items():
+                    plat_deps[name] = str(ms.version) if ms.version else "*"
+                plat_tbl.add("dependencies", plat_deps)
             target_tbl.add(platform, plat_tbl)
         feat_tbl.add("target", target_tbl)
 
     feat_container.add(feature.name, feat_tbl)
 
 
-def _add_target_deps(doc: tomlkit.TOMLDocument, feature: Feature) -> None:
-    """Add ``[target.<platform>.dependencies]`` for the default feature."""
+def _add_target_overrides(doc: tomlkit.TOMLDocument, feature: Feature) -> None:
+    """Add ``[target.<platform>.*]`` overrides for the default feature."""
     if "target" not in doc:
         doc.add("target", tomlkit.table(is_super_table=True))
     target = cast("Table", doc["target"])
 
-    for platform, platform_deps in feature.target_conda_dependencies.items():
+    for platform in sorted(feature.target_conda_dependencies):
         plat_tbl = tomlkit.table()
-        plat_deps: dict[str, str] = {}
-        for name, ms in platform_deps.items():
-            plat_deps[name] = str(ms.version) if ms.version else "*"
-        plat_tbl.add("dependencies", plat_deps)
+        if platform_deps := feature.target_conda_dependencies.get(platform):
+            plat_deps: dict[str, str] = {}
+            for name, ms in platform_deps.items():
+                plat_deps[name] = str(ms.version) if ms.version else "*"
+            plat_tbl.add("dependencies", plat_deps)
         target.add(platform, plat_tbl)

--- a/conda_workspaces/manifests/base.py
+++ b/conda_workspaces/manifests/base.py
@@ -11,12 +11,12 @@ from typing import TYPE_CHECKING
 import tomlkit
 from packaging.requirements import InvalidRequirement, Requirement
 
-from ..exceptions import ManifestExistsError
+from ..exceptions import ManifestExistsError, WorkspaceParseError
 
 _PYPI_NAME_TAIL_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)(.*)$")
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Mapping
     from pathlib import Path
     from typing import Any, ClassVar
 
@@ -51,6 +51,22 @@ class ManifestParser(ABC):
     #: Optional user-friendly aliases for the exporter plugin (e.g.
     #: ``("conda",)`` for ``conda-toml``).  Empty tuple is fine.
     exporter_aliases: ClassVar[tuple[str, ...]] = ()
+    rich_platform_system_requirement_keys: ClassVar[set[str]] = {
+        "archspec",
+        "cuda",
+        "glibc",
+        "libc",
+        "linux",
+        "macos",
+        "osx",
+        "win",
+        "windows",
+    }
+    system_requirement_aliases: ClassVar[dict[str, str]] = {
+        "libc": "glibc",
+        "macos": "osx",
+        "windows": "win",
+    }
 
     @staticmethod
     @lru_cache(maxsize=16)
@@ -191,6 +207,93 @@ class ManifestParser(ABC):
         export still writes the exporter output verbatim.
         """
         return exported
+
+    def parse_system_requirements(
+        self,
+        requirements: Mapping[str, Any],
+    ) -> dict[str, str]:
+        """Parse Pixi-facing system requirements into conda virtual names.
+
+        Pixi exposes TOML names like ``libc`` / ``macos`` / ``windows``;
+        conda virtual packages use ``__glibc`` / ``__osx`` / ``__win``.
+        The workspace model stores bare conda names while preserving raw
+        ``__name`` escape hatches for callers that already use virtual
+        package names.
+        """
+        parsed: dict[str, str] = {}
+        for raw_name, raw_value in requirements.items():
+            name = str(raw_name)
+            prefixed = name.startswith("__")
+            bare_name = name[2:] if prefixed else name
+
+            if bare_name == "libc" and isinstance(raw_value, dict):
+                family = str(raw_value.get("family", "glibc"))
+                version = raw_value.get("version")
+                bare_name = self.system_requirement_aliases.get(family, family)
+                raw_value = "" if version is None else version
+            else:
+                bare_name = self.system_requirement_aliases.get(bare_name, bare_name)
+
+            parsed[f"__{bare_name}" if prefixed else bare_name] = str(raw_value)
+        return parsed
+
+    def parse_workspace_platforms(
+        self,
+        raw: Iterable[Any],
+        path: Path,
+    ) -> tuple[list[str], dict[str, dict[str, str]]]:
+        """Parse Pixi-compatible workspace platform entries.
+
+        Bare strings remain plain conda subdirs.  Inline tables can add
+        virtual package requirements to that subdir, e.g.
+        ``{ platform = "linux-64", libc = "2.28" }``.  Pixi also
+        supports custom rich-platform names; conda-workspaces still
+        stores lockfile entries by conda subdir, so custom names are
+        rejected instead of being silently discarded.
+        """
+        platforms: list[str] = []
+        platform_system_requirements: dict[str, dict[str, str]] = {}
+
+        for item in raw:
+            if isinstance(item, str):
+                platforms.append(item)
+                continue
+            if not isinstance(item, dict):
+                raise WorkspaceParseError(
+                    path,
+                    "[workspace].platforms entries must be strings or inline tables",
+                )
+
+            subdir = item.get("platform") or item.get("name")
+            if not subdir:
+                raise WorkspaceParseError(
+                    path,
+                    "Rich platform entries must set `platform` or `name`.",
+                )
+            platform = str(subdir)
+
+            name = item.get("name")
+            if name is not None and "platform" in item and str(name) != platform:
+                raise WorkspaceParseError(
+                    path,
+                    "Custom rich platform names are not supported yet; "
+                    "omit `name` or set it equal to `platform`.",
+                )
+
+            platforms.append(platform)
+
+            requirements = {
+                key: value
+                for key, value in item.items()
+                if key in self.rich_platform_system_requirement_keys
+                or str(key).startswith("__")
+            }
+            if requirements:
+                platform_system_requirements[platform] = self.parse_system_requirements(
+                    requirements
+                )
+
+        return platforms, platform_system_requirements
 
     @classmethod
     def for_exporter_format(cls, name: str) -> ManifestParser | None:

--- a/conda_workspaces/manifests/pixi_toml.py
+++ b/conda_workspaces/manifests/pixi_toml.py
@@ -15,7 +15,11 @@ from ..exceptions import TaskNotFoundError, TaskParseError, WorkspaceParseError
 from ..models import WorkspaceConfig
 from .base import ManifestParser
 from .normalize import parse_feature_tasks, parse_tasks_and_targets
-from .toml import parse_archive_config, parse_channels, parse_features_and_envs
+from .toml import (
+    parse_archive_config,
+    parse_channels,
+    parse_features_and_envs,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -57,19 +61,25 @@ class PixiTomlParser(ManifestParser):
         if not ws:
             raise WorkspaceParseError(path, "No [workspace] or [project] table found")
 
+        platforms, platform_system_requirements = self.parse_workspace_platforms(
+            ws.get("platforms", []),
+            path,
+        )
+
         config = WorkspaceConfig(
             name=ws.get("name"),
             version=ws.get("version"),
             description=ws.get("description"),
             channels=parse_channels(ws.get("channels", [])),
-            platforms=list(ws.get("platforms", [])),
+            platforms=platforms,
+            platform_system_requirements=platform_system_requirements,
             root=root,
             manifest_path=str(path),
             channel_priority=ws.get("channel-priority"),
             archive=parse_archive_config(ws),
         )
 
-        parse_features_and_envs(data, config, path)
+        parse_features_and_envs(data, config, path, self)
         return config
 
     def has_tasks(self, path: Path) -> bool:

--- a/conda_workspaces/manifests/pyproject_toml.py
+++ b/conda_workspaces/manifests/pyproject_toml.py
@@ -22,7 +22,11 @@ from ..exceptions import (
 from ..models import WorkspaceConfig
 from .base import ManifestParser
 from .normalize import parse_feature_tasks, parse_tasks_and_targets
-from .toml import parse_archive_config, parse_channels, parse_features_and_envs
+from .toml import (
+    parse_archive_config,
+    parse_channels,
+    parse_features_and_envs,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -176,19 +180,25 @@ class PyprojectTomlParser(ManifestParser):
 
         ws = source.get("workspace", {})
 
+        platforms, platform_system_requirements = self.parse_workspace_platforms(
+            ws.get("platforms", []),
+            path,
+        )
+
         config = WorkspaceConfig(
             name=ws.get("name") or data.get("project", {}).get("name"),
             version=ws.get("version") or data.get("project", {}).get("version"),
             description=data.get("project", {}).get("description"),
             channels=parse_channels(ws.get("channels", [])),
-            platforms=list(ws.get("platforms", [])),
+            platforms=platforms,
+            platform_system_requirements=platform_system_requirements,
             root=root,
             manifest_path=str(path),
             channel_priority=ws.get("channel-priority"),
             archive=parse_archive_config(ws),
         )
 
-        parse_features_and_envs(source, config, path)
+        parse_features_and_envs(source, config, path, self)
         return config
 
     def has_tasks(self, path: Path) -> bool:

--- a/conda_workspaces/manifests/toml.py
+++ b/conda_workspaces/manifests/toml.py
@@ -411,6 +411,13 @@ def parse_target_overrides(
     """Parse ``[target.<platform>]`` dep overrides into a feature."""
     resolver = resolver or WorkspaceDependencyResolver()
     for platform, tdata in target_data.items():
+        if "system-requirements" in tdata:
+            resolver.error(
+                f"[target.{platform}.system-requirements] is not supported; "
+                "use rich [workspace].platforms entries or "
+                "[feature.<name>.system-requirements]."
+            )
+
         conda = resolver.parse_dependency_table(
             tdata.get("dependencies", {}),
             table_name=f"[target.{platform}.dependencies]",
@@ -426,6 +433,7 @@ def parse_target_overrides(
 def parse_feature(
     name: str,
     feat_data: dict[str, Any],
+    parser: ManifestParser,
     resolver: WorkspaceDependencyResolver | None = None,
 ) -> Feature:
     """Parse a single ``[feature.<name>]`` table into a Feature.
@@ -452,7 +460,7 @@ def parse_feature(
 
     sysreq = feat_data.get("system-requirements", {})
     if sysreq:
-        feature.system_requirements = {k: str(v) for k, v in sysreq.items()}
+        feature.system_requirements = parser.parse_system_requirements(sysreq)
 
     activation = feat_data.get("activation", {})
     if activation:
@@ -467,6 +475,7 @@ def parse_features_and_envs(
     source: dict[str, Any],
     config: WorkspaceConfig,
     path: Path,
+    parser: ManifestParser,
 ) -> None:
     """Parse features and environments from *source* into *config*.
 
@@ -482,11 +491,17 @@ def parse_features_and_envs(
     config.features[Feature.DEFAULT_NAME] = parse_feature(
         Feature.DEFAULT_NAME,
         source,
+        parser,
         resolver,
     )
 
     for feat_name, feat_data in source.get("feature", {}).items():
-        config.features[feat_name] = parse_feature(feat_name, feat_data, resolver)
+        config.features[feat_name] = parse_feature(
+            feat_name,
+            feat_data,
+            parser,
+            resolver,
+        )
 
     envs_data = source.get("environments", {})
     if envs_data:

--- a/conda_workspaces/models.py
+++ b/conda_workspaces/models.py
@@ -163,6 +163,9 @@ class WorkspaceConfig:
 
     channels: list[Channel] = field(default_factory=list)
     platforms: list[str] = field(default_factory=list)
+    platform_system_requirements: dict[str, dict[str, str]] = field(
+        default_factory=dict
+    )
 
     # Root-level dependency pool from [workspace.dependencies].
     # Concrete feature dependencies may opt in with { workspace = true }.
@@ -261,6 +264,42 @@ class WorkspaceConfig:
             if platform and platform in feature.target_pypi_dependencies:
                 merged.update(feature.target_pypi_dependencies[platform])
         return merged
+
+    def merged_system_requirements(
+        self,
+        environment: Environment,
+        platform: str | None = None,
+    ) -> dict[str, str]:
+        """Merge system requirements across features for *environment*."""
+        merged: dict[str, str] = {}
+        for feature in self.resolve_features(environment):
+            merged.update(feature.system_requirements)
+        if platform and platform in self.platform_system_requirements:
+            merged.update(self.platform_system_requirements[platform])
+        return merged
+
+    def platforms_for_toml(self) -> list[str | dict[str, str]]:
+        """Return platforms in a TOML shape compatible with Pixi."""
+        aliases = {
+            "glibc": "libc",
+            "__glibc": "__glibc",
+            "osx": "macos",
+            "__osx": "__osx",
+            "win": "windows",
+            "__win": "__win",
+        }
+        result: list[str | dict[str, str]] = []
+        for platform in self.platforms:
+            requirements = self.platform_system_requirements.get(platform)
+            if not requirements:
+                result.append(platform)
+                continue
+            entry = {"platform": platform}
+            entry.update(
+                {aliases.get(name, name): value for name, value in requirements.items()}
+            )
+            result.append(entry)
+        return result
 
     def merged_channels(self, environment: Environment) -> list[Channel]:
         """Merge channels across features for *environment*.

--- a/conda_workspaces/resolver.py
+++ b/conda_workspaces/resolver.py
@@ -46,6 +46,21 @@ class ResolvedEnvironment:
     system_requirements: dict[str, str] = field(default_factory=dict)
     channel_priority: str | None = None
 
+    def system_requirement_version(self, name: str) -> str | None:
+        """Look up a system requirement by conda or Pixi-facing virtual name."""
+        aliases = {
+            "glibc": ("glibc", "libc"),
+            "osx": ("osx", "macos"),
+            "win": ("win", "windows"),
+        }
+        for candidate in aliases.get(name, (name,)):
+            version = self.system_requirements.get(
+                candidate
+            ) or self.system_requirements.get(f"__{candidate}")
+            if version:
+                return version
+        return None
+
     def virtual_package_overrides(self, platform: str) -> dict[str, str]:
         """Return ``CONDA_OVERRIDE_*`` env vars that enable a cross-platform solve.
 
@@ -87,20 +102,20 @@ class ResolvedEnvironment:
         if not target_family or family(conda_context.subdir) == target_family:
             return {}
 
-        def req_version(name: str) -> str | None:
-            """Look up a ``[system-requirements]`` entry by bare or ``__`` name."""
-            return self.system_requirements.get(name) or self.system_requirements.get(
-                f"__{name}"
-            )
-
         baseline: dict[str, str] = {}
         if target_family == "linux":
-            baseline["CONDA_OVERRIDE_GLIBC"] = req_version("glibc") or "2.17"
+            baseline["CONDA_OVERRIDE_GLIBC"] = (
+                self.system_requirement_version("glibc") or "2.17"
+            )
         elif target_family == "osx":
             default = "11.0" if platform == "osx-arm64" else "10.15"
-            baseline["CONDA_OVERRIDE_OSX"] = req_version("osx") or default
+            baseline["CONDA_OVERRIDE_OSX"] = (
+                self.system_requirement_version("osx") or default
+            )
         elif target_family == "win":
-            baseline["CONDA_OVERRIDE_WIN"] = req_version("win") or "0"
+            baseline["CONDA_OVERRIDE_WIN"] = (
+                self.system_requirement_version("win") or "0"
+            )
 
         return {k: v for k, v in baseline.items() if k not in os.environ}
 
@@ -311,12 +326,12 @@ def resolve_environment(
     resolved.conda_dependencies = config.merged_conda_dependencies(env, platform)
     resolved.pypi_dependencies = config.merged_pypi_dependencies(env, platform)
     resolved.channels = config.merged_channels(env)
+    resolved.system_requirements = config.merged_system_requirements(env, platform)
 
-    # Merge activation and system requirements
+    # Merge activation settings
     for feat in features:
         resolved.activation_scripts.extend(feat.activation_scripts)
         resolved.activation_env.update(feat.activation_env)
-        resolved.system_requirements.update(feat.system_requirements)
 
     return resolved
 

--- a/tests/cli/workspace/test_import.py
+++ b/tests/cli/workspace/test_import.py
@@ -153,6 +153,57 @@ def test_import_manifest_produces_workspace(
     assert "channels" in doc["workspace"]
 
 
+@pytest.mark.parametrize(
+    ("filename", "content"),
+    [
+        pytest.param(
+            "pixi.toml",
+            """\
+[workspace]
+name = "rich-platform"
+channels = ["conda-forge"]
+platforms = [
+  "osx-arm64",
+  { platform = "linux-64", libc = "2.28" },
+]
+""",
+            id="pixi",
+        ),
+        pytest.param(
+            "pyproject.toml",
+            """\
+[project]
+name = "rich-platform"
+
+[tool.pixi.workspace]
+channels = ["conda-forge"]
+platforms = [
+  "osx-arm64",
+  { platform = "linux-64", libc = "2.28" },
+]
+""",
+            id="pyproject",
+        ),
+    ],
+)
+def test_import_rich_platform_system_requirements(
+    tmp_path: Path,
+    filename: str,
+    content: str,
+) -> None:
+    p = tmp_path / filename
+    p.write_text(
+        content,
+        encoding="utf-8",
+    )
+
+    doc = find_importer(p).convert(p)
+
+    platforms = doc["workspace"]["platforms"]
+    assert platforms[0] == "osx-arm64"
+    assert dict(platforms[1]) == {"platform": "linux-64", "libc": "2.28"}
+
+
 def test_import_conda_project(tmp_path: Path) -> None:
     (tmp_path / "conda-project.yml").write_text(_CONDA_PROJECT_YML, encoding="utf-8")
     (tmp_path / "environment.yml").write_text(_CONDA_PROJECT_ENV_YML, encoding="utf-8")

--- a/tests/manifests/test_pixi_toml.py
+++ b/tests/manifests/test_pixi_toml.py
@@ -138,6 +138,47 @@ gcc = ">=12"
     assert "gcc" in default.target_conda_dependencies["linux-64"]
 
 
+def test_parse_rich_platform_system_requirements(tmp_path):
+    content = """\
+[workspace]
+name = "rich-platform-sysreq-test"
+channels = ["conda-forge"]
+platforms = [
+  "osx-arm64",
+  { platform = "linux-64", libc = "2.28" },
+  { platform = "linux-aarch64", libc = "2.28" },
+]
+"""
+    path = tmp_path / "pixi.toml"
+    path.write_text(content, encoding="utf-8")
+
+    parser = PixiTomlParser()
+    config = parser.parse(path)
+    assert config.platforms == ["osx-arm64", "linux-64", "linux-aarch64"]
+    assert config.platform_system_requirements == {
+        "linux-64": {"glibc": "2.28"},
+        "linux-aarch64": {"glibc": "2.28"},
+    }
+
+
+def test_parse_target_system_requirements_rejected(tmp_path):
+    content = """\
+[workspace]
+name = "target-sysreq-test"
+channels = ["conda-forge"]
+platforms = ["linux-64", "linux-aarch64", "osx-arm64", "win-64"]
+
+[target.linux-64.system-requirements]
+libc = "2.28"
+"""
+    path = tmp_path / "pixi.toml"
+    path.write_text(content, encoding="utf-8")
+
+    parser = PixiTomlParser()
+    with pytest.raises(WorkspaceParseError, match="not supported"):
+        parser.parse(path)
+
+
 def test_parse_with_pypi_deps(tmp_path):
     content = """\
 [workspace]
@@ -228,12 +269,21 @@ platforms = ["linux-64"]
 [system-requirements]
 linux = "5.10"
 cuda = "12.0"
+libc = { family = "glibc", version = "2.28" }
+macos = "13.0"
+windows = "0"
 """
     path = tmp_path / "pixi.toml"
     path.write_text(content, encoding="utf-8")
     config = PixiTomlParser().parse(path)
     default = config.features["default"]
-    assert default.system_requirements == {"linux": "5.10", "cuda": "12.0"}
+    assert default.system_requirements == {
+        "linux": "5.10",
+        "cuda": "12.0",
+        "glibc": "2.28",
+        "osx": "13.0",
+        "win": "0",
+    }
 
 
 def test_parse_feature_system_requirements(tmp_path):

--- a/tests/manifests/test_pyproject_toml.py
+++ b/tests/manifests/test_pyproject_toml.py
@@ -266,3 +266,30 @@ cuda = "11.8"
     path.write_text(content, encoding="utf-8")
     config = parser.parse(path)
     assert config.features["gpu"].system_requirements == {"cuda": "11.8"}
+
+
+@pytest.mark.parametrize(
+    "tool_table",
+    [
+        pytest.param("tool.conda", id="tool-conda"),
+        pytest.param("tool.pixi", id="tool-pixi"),
+    ],
+)
+def test_parse_rich_platform_system_requirements(parser, tmp_path, tool_table):
+    """Pixi-style rich platform system requirements in pyproject.toml."""
+    content = f"""\
+[project]
+name = "rich-platform-sysreq"
+
+[{tool_table}.workspace]
+channels = ["conda-forge"]
+platforms = [
+  "osx-arm64",
+  {{ platform = "linux-64", libc = "2.28" }},
+]
+"""
+    path = tmp_path / "pyproject.toml"
+    path.write_text(content, encoding="utf-8")
+    config = parser.parse(path)
+    assert config.platforms == ["osx-arm64", "linux-64"]
+    assert config.platform_system_requirements == {"linux-64": {"glibc": "2.28"}}

--- a/tests/manifests/test_toml.py
+++ b/tests/manifests/test_toml.py
@@ -375,12 +375,22 @@ def test_parse_environment_no_default_feature(tmp_path):
 )
 def test_parse_target_overrides(platform, dep_key, attr, pkg):
     feature = Feature(name="default")
-    version = ">=12" if dep_key == "dependencies" else ">=2.0"
+    if dep_key == "dependencies":
+        version = ">=12"
+    else:
+        version = ">=2.0"
     target_data = {platform: {dep_key: {pkg: version}}}
     parse_target_overrides(target_data, feature)
     result = getattr(feature, attr)
     assert platform in result
     assert pkg in result[platform]
+
+
+def test_parse_target_system_requirements_rejected():
+    feature = Feature(name="default")
+    target_data = {"linux-64": {"system-requirements": {"libc": "2.28"}}}
+    with pytest.raises(ValueError, match="not supported"):
+        parse_target_overrides(target_data, feature)
 
 
 def test_parse_target_overrides_empty():

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -516,6 +516,60 @@ def test_generate_lockfile_resolves_target_dependencies_per_platform(
     assert not forbidden & locked_names
 
 
+@pytest.mark.parametrize(
+    ("platform", "expected_requirements"),
+    [
+        pytest.param("linux-64", {"glibc": "2.28"}, id="linux-64"),
+        pytest.param("linux-aarch64", {"glibc": "2.28"}, id="linux-aarch64"),
+        pytest.param("osx-arm64", {}, id="osx-arm64"),
+        pytest.param("win-64", {}, id="win-64"),
+    ],
+)
+def test_generate_lockfile_resolves_rich_platform_system_requirements(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    platform: str,
+    expected_requirements: dict[str, str],
+) -> None:
+    """Rich-platform requirements are scoped to their matching platform."""
+    config = WorkspaceConfig(
+        name="rich-platform-sysreq-repro",
+        channels=[Channel("conda-forge")],
+        platforms=["linux-64", "linux-aarch64", "osx-arm64", "win-64"],
+        platform_system_requirements={
+            "linux-64": {"glibc": "2.28"},
+            "linux-aarch64": {"glibc": "2.28"},
+        },
+        features={"default": Feature(name="default")},
+        environments={"default": Environment(name="default")},
+        root=str(tmp_path),
+        manifest_path=str(tmp_path / "conda.toml"),
+    )
+    ctx = WorkspaceContext(config)
+    ctx._cache["platform"] = "osx-arm64"
+    resolved_envs = {
+        "default": resolve_environment(config, "default", platform=ctx.platform)
+    }
+    observed_requirements: dict[str, dict[str, str]] = {}
+    observed_overrides: dict[str, dict[str, str]] = {}
+
+    def fake_solve(self, platform, *, prefix):
+        observed_requirements[platform] = dict(self.system_requirements)
+        observed_overrides[platform] = self.virtual_package_overrides(platform)
+        return [_FakePkg("python", f"https://example.com/python-{platform}.conda")]
+
+    monkeypatch.setattr(ResolvedEnvironment, "solve_for_platform", fake_solve)
+
+    with conda_context._override("_subdir", "osx-arm64"):
+        generate_lockfile(ctx, resolved_envs, config=config)
+
+    assert observed_requirements[platform] == expected_requirements
+    if platform.startswith("linux-"):
+        assert observed_overrides[platform]["CONDA_OVERRIDE_GLIBC"] == "2.28"
+    else:
+        assert "CONDA_OVERRIDE_GLIBC" not in observed_overrides[platform]
+
+
 def test_generate_lockfile_progress_callback(
     workspace_ctx_factory: Callable[..., WorkspaceContext],
     fake_solver_factory,
@@ -836,12 +890,14 @@ def test_virtual_package_overrides_respect_existing_env(
     [
         ({}, {"CONDA_OVERRIDE_GLIBC": "2.17"}),
         ({"glibc": "2.28"}, {"CONDA_OVERRIDE_GLIBC": "2.28"}),
+        ({"libc": "2.28"}, {"CONDA_OVERRIDE_GLIBC": "2.28"}),
         ({"__glibc": "2.34"}, {"CONDA_OVERRIDE_GLIBC": "2.34"}),
         ({"osx": "12.0"}, {"CONDA_OVERRIDE_GLIBC": "2.17"}),
     ],
     ids=[
         "default-baseline",
         "bare-name-wins",
+        "pixi-name-wins",
         "dunder-name-wins",
         "unrelated-requirement-ignored",
     ],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -240,6 +240,31 @@ def test_config_merged_pypi_deps_with_target():
     assert "uvloop" in merged
 
 
+@pytest.mark.parametrize(
+    ("platform", "expected"),
+    [
+        pytest.param("linux-64", {"cuda": "12.0", "glibc": "2.28"}, id="override"),
+        pytest.param("osx-arm64", {"cuda": "12.0", "glibc": "2.17"}, id="fallback"),
+    ],
+)
+def test_config_merged_system_requirements_with_platform(
+    platform: str,
+    expected: dict[str, str],
+) -> None:
+    default_feat = Feature(
+        name="default",
+        system_requirements={"cuda": "12.0", "glibc": "2.17"},
+    )
+    config = WorkspaceConfig(
+        platform_system_requirements={"linux-64": {"glibc": "2.28"}},
+        features={"default": default_feat},
+        environments={"default": Environment(name="default")},
+    )
+    env = config.environments["default"]
+
+    assert config.merged_system_requirements(env, platform=platform) == expected
+
+
 def test_config_merged_channels_feature_adds_new():
     default_feat = Feature(name="default")
     extra_feat = Feature(name="bio", channels=[Channel("bioconda")])

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -243,6 +243,40 @@ def test_resolve_system_requirements_merged():
 
 
 @pytest.mark.parametrize(
+    ("platform", "expected"),
+    [
+        pytest.param("linux-64", {"cuda": "12.0", "glibc": "2.28"}, id="linux"),
+        pytest.param("osx-arm64", {"cuda": "12.0", "osx": "13.0"}, id="osx"),
+        pytest.param("win-64", {"cuda": "12.0"}, id="win"),
+    ],
+)
+def test_resolve_system_requirements_with_rich_platform(
+    platform: str,
+    expected: dict[str, str],
+) -> None:
+    """Rich-platform requirements are merged only for their platform."""
+    default_feat = Feature(
+        name="default",
+        system_requirements={"cuda": "12.0"},
+    )
+    config = WorkspaceConfig(
+        channels=[Channel("conda-forge")],
+        platforms=["linux-64", "osx-arm64", "win-64"],
+        platform_system_requirements={
+            "linux-64": {"glibc": "2.28"},
+            "osx-arm64": {"osx": "13.0"},
+        },
+        features={"default": default_feat},
+        environments={
+            "default": Environment(name="default"),
+        },
+    )
+
+    resolved = resolve_environment(config, "default", platform=platform)
+    assert resolved.system_requirements == expected
+
+
+@pytest.mark.parametrize(
     "priority, expected",
     [
         ("strict", "strict"),


### PR DESCRIPTION
## Summary
- Add support for Pixi-style rich entries in `workspace.platforms`, including per-platform virtual package requirements such as `libc`, `macos`, and `windows`.
- Reject `[target.<platform>.system-requirements]` instead of adding a conda-workspaces-only extension.
- Preserve rich platform entries when importing Pixi and Pyproject manifests back to `conda.toml`.
- Keep parsing and virtual package lookup behavior on parser/resolved-environment methods instead of static model helpers.

## Why
Pixi has moved toward rich platform entries as the recommended manifest shape for platform-scoped system requirements. Keeping conda-workspaces aligned with that shape avoids adding a custom target-scoped system-requirements extension.

## Impact
Users can declare per-platform virtual packages in the Pixi-compatible `workspace.platforms` array and have those requirements flow through parsing, environment resolution, lockfile generation, virtual package overrides, and import serialization.

## Validation
- `pixi run -e test pytest`
- `pixi run ruff check`
- `pixi run ruff format --check conda_workspaces tests`

Note: repo-wide `pixi run ruff format --check` still reports unrelated untracked `demos/generate-voiceover.py` as needing formatting; this PR leaves it untouched.

Closes #87