### PR TITLE
Validate archive output paths

### DIFF
--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -14,7 +14,7 @@ import shutil
 import subprocess
 import tarfile
 from contextlib import contextmanager
-from pathlib import Path, PurePosixPath, PureWindowsPath
+from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
@@ -25,9 +25,11 @@ from .exceptions import (
     ArchiveHashMismatchError,
     ArchivePathTraversalError,
 )
+from .paths import parse_relative_posix_path
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from pathlib import PurePosixPath
     from typing import Any
 
     from .models import ArchiveConfig
@@ -69,16 +71,6 @@ BUILTIN_EXCLUDE_DIRS: frozenset[str] = frozenset(
 """Directories excluded from archives regardless of user configuration."""
 
 
-def has_absolute_path_syntax(path: str) -> bool:
-    """Return whether *path* is absolute using POSIX or Windows syntax.
-
-    Workspace archives can be created and verified on a different OS than
-    the one that consumes them, so callers cannot rely on host-only path
-    parsing for archive metadata.
-    """
-    return PurePosixPath(path).is_absolute() or PureWindowsPath(path).is_absolute()
-
-
 def parse_relative_archive_path(
     path: str,
     *,
@@ -91,20 +83,14 @@ def parse_relative_archive_path(
     verification reject the same ambiguous path syntax while raising their
     own domain-specific errors.
     """
-    posix_path = PurePosixPath(path)
-    windows_path = PureWindowsPath(path)
-    if (
-        not path
-        or "\0" in path
-        or "\\" in path
-        or posix_path.is_absolute()
-        or windows_path.drive
-        or not posix_path.parts
-        or posix_path.as_posix() != path
-        or (not allow_parent and any(part == ".." for part in posix_path.parts))
-    ):
-        raise ValueError(f"Invalid relative archive path: {path!r}")
-    return posix_path
+    try:
+        return parse_relative_posix_path(
+            path,
+            allow_parent=allow_parent,
+            require_canonical=True,
+        )
+    except ValueError as exc:
+        raise ValueError(f"Invalid relative archive path: {path!r}") from exc
 
 
 def is_git_repo(root: Path) -> bool:

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -18,7 +18,6 @@ from ...archive import (
     collect_bundle_packages,
     create_archive,
     extract_archive,
-    has_absolute_path_syntax,
     inspect_archive,
     prime_package_cache,
     verify_package_hashes,
@@ -26,6 +25,7 @@ from ...archive import (
 from ...exceptions import ArchiveError
 from ...lockfile import lockfile_path as _lockfile_path
 from ...models import ArchiveConfig
+from ...paths import has_absolute_path_syntax, is_path_segment
 from ...receipts import ArchiveReceipt
 from .. import status
 from . import workspace_context_from_args
@@ -233,6 +233,14 @@ def execute_archive(
     output: Path | None = args.output
     if output is None:
         name = config.name or ctx.root.name
+        if not is_path_segment(name):
+            raise ArchiveError(
+                "Workspace name cannot be used as a default archive filename.",
+                hints=[
+                    "Use a simple workspace name without path separators,",
+                    "or pass -o/--output to choose the archive path explicitly.",
+                ],
+            )
         ext = {"zst": ".tar.zst", "gz": ".tar.gz", "bz2": ".tar.bz2"}.get(
             config.archive.compression, ".tar.zst"
         )

--- a/conda_workspaces/paths.py
+++ b/conda_workspaces/paths.py
@@ -1,0 +1,55 @@
+"""Path validation helpers shared across workspace boundaries."""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath, PureWindowsPath
+
+
+def has_absolute_path_syntax(path: str) -> bool:
+    """Return whether *path* is absolute using POSIX or Windows syntax."""
+    return PurePosixPath(path).is_absolute() or PureWindowsPath(path).is_absolute()
+
+
+def parse_relative_posix_path(
+    path: str,
+    *,
+    allow_parent: bool = False,
+    require_canonical: bool = False,
+) -> PurePosixPath:
+    """Return *path* as a validated POSIX relative path.
+
+    This lives at module level because archives, receipts, and imported
+    manifests all need the same host-independent path syntax policy while
+    raising domain-specific errors at their own call sites.
+    """
+    posix_path = PurePosixPath(path)
+    windows_path = PureWindowsPath(path)
+    windows_parts = tuple(windows_path.parts)
+    posix_parts = tuple(posix_path.parts)
+    if (
+        not path
+        or "\0" in path
+        or posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or windows_path.drive
+        or windows_path.root
+        or not posix_parts
+        or windows_parts != posix_parts
+        or (require_canonical and posix_path.as_posix() != path)
+        or (not allow_parent and any(part == ".." for part in posix_parts))
+    ):
+        raise ValueError(f"Invalid relative path: {path!r}")
+    return posix_path
+
+
+def is_path_segment(value: str) -> bool:
+    """Return whether *value* is one portable path segment.
+
+    This is for manifest values that are used as filenames or directory
+    names, not paths.  It checks POSIX and Windows parsing so a value that
+    is harmless on the host OS but path-like elsewhere is still rejected.
+    """
+    try:
+        return len(parse_relative_posix_path(value, require_canonical=True).parts) == 1
+    except ValueError:
+        return False

--- a/conda_workspaces/receipts.py
+++ b/conda_workspaces/receipts.py
@@ -11,11 +11,11 @@ from conda_lockfiles.load_yaml import load_yaml
 
 from .archive import (
     file_sha256,
-    has_absolute_path_syntax,
     parse_relative_archive_path,
     url_to_filename,
 )
 from .exceptions import ArchiveError, ArchiveHashMismatchError
+from .paths import has_absolute_path_syntax
 
 if TYPE_CHECKING:
     from collections.abc import Mapping

--- a/docs/features.md
+++ b/docs/features.md
@@ -771,6 +771,10 @@ files:
 conda workspace archive -o my-project.tar.zst
 ```
 
+When `-o/--output` is omitted, the archive is written in the workspace
+root using the workspace name as the filename stem. That default name
+must be a single filename segment; use `-o/--output` for other paths.
+
 In git repos, only tracked files are included. Built-in exclusions
 (`.git`, `__pycache__`, `.conda/envs`, `.pixi`) always apply.
 Configure additional exclusions in the manifest:

--- a/docs/tutorials/archives.md
+++ b/docs/tutorials/archives.md
@@ -33,7 +33,9 @@ my-project.tar.zst
 ```
 
 If no `-o` is given, the archive is named after the workspace
-(`<name>.tar.zst`) and placed in the project root.
+(`<name>.tar.zst`) and placed in the project root. The workspace name
+must be a single filename segment for this default; pass `-o/--output`
+when you want to write the archive somewhere else.
 
 ## Use gzip compression
 

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -236,6 +236,84 @@ def test_execute_archive_no_output(
     assert expected.is_file()
 
 
+@pytest.mark.parametrize(
+    "workspace_name",
+    [
+        "../escaped-output",
+        "nested/archive-test",
+        r"nested\archive-test",
+        "/tmp/escaped-output",
+        "C:escaped-output",
+        "C:/escaped-output",
+    ],
+    ids=[
+        "parent",
+        "nested-posix",
+        "nested-windows",
+        "absolute",
+        "windows-drive-relative",
+        "windows-absolute",
+    ],
+)
+def test_execute_archive_rejects_path_like_default_output_name(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_name: str,
+) -> None:
+    manifest = archive_workspace / "conda.toml"
+    manifest.write_text(
+        f"""\
+[workspace]
+name = '{workspace_name}'
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-arm64"]
+
+[dependencies]
+python = ">=3.10"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(archive_workspace)
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    with pytest.raises(ArchiveError, match="default archive filename"):
+        execute_archive(make_args(_ARCHIVE_DEFAULTS), console=console)
+
+    assert not (archive_workspace.parent / "escaped-output.tar.zst").exists()
+    assert not (archive_workspace / "nested").exists()
+
+
+def test_execute_archive_explicit_output_allows_path_like_workspace_name(
+    archive_workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest = archive_workspace / "conda.toml"
+    manifest.write_text(
+        """\
+[workspace]
+name = '../escaped-output'
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-arm64"]
+
+[dependencies]
+python = ">=3.10"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(archive_workspace)
+    output = tmp_path / "chosen.tar.gz"
+    console = Console(file=StringIO(), width=200, highlight=False)
+
+    result = execute_archive(
+        make_args(_ARCHIVE_DEFAULTS, output=output),
+        console=console,
+    )
+
+    assert result == 0
+    assert output.is_file()
+
+
 def test_execute_archive_exclude(
     archive_workspace: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,138 @@
+"""Tests for conda_workspaces.paths."""
+
+from __future__ import annotations
+
+import pytest
+
+from conda_workspaces.paths import (
+    has_absolute_path_syntax,
+    is_path_segment,
+    parse_relative_posix_path,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("/tmp/project", True),
+        ("C:/project", True),
+        (r"C:\project", True),
+        ("relative/project", False),
+        (r"relative\project", False),
+        ("C:project", False),
+    ],
+    ids=[
+        "posix-absolute",
+        "windows-absolute-forward",
+        "windows-absolute-backslash",
+        "relative-posix",
+        "relative-windows",
+        "windows-drive-relative",
+    ],
+)
+def test_has_absolute_path_syntax(value: str, expected: bool) -> None:
+    assert has_absolute_path_syntax(value) is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "allow_parent", "require_canonical", "expected"),
+    [
+        ("conda.toml", False, False, "conda.toml"),
+        ("envs/default/history", False, False, "envs/default/history"),
+        ("../target", True, False, "../target"),
+        ("dir/./file", False, False, "dir/file"),
+    ],
+    ids=["file", "nested", "parent-allowed", "non-canonical-allowed"],
+)
+def test_parse_relative_posix_path_accepts_valid_paths(
+    value: str,
+    allow_parent: bool,
+    require_canonical: bool,
+    expected: str,
+) -> None:
+    path = parse_relative_posix_path(
+        value,
+        allow_parent=allow_parent,
+        require_canonical=require_canonical,
+    )
+
+    assert path.as_posix() == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "allow_parent", "require_canonical"),
+    [
+        ("", False, False),
+        ("/tmp/project", False, False),
+        ("C:/project", False, False),
+        (r"C:\project", False, False),
+        (r"dir\file", False, False),
+        ("C:project", True, False),
+        ("dir/../file", False, False),
+        ("dir/./file", False, True),
+        ("dir//file", False, True),
+        ("bad\0path", False, False),
+    ],
+    ids=[
+        "empty",
+        "posix-absolute",
+        "windows-absolute-forward",
+        "windows-absolute-backslash",
+        "backslash",
+        "windows-drive-relative",
+        "parent",
+        "current-dir-canonical",
+        "double-slash-canonical",
+        "nul",
+    ],
+)
+def test_parse_relative_posix_path_rejects_invalid_paths(
+    value: str,
+    allow_parent: bool,
+    require_canonical: bool,
+) -> None:
+    with pytest.raises(ValueError):
+        parse_relative_posix_path(
+            value,
+            allow_parent=allow_parent,
+            require_canonical=require_canonical,
+        )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("archive-test", True),
+        ("archive test", True),
+        ("", False),
+        (".", False),
+        ("..", False),
+        ("nested/archive-test", False),
+        (r"nested\archive-test", False),
+        ("/tmp/archive-test", False),
+        (r"\archive-test", False),
+        ("C:archive-test", False),
+        ("C:/archive-test", False),
+        (r"C:\archive-test", False),
+        (r"\\server\share\archive-test", False),
+        ("bad\0name", False),
+    ],
+    ids=[
+        "name",
+        "space",
+        "empty",
+        "dot",
+        "dot-dot",
+        "nested-posix",
+        "nested-windows",
+        "absolute",
+        "windows-rooted",
+        "windows-drive-relative",
+        "windows-absolute-forward",
+        "windows-absolute-backslash",
+        "windows-unc",
+        "nul",
+    ],
+)
+def test_is_path_segment(value: str, expected: bool) -> None:
+    assert is_path_segment(value) is expected


### PR DESCRIPTION
## Summary
- Add shared portable path validation helpers for archive and receipt paths.
- Reject workspace names that cannot safely form the default archive filename.
- Reuse the shared absolute-path detection for receipt path validation.

## Security
- Prevent manifest-controlled workspace names from writing the default archive outside the workspace root.
- Keep archive-relative path validation consistent across archive extraction and receipts.

## Validation
- `pixi run -e test pytest`
- `pixi run ruff check`
- `pixi run ruff format --check`