### PR TITLE
Preserve manifest channels when merging lock fragments

### DIFF
--- a/conda_workspaces/lockfile.py
+++ b/conda_workspaces/lockfile.py
@@ -514,10 +514,14 @@ def merge_lockfiles(paths: Sequence[Path], ctx: WorkspaceContext) -> Path:
     conda.lock.<subdir>``), and a coordinator job stitches them back
     into a single ``<workspace>/conda.lock`` with this function.
 
-    Every fragment must be a ``version: 1`` lockfile.  Fragments that
-    declare the same environment must agree on its ``channels`` list
-    entry-for-entry and in the same order.  Two fragments may not both
-    carry entries for the same ``(environment, platform)`` pair —
+    Every fragment must be a ``version: 1`` lockfile.  When the current
+    workspace manifest declares the fragment environment, its channel
+    list is canonical: fragments may omit unused manifest channels, but
+    any channels they do declare must be an ordered subset of the
+    manifest's list.  Fragment environments not declared in the manifest
+    keep the stricter legacy rule and must agree on their ``channels``
+    list entry-for-entry and in the same order.  Two fragments may not
+    both carry entries for the same ``(environment, platform)`` pair —
     overlapping platforms indicate a misconfigured pipeline rather than
     a legitimate merge.  Any violation raises
     :class:`LockfileMergeError` and nothing is written.
@@ -550,6 +554,15 @@ def merge_lockfiles(paths: Sequence[Path], ctx: WorkspaceContext) -> Path:
     env_platforms: dict[str, dict[str, list[dict[str, str]]]] = {}
     seen_pairs: dict[tuple[str, str], Path] = {}
     packages_by_url: dict[str, dict[str, Any]] = {}
+    manifest_env_channels: dict[str, list[dict[str, str]]] = {}
+    manifest_env_channel_urls: dict[str, list[str]] = {}
+
+    for env_name, env_obj in ctx.config.environments.items():
+        entries = [{"url": str(ch)} for ch in ctx.config.merged_channels(env_obj)]
+        manifest_env_channels[env_name] = entries
+        manifest_env_channel_urls[env_name] = _normalize_channel_urls(
+            entry["url"] for entry in entries
+        )
 
     for path in paths:
         if not path.is_file():
@@ -569,6 +582,27 @@ def merge_lockfiles(paths: Sequence[Path], ctx: WorkspaceContext) -> Path:
 
         for env_name, env_data in (data.get("environments") or {}).items():
             channels = list(env_data.get("channels") or [])
+            manifest_channels = manifest_env_channels.get(env_name)
+            if manifest_channels is not None:
+                manifest_urls = manifest_env_channel_urls[env_name]
+                fragment_urls = _normalize_channel_urls(
+                    str(entry.get("url", "")) for entry in channels
+                )
+                next_index = 0
+                for url in fragment_urls:
+                    try:
+                        next_index = manifest_urls.index(url, next_index) + 1
+                    except ValueError as exc:
+                        raise LockfileMergeError(
+                            f"environment '{env_name}' channels differ between "
+                            f"fragment '{path}' and the manifest",
+                            hints=[
+                                "Every fragment channel list must be an ordered"
+                                " subset of the manifest channel list for a"
+                                " shared environment.",
+                            ],
+                        ) from exc
+                channels = list(manifest_channels)
             existing = env_channels.get(env_name)
             if existing is None:
                 env_order.append(env_name)

--- a/conda_workspaces/lockfile.py
+++ b/conda_workspaces/lockfile.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
     from conda.models.environment import Environment
 
     from .context import WorkspaceContext
+    from .models import Environment as WorkspaceEnvironment
     from .models import WorkspaceConfig
     from .resolver import ResolvedEnvironment
 
@@ -100,6 +101,29 @@ def lockfile_path(ctx: WorkspaceContext) -> Path:
 def _normalize_channel_urls(urls: Iterable[str]) -> list[str]:
     """Strip trailing slashes from channel URLs for comparison."""
     return [url.rstrip("/") for url in urls]
