### PR TITLE
Verify lockfile package integrity during install

### DIFF
--- a/conda_workspaces/exceptions.py
+++ b/conda_workspaces/exceptions.py
@@ -217,6 +217,21 @@ class LockfileNotFoundError(CondaWorkspacesError):
         )
 
 
+class LockfileIntegrityError(CondaWorkspacesError):
+    """A lockfile package reference is not bound to trusted metadata."""
+
+    def __init__(self, path: str | Path, reason: str) -> None:
+        self.path = path
+        self.reason = reason
+        super().__init__(
+            f"Lockfile '{path}' failed integrity validation: {reason}",
+            hints=[
+                "Regenerate the lockfile with 'conda workspace lock'"
+                " before installing from it.",
+            ],
+        )
+
+
 class LockfileMergeError(CondaWorkspacesError):
     """A set of ``conda.lock`` fragments cannot be merged into one file.
 

--- a/conda_workspaces/lockfile.py
+++ b/conda_workspaces/lockfile.py
@@ -54,6 +54,7 @@ from conda.plugins.types import EnvironmentSpecBase
 
 from .exceptions import (
     AllTargetsUnsolvableError,
+    LockfileIntegrityError,
     LockfileMergeError,
     LockfileNotFoundError,
     SolveError,
@@ -213,11 +214,52 @@ def check_lockfile_satisfiability(
         if platform_refs is None:
             continue
 
+        records_by_url = CondaLockLoader.package_records_by_url_from_data(lockfile_data)
+        try:
+            channel_urls = CondaLockLoader.channel_urls_for_env_data(
+                lock_env,
+                current_platform,
+            )
+        except ValueError as exc:
+            return LockfileStatus(status=_stale, reason=str(exc))
+
         locked_versions: dict[str, list[str]] = {}
         for ref in platform_refs:
+            if not isinstance(ref, dict):
+                continue
             url = ref.get("conda", "")
             if not url:
                 continue
+            if not isinstance(url, str):
+                return LockfileStatus(
+                    status=_stale,
+                    reason=(
+                        f"Environment '{env_name}' contains an invalid "
+                        f"package ref on '{current_platform}'"
+                    ),
+                )
+            if not CondaLockLoader.url_matches_channel(url, channel_urls):
+                return LockfileStatus(
+                    status=_stale,
+                    reason=(
+                        f"Package URL '{url}' in environment '{env_name}' "
+                        f"on '{current_platform}' is not under a declared "
+                        "channel"
+                    ),
+                )
+            record = records_by_url.get(url)
+            if record is None:
+                return LockfileStatus(
+                    status=_stale,
+                    reason=(
+                        f"Package URL '{url}' in environment '{env_name}' "
+                        "has no top-level package record"
+                    ),
+                )
+            try:
+                CondaLockLoader.digest_fragment_for_record(record, url)
+            except ValueError as exc:
+                return LockfileStatus(status=_stale, reason=str(exc))
             dist = Dist(url)
             locked_versions.setdefault(dist.name, []).append(dist.version)
 
@@ -350,6 +392,158 @@ class CondaLockLoader(EnvironmentSpecBase):
                 f"Available environments: {dashlist(sorted(environments))}"
             )
         return environments[name]
+
+    def explicit_package_specs_for(
+        self,
+        platform: str,
+        name: str = "default",
+    ) -> list[str]:
+        """Return hash-bearing explicit conda specs for *name* on *platform*."""
+        env_data = self._env_data(name)
+        platform_refs = env_data.get("packages", {}).get(platform)
+        if platform_refs is None:
+            raise ValueError(
+                f"Environment {name!r} does not include packages for {platform!r}"
+            )
+
+        records_by_url = self.package_records_by_url()
+        channel_urls = self.channel_urls_for(env_data, platform)
+        explicit_specs: list[str] = []
+        for ref in platform_refs:
+            if not isinstance(ref, dict) or "conda" not in ref:
+                continue
+            url = ref["conda"]
+            if not isinstance(url, str) or not url:
+                raise LockfileIntegrityError(
+                    self.path,
+                    f"environment {name!r} has an invalid conda package ref",
+                )
+            if not self.url_matches_channel(url, channel_urls):
+                raise LockfileIntegrityError(
+                    self.path,
+                    f"package URL {url!r} is not under any channel declared "
+                    f"for environment {name!r}",
+                )
+            record = records_by_url.get(url)
+            if record is None:
+                raise LockfileIntegrityError(
+                    self.path,
+                    f"package URL {url!r} has no top-level package record",
+                )
+            digest = self.digest_fragment_for(record, url)
+            explicit_specs.append(f"{url}#{digest}")
+        return explicit_specs
+
+    def package_records_by_url(self) -> dict[str, dict[str, Any]]:
+        """Return top-level conda package records keyed by their exact URL."""
+        return self.package_records_by_url_from_data(self._data)
+
+    @staticmethod
+    def package_records_by_url_from_data(
+        data: dict[str, Any],
+    ) -> dict[str, dict[str, Any]]:
+        """Return top-level conda package records from *data* keyed by URL."""
+        records_by_url: dict[str, dict[str, Any]] = {}
+        for record in data.get("packages", []) or []:
+            if not isinstance(record, dict):
+                continue
+            url = record.get("conda") or record.get("url")
+            if isinstance(url, str) and url:
+                records_by_url.setdefault(url, record)
+        return records_by_url
+
+    def channel_urls_for(
+        self,
+        env_data: dict[str, Any],
+        platform: str,
+    ) -> tuple[str, ...]:
+        """Return concrete package-containing channel URLs for *platform*."""
+        return self.channel_urls_for_env_data(env_data, platform, path=self.path)
+
+    @staticmethod
+    def channel_urls_for_env_data(
+        env_data: dict[str, Any],
+        platform: str,
+        *,
+        path: Path | None = None,
+    ) -> tuple[str, ...]:
+        """Return concrete package-containing channel URLs for *platform*."""
+        from conda.models.channel import Channel
+
+        urls: set[str] = set()
+        for entry in env_data.get("channels", []) or []:
+            if not isinstance(entry, dict):
+                continue
+            raw_url = entry.get("url")
+            if not isinstance(raw_url, str) or not raw_url:
+                continue
+            try:
+                channel = Channel(raw_url)
+                for with_credentials in (False, True):
+                    urls.update(
+                        channel.urls(
+                            with_credentials=with_credentials,
+                            subdirs=(platform, "noarch"),
+                        )
+                    )
+            except Exception as exc:
+                reason = f"environment channel {raw_url!r} cannot be resolved"
+                if path is None:
+                    raise ValueError(reason) from exc
+                raise LockfileIntegrityError(path, reason) from exc
+        return tuple(sorted(url.rstrip("/") for url in urls))
+
+    @staticmethod
+    def url_matches_channel(url: str, channel_urls: tuple[str, ...]) -> bool:
+        """Return whether *url* is contained by one declared channel URL."""
+        return any(url.startswith(f"{channel_url}/") for channel_url in channel_urls)
+
+    def digest_fragment_for(self, record: dict[str, Any], url: str) -> str:
+        """Return the conda explicit-file digest fragment for *record*."""
+        return self.digest_fragment_for_record(record, url, path=self.path)
+
+    @classmethod
+    def digest_fragment_for_record(
+        cls,
+        record: dict[str, Any],
+        url: str,
+        *,
+        path: Path | None = None,
+    ) -> str:
+        """Return the conda explicit-file digest fragment for *record*."""
+        sha256 = record.get("sha256")
+        if sha256 is not None:
+            if cls.is_hex_digest(sha256, 64):
+                return f"sha256:{sha256.lower()}"
+            reason = f"package URL {url!r} has an invalid sha256 digest"
+            if path is None:
+                raise ValueError(reason)
+            raise LockfileIntegrityError(path, reason)
+
+        md5 = record.get("md5")
+        if md5 is not None:
+            if cls.is_hex_digest(md5, 32):
+                return md5.lower()
+            reason = f"package URL {url!r} has an invalid md5 digest"
+            if path is None:
+                raise ValueError(reason)
+            raise LockfileIntegrityError(path, reason)
+
+        reason = f"package URL {url!r} is missing a sha256 or md5 digest"
+        if path is None:
+            raise ValueError(reason)
+        raise LockfileIntegrityError(path, reason)
+
+    @staticmethod
+    def is_hex_digest(value: object, length: int) -> bool:
+        """Return whether *value* is a hex digest with *length* characters."""
+        if not isinstance(value, str) or len(value) != length:
+            return False
+        try:
+            int(value, 16)
+        except ValueError:
+            return False
+        return True
 
     @classmethod
     def compose(cls, envs: Iterable[Environment]) -> dict[str, Any]:
@@ -726,15 +920,9 @@ def install_from_lockfile(
 
     loader = CondaLockLoader(path)
     try:
-        env_data = loader._env_data(env_name)
+        urls = loader.explicit_package_specs_for(ctx.platform, env_name)
     except (ValueError, OSError) as exc:
         raise LockfileNotFoundError(env_name, path) from exc
-
-    platform_pkgs = env_data.get("packages", {}).get(ctx.platform)
-    if platform_pkgs is None:
-        raise LockfileNotFoundError(env_name, path)
-
-    urls = [ref["conda"] for ref in platform_pkgs if "conda" in ref]
 
     install_prefix = prefix or ctx.env_prefix(env_name)
     install_prefix.mkdir(parents=True, exist_ok=True)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -16,6 +16,7 @@ from conda_workspaces.exceptions import (
     EnvironmentNotFoundError,
     EnvironmentNotInstalledError,
     FeatureNotFoundError,
+    LockfileIntegrityError,
     LockfileNotFoundError,
     ManifestExistsError,
     PlatformError,
@@ -65,6 +66,10 @@ from conda_workspaces.exceptions import (
             ["test", "conda.lock"],
         ),
         (
+            LockfileIntegrityError(Path("conda.lock"), "bad digest"),
+            ["conda.lock", "bad digest"],
+        ),
+        (
             EnvironmentNotInstalledError("dev"),
             ["dev", "not installed"],
         ),
@@ -83,6 +88,7 @@ from conda_workspaces.exceptions import (
         "solve-error",
         "activation-error",
         "lockfile-not-found",
+        "lockfile-integrity",
         "env-not-installed",
         "manifest-exists",
     ],
@@ -102,8 +108,13 @@ def test_inheritance():
     [
         (ActivationError("dev", "shell not found"), "environment", "dev"),
         (LockfileNotFoundError("test", Path("conda.lock")), "environment", "test"),
+        (
+            LockfileIntegrityError(Path("conda.lock"), "bad digest"),
+            "reason",
+            "bad digest",
+        ),
     ],
-    ids=["activation-env", "lockfile-env"],
+    ids=["activation-env", "lockfile-env", "lockfile-integrity-reason"],
 )
 def test_exception_attributes(exc, attr, expected):
     assert getattr(exc, attr) == expected
@@ -122,6 +133,7 @@ def test_exception_attributes(exc, attr, expected):
         SolveError("test", "conflict"),
         ActivationError("dev", "shell not found"),
         LockfileNotFoundError("test", Path("conda.lock")),
+        LockfileIntegrityError(Path("conda.lock"), "bad digest"),
     ],
     ids=[
         "workspace-not-found",
@@ -134,6 +146,7 @@ def test_exception_attributes(exc, attr, expected):
         "solve-error",
         "activation-error",
         "lockfile-not-found",
+        "lockfile-integrity",
     ],
 )
 def test_error_message_and_hints_separate(exc):

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -19,6 +19,7 @@ from conda_lockfiles.load_yaml import load_yaml
 
 from conda_workspaces.context import WorkspaceContext
 from conda_workspaces.exceptions import (
+    LockfileIntegrityError,
     LockfileMergeError,
     LockfileNotFoundError,
     SolveError,
@@ -712,6 +713,10 @@ def test_install_from_lockfile(
 ) -> None:
     """install_from_lockfile reads conda.lock, extracts URLs, and installs."""
     ctx = workspace_ctx_factory()
+    python_url = "https://example.com/channel/linux-64/python.conda"
+    numpy_url = "https://example.com/channel/noarch/numpy.conda"
+    python_sha256 = "a" * 64
+    numpy_md5 = "b" * 32
 
     lockfile = tmp_path / LOCKFILE_NAME
     lockfile.write_text(
@@ -719,16 +724,16 @@ def test_install_from_lockfile(
         "environments:\n"
         "  default:\n"
         "    channels:\n"
-        "    - url: conda-forge\n"
+        "    - url: https://example.com/channel\n"
         "    packages:\n"
         "      linux-64:\n"
-        "      - conda: https://example.com/python.conda\n"
-        "      - conda: https://example.com/numpy.conda\n"
+        f"      - conda: {python_url}\n"
+        f"      - conda: {numpy_url}\n"
         "packages:\n"
-        "- conda: https://example.com/python.conda\n"
-        "  sha256: aaa\n"
-        "- conda: https://example.com/numpy.conda\n"
-        "  sha256: bbb\n",
+        f"- conda: {python_url}\n"
+        f"  sha256: {python_sha256}\n"
+        f"- conda: {numpy_url}\n"
+        f"  md5: {numpy_md5}\n",
         encoding="utf-8",
     )
 
@@ -758,12 +763,130 @@ def test_install_from_lockfile(
 
     assert len(get_records_calls) == 1
     assert get_records_calls[0] == [
-        "https://example.com/python.conda",
-        "https://example.com/numpy.conda",
+        f"{python_url}#sha256:{python_sha256}",
+        f"{numpy_url}#{numpy_md5}",
     ]
     assert len(install_calls) == 1
     assert install_calls[0]["records"] == records_sentinel
     assert install_calls[0]["prefix"] == str(ctx.env_prefix("default"))
+
+
+@pytest.mark.parametrize(
+    ("package_url", "package_record", "match"),
+    [
+        pytest.param(
+            "https://attacker.example/pkgs/linux-64/python-3.11.9-hbad_0.tar.bz2",
+            {
+                "conda": (
+                    "https://attacker.example/pkgs/linux-64/"
+                    "python-3.11.9-hbad_0.tar.bz2"
+                ),
+                "sha256": "0" * 64,
+            },
+            "not under any channel",
+            id="off-channel",
+        ),
+        pytest.param(
+            "https://example.com/channel/linux-64/python-3.11.9-hgood_0.tar.bz2",
+            None,
+            "no top-level package record",
+            id="missing-top-level-record",
+        ),
+        pytest.param(
+            "https://example.com/channel/linux-64/python-3.11.9-hgood_0.tar.bz2",
+            {
+                "conda": (
+                    "https://example.com/channel/linux-64/python-3.11.9-hgood_0.tar.bz2"
+                )
+            },
+            "missing a sha256 or md5 digest",
+            id="missing-digest",
+        ),
+        pytest.param(
+            "https://example.com/channel/linux-64/python-3.11.9-hgood_0.tar.bz2",
+            {
+                "conda": (
+                    "https://example.com/channel/linux-64/python-3.11.9-hgood_0.tar.bz2"
+                ),
+                "sha256": "not-a-valid-sha256",
+            },
+            "invalid sha256 digest",
+            id="invalid-sha256",
+        ),
+    ],
+)
+def test_install_from_lockfile_rejects_unbound_package_refs(
+    tmp_path: Path,
+    workspace_ctx_factory: Callable[..., WorkspaceContext],
+    monkeypatch: pytest.MonkeyPatch,
+    package_url: str,
+    package_record: dict[str, str] | None,
+    match: str,
+) -> None:
+    """Locked installs reject refs that are not bound to channel + hash metadata."""
+    ctx = workspace_ctx_factory()
+    packages = [] if package_record is None else [package_record]
+    lockfile = {
+        "version": LOCKFILE_VERSION,
+        "environments": {
+            "default": {
+                "channels": [{"url": "https://example.com/channel"}],
+                "packages": {"linux-64": [{"conda": package_url}]},
+            }
+        },
+        "packages": packages,
+    }
+    buf = io.StringIO()
+    yaml_dump(lockfile, buf)
+    (tmp_path / LOCKFILE_NAME).write_text(buf.getvalue(), encoding="utf-8")
+
+    get_records_calls: list[list] = []
+
+    def fake_get_records(lines):
+        get_records_calls.append(lines)
+        return []
+
+    monkeypatch.setattr(
+        "conda.misc.get_package_records_from_explicit",
+        fake_get_records,
+    )
+
+    with pytest.raises(LockfileIntegrityError, match=match):
+        install_from_lockfile(ctx, "default")
+
+    assert get_records_calls == []
+
+
+def test_lockfile_status_rejects_off_channel_package_refs() -> None:
+    """Freshness checks reject the off-channel URL used by the scan PoC."""
+    config = WorkspaceConfig(
+        name="lock-test",
+        channels=[Channel("conda-forge")],
+        platforms=["linux-64"],
+        features={
+            "default": Feature(
+                name="default",
+                conda_dependencies={"python": MatchSpec("python >=3.11")},
+            )
+        },
+        environments={"default": Environment(name="default")},
+    )
+    package_url = "https://attacker.example/pkgs/linux-64/python-3.11.9-hbad_0.tar.bz2"
+    lockfile_data = {
+        "version": LOCKFILE_VERSION,
+        "environments": {
+            "default": {
+                "channels": [{"url": str(Channel("conda-forge"))}],
+                "packages": {"linux-64": [{"conda": package_url}]},
+            }
+        },
+        "packages": [{"conda": package_url, "sha256": "0" * 64}],
+    }
+
+    status = check_lockfile_satisfiability(config, lockfile_data, "linux-64")
+
+    assert status.status == LockfileStatus.OUT_OF_DATE
+    assert "not under a declared channel" in status.reason
 
 
 def test_install_from_lockfile_explicit_prefix_override(
@@ -773,6 +896,8 @@ def test_install_from_lockfile_explicit_prefix_override(
 ) -> None:
     """install_from_lockfile can install elsewhere while embedding a final prefix."""
     ctx = workspace_ctx_factory()
+    package_url = "https://example.com/channel/linux-64/python.conda"
+    package_sha256 = "a" * 64
 
     lockfile = tmp_path / LOCKFILE_NAME
     lockfile.write_text(
@@ -780,20 +905,20 @@ def test_install_from_lockfile_explicit_prefix_override(
         "environments:\n"
         "  default:\n"
         "    channels:\n"
-        "    - url: conda-forge\n"
+        "    - url: https://example.com/channel\n"
         "    packages:\n"
         "      linux-64:\n"
-        "      - conda: https://example.com/python.conda\n"
+        f"      - conda: {package_url}\n"
         "packages:\n"
-        "- conda: https://example.com/python.conda\n"
-        "  sha256: aaa\n",
+        f"- conda: {package_url}\n"
+        f"  sha256: {package_sha256}\n",
         encoding="utf-8",
     )
 
     records_sentinel = [object()]
 
     def fake_get_records(lines):
-        assert lines == ["https://example.com/python.conda"]
+        assert lines == [f"{package_url}#sha256:{package_sha256}"]
         return records_sentinel
 
     monkeypatch.setattr(
@@ -1173,6 +1298,7 @@ environments:
       - conda: {main}/linux-64/python-linux-64.conda
 packages:
 - conda: {main}/linux-64/python-linux-64.conda
+  sha256: {"a" * 64}
 """,
         encoding="utf-8",
     )
@@ -1328,6 +1454,14 @@ def lockfile_data_factory():
         if version is not None:
             data["version"] = version
         if environments is None:
+            linux_url = (
+                "https://conda.anaconda.org/conda-forge/linux-64/"
+                "python-3.12.0-hab00c5b_0.conda"
+            )
+            osx_url = (
+                "https://conda.anaconda.org/conda-forge/osx-arm64/"
+                "python-3.12.0-h47c9636_0.conda"
+            )
             environments = {
                 "default": {
                     "channels": [
@@ -1336,17 +1470,22 @@ def lockfile_data_factory():
                     "packages": {
                         "linux-64": [
                             {
-                                "conda": "https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0.conda"
+                                "conda": linux_url,
                             },
                         ],
                         "osx-arm64": [
                             {
-                                "conda": "https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0.conda"
+                                "conda": osx_url,
                             },
                         ],
                     },
                 },
             }
+            if packages is None:
+                packages = [
+                    {"conda": linux_url, "sha256": "a" * 64},
+                    {"conda": osx_url, "sha256": "b" * 64},
+                ]
         data["environments"] = environments
         data["packages"] = packages or []
         return data


### PR DESCRIPTION
## Summary
- Bind locked conda package refs to declared channel URLs and exact top-level package records before install.
- Pass sha256/md5-bearing explicit specs to conda instead of bare URLs, preferring sha256 when available.
- Mark off-channel or un-hashed lockfile refs out-of-date during lockfile satisfiability checks.

## Root cause
`install_from_lockfile()` extracted only `ref["conda"]` URLs from environment package refs, so a lockfile could look fresh while sending conda an attacker-controlled explicit package URL without enforcing the stored lockfile digest metadata.

## Validation
- `pixi run python /tmp/codex-security-scans/conda-workspaces/00c244a6a4fc_20260611T234822Z/artifacts/05_findings/CW-CAN-002/validation_artifacts/lockfile_url_poc.py`
- `pixi run -e test pytest tests/test_lockfile.py tests/test_exceptions.py`
- `pixi run -e test pytest`
- `pixi run ruff check`
- `pixi run ruff format --check`

## Notes
- The AGENTS.md pytest and ruff commands pass on the PR commit in a clean temporary worktree. The dirty local checkout still has unrelated untracked files outside this PR.
- `pixi run -e test ty check` is not a clean gate today; it reports existing repository typing diagnostics, mostly in tests, unrelated to this lockfile fix.