+
+
+def _manifest_channel_entries(
+    config: WorkspaceConfig,
+    environment: WorkspaceEnvironment,
+) -> list[dict[str, str]]:
+    """Return manifest channel entries without conda canonical-name deduplication."""
+    seen: set[str] = set()
+    entries: list[dict[str, str]] = []
+    for ch in config.channels:
+        url = str(ch)
+        normalized = url.rstrip("/")
+        if normalized not in seen:
+            seen.add(normalized)
+            entries.append({"url": url})
+    for feature in config.resolve_features(environment):
+        for ch in feature.channels:
+            url = str(ch)
+            normalized = url.rstrip("/")
+            if normalized not in seen:
+                seen.add(normalized)
+                entries.append({"url": url})
+    return entries
 
 
 def lockfile_status(
@@ -154,9 +178,9 @@ def check_lockfile_satisfiability(
 
         lock_env = lock_envs[env_name]
 
-        manifest_channels = config.merged_channels(env_obj)
+        manifest_channels = _manifest_channel_entries(config, env_obj)
         manifest_urls = _normalize_channel_urls(
-            ch.base_url for ch in manifest_channels if ch.base_url
+            entry["url"] for entry in manifest_channels
         )
         lock_channel_entries = lock_env.get("channels", [])
         lock_urls = _normalize_channel_urls(
@@ -558,7 +582,7 @@ def merge_lockfiles(paths: Sequence[Path], ctx: WorkspaceContext) -> Path:
     manifest_env_channel_urls: dict[str, list[str]] = {}
 
     for env_name, env_obj in ctx.config.environments.items():
-        entries = [{"url": str(ch)} for ch in ctx.config.merged_channels(env_obj)]
+        entries = _manifest_channel_entries(ctx.config, env_obj)
         manifest_env_channels[env_name] = entries
         manifest_env_channel_urls[env_name] = _normalize_channel_urls(
             entry["url"] for entry in entries

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import os
 from typing import TYPE_CHECKING
 
@@ -12,6 +13,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 from conda.base.context import context as conda_context
+from conda.common.serialize.yaml import dump as yaml_dump
 from conda.models.match_spec import MatchSpec
 from conda_lockfiles.load_yaml import load_yaml
 
@@ -1056,29 +1058,176 @@ def test_merge_lockfiles_rejects_wrong_version(
         merge_lockfiles([bad], ctx)
 
 
-def test_merge_lockfiles_channel_mismatch(
-    workspace_ctx_factory: Callable[..., WorkspaceContext],
-    fake_solver_factory,
-    resolved_envs_factory,
-    write_fragment: Callable[[WorkspaceContext, dict, str], Path],
+def test_merge_lockfiles_fills_manifest_channels_for_fragment_subset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    ctx = workspace_ctx_factory(env_names=["default"])
-    fake_solver_factory()
-    resolved_envs = resolved_envs_factory(default=["linux-64"])
-    frag_a = write_fragment(ctx, resolved_envs, "linux-64")
-
-    # Produce a second fragment with a different channel list by
-    # tweaking the saved content directly.
-    frag_b = ctx.root / "conda.lock.osx-arm64"
-    content = (
-        frag_a.read_text(encoding="utf-8")
-        .replace("linux-64", "osx-arm64")
-        .replace(
-            "conda-forge",
-            "different-channel",
-        )
+    """Merge accepts fragments that omit an unused manifest-declared channel."""
+    main = "https://repo.anaconda.com/pkgs/main"
+    msys2 = "https://repo.anaconda.com/pkgs/msys2"
+    config = WorkspaceConfig(
+        name="fragment-channel-subset",
+        channels=[Channel(main), Channel(msys2)],
+        platforms=["linux-64", "win-64"],
+        features={"default": Feature(name="default")},
+        environments={"default": Environment(name="default")},
+        root=str(tmp_path),
+        manifest_path=str(tmp_path / "conda.toml"),
     )
-    frag_b.write_text(content, encoding="utf-8")
+    ctx = WorkspaceContext(config)
+    ctx._cache["platform"] = "linux-64"
+    resolved_envs = {
+        "default": ResolvedEnvironment(
+            name="default",
+            platforms=["linux-64", "win-64"],
+        )
+    }
+
+    def fake_solve(
+        self: ResolvedEnvironment,
+        platform: str,
+        *,
+        prefix: str | Path,
+    ) -> list[_FakePkg]:
+        return [_FakePkg("python", f"{main}/{platform}/python-{platform}.conda")]
+
+    monkeypatch.setattr(ResolvedEnvironment, "solve_for_platform", fake_solve)
+
+    frag_linux = generate_lockfile(
+        ctx,
+        resolved_envs,
+        config=config,
+        platforms=("linux-64",),
+        output_path=tmp_path / "conda.lock.linux-64",
+    )
+    frag_win = generate_lockfile(
+        ctx,
+        resolved_envs,
+        config=config,
+        platforms=("win-64",),
+        output_path=tmp_path / "conda.lock.win-64",
+    )
+
+    win_data = load_yaml(frag_win)
+    win_data["environments"]["default"]["channels"] = [{"url": main}]
+    buf = io.StringIO()
+    yaml_dump(win_data, buf)
+    frag_win.write_text(buf.getvalue(), encoding="utf-8")
+    load_yaml.cache_clear()
+
+    merged_path = merge_lockfiles([frag_linux, frag_win], ctx)
+    merged = load_yaml(merged_path)
+
+    assert merged["environments"]["default"]["channels"] == [
+        {"url": main},
+        {"url": msys2},
+    ]
+    assert set(merged["environments"]["default"]["packages"]) == {
+        "linux-64",
+        "win-64",
+    }
+
+
+@pytest.mark.parametrize(
+    ("fragment_channels", "case"),
+    [
+        pytest.param(
+            [
+                "https://repo.anaconda.com/pkgs/main",
+                "https://repo.anaconda.com/pkgs/extra",
+            ],
+            "unknown",
+            id="unknown-channel",
+        ),
+        pytest.param(
+            [
+                "https://repo.anaconda.com/pkgs/msys2",
+                "https://repo.anaconda.com/pkgs/main",
+            ],
+            "reordered",
+            id="reordered-subset",
+        ),
+    ],
+)
+def test_merge_lockfiles_rejects_manifest_channel_mismatch(
+    tmp_path: Path,
+    fragment_channels: list[str],
+    case: str,
+) -> None:
+    """Fragments can omit manifest channels but cannot add or reorder them."""
+    main = "https://repo.anaconda.com/pkgs/main"
+    msys2 = "https://repo.anaconda.com/pkgs/msys2"
+    config = WorkspaceConfig(
+        name=f"fragment-channel-{case}",
+        channels=[Channel(main), Channel(msys2)],
+        platforms=["linux-64"],
+        features={"default": Feature(name="default")},
+        environments={"default": Environment(name="default")},
+        root=str(tmp_path),
+        manifest_path=str(tmp_path / "conda.toml"),
+    )
+    ctx = WorkspaceContext(config)
+    channel_lines = "\n".join(f"    - url: {url}" for url in fragment_channels)
+    fragment = tmp_path / "conda.lock.linux-64"
+    fragment.write_text(
+        f"""\
+version: 1
+environments:
+  default:
+    channels:
+{channel_lines}
+    packages:
+      linux-64:
+      - conda: {main}/linux-64/python-linux-64.conda
+packages:
+- conda: {main}/linux-64/python-linux-64.conda
+""",
+        encoding="utf-8",
+    )
+    load_yaml.cache_clear()
+
+    with pytest.raises(LockfileMergeError, match="channels differ"):
+        merge_lockfiles([fragment], ctx)
+
+
+def test_merge_lockfiles_channel_mismatch_for_manifest_unknown_env(
+    tmp_path: Path,
+    workspace_ctx_factory: Callable[..., WorkspaceContext],
+) -> None:
+    """Manifest-unknown environments keep strict fragment-to-fragment checks."""
+    ctx = workspace_ctx_factory(env_names=["default"])
+    frag_a = tmp_path / "conda.lock.external-linux-64"
+    frag_a.write_text(
+        """\
+version: 1
+environments:
+  external:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge
+    packages:
+      linux-64:
+      - conda: https://example.com/python-linux-64.conda
+packages:
+- conda: https://example.com/python-linux-64.conda
+""",
+        encoding="utf-8",
+    )
+    frag_b = ctx.root / "conda.lock.osx-arm64"
+    frag_b.write_text(
+        """\
+version: 1
+environments:
+  external:
+    channels:
+    - url: https://conda.anaconda.org/different-channel
+    packages:
+      osx-arm64:
+      - conda: https://example.com/python-osx-arm64.conda
+packages:
+- conda: https://example.com/python-osx-arm64.conda
+""",
+        encoding="utf-8",
+    )
     load_yaml.cache_clear()
 
     with pytest.raises(LockfileMergeError, match="channels differ"):

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -1128,6 +1128,67 @@ def test_merge_lockfiles_fills_manifest_channels_for_fragment_subset(
     }
 
 
+def test_merge_lockfiles_preserves_manifest_channels_with_canonical_collision(
+    tmp_path: Path,
+) -> None:
+    """Merge preserves distinct manifest URLs even if conda canonicalizes them alike."""
+    main = "https://repo.anaconda.com/pkgs/main"
+    msys2 = "https://repo.anaconda.com/pkgs/msys2"
+
+    class CanonicalCollisionChannel:
+        canonical_name = "defaults"
+
+        def __init__(self, url: str) -> None:
+            self.url = url
+
+        def __str__(self) -> str:
+            return self.url
+
+    config = WorkspaceConfig(
+        name="fragment-channel-collision",
+        channels=[
+            CanonicalCollisionChannel(main),  # type: ignore[list-item]
+            CanonicalCollisionChannel(msys2),  # type: ignore[list-item]
+        ],
+        platforms=["linux-64"],
+        features={"default": Feature(name="default")},
+        environments={"default": Environment(name="default")},
+        root=str(tmp_path),
+        manifest_path=str(tmp_path / "conda.toml"),
+    )
+    env = config.environments["default"]
+    assert [str(ch) for ch in config.merged_channels(env)] == [main]
+    ctx = WorkspaceContext(config)
+
+    fragment = tmp_path / "conda.lock.linux-64"
+    fragment.write_text(
+        f"""\
+version: 1
+environments:
+  default:
+    channels:
+    - url: {main}
+    packages:
+      linux-64:
+      - conda: {main}/linux-64/python-linux-64.conda
+packages:
+- conda: {main}/linux-64/python-linux-64.conda
+""",
+        encoding="utf-8",
+    )
+    load_yaml.cache_clear()
+
+    merged_path = merge_lockfiles([fragment], ctx)
+    merged = load_yaml(merged_path)
+
+    assert merged["environments"]["default"]["channels"] == [
+        {"url": main},
+        {"url": msys2},
+    ]
+    result = check_lockfile_satisfiability(config, merged, "linux-64")
+    assert result.status == LockfileStatus.UP_TO_DATE
+
+
 @pytest.mark.parametrize(
     ("fragment_channels", "case"),
     [


### PR DESCRIPTION
## Summary
- treat manifest-declared environment channels as canonical during lock fragment merges
- allow platform fragments to omit unused manifest channels while preserving manifest order in the merged lockfile
- keep strict channel equality checks for environments that are not declared in the manifest

## Root cause
Per-platform lock fragments can legitimately differ when one platform does not use a channel declared in the workspace manifest, such as Windows omitting `pkgs/msys2`. The merge step compared fragment channel lists directly, so those valid fragments failed to merge.

Fixes #88.

## Validation
- `pixi run -e test pytest tests/test_lockfile.py -q`
- `pixi run -e test pytest`
- `pixi run ruff check`
- `pixi run ruff format --check conda_workspaces/lockfile.py tests/test_lockfile.py`

Note: full `pixi run ruff format --check` still reports unrelated untracked `demos/generate-voiceover.py` would be reformatted.