### PR TITLE
Reject unsafe unarchive targets

### DIFF
--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -339,12 +339,36 @@ def open_tar(archive_path: Path) -> Iterator[tarfile.TarFile]:
         yield tf
 
 
+def ensure_extract_target_empty(target: Path) -> None:
+    """Reject archive extraction into non-empty or unsafe targets."""
+    if target.is_symlink():
+        raise ArchiveError("Cannot extract archive into an existing symlink target.")
+    if not target.exists():
+        return
+    if not target.is_dir():
+        raise ArchiveError(
+            "Cannot extract archive into an existing non-directory target."
+        )
+    try:
+        target_has_files = any(target.iterdir())
+    except OSError as exc:
+        raise ArchiveError(
+            f"Cannot inspect target before archive extraction: {target}"
+        ) from exc
+    if target_has_files:
+        raise ArchiveError(
+            "Cannot extract archive into a non-empty target.",
+            hints=["Choose an empty target directory or remove existing files first."],
+        )
+
+
 def extract_archive(archive_path: Path, target: Path) -> Path:
     """Extract *archive_path* into *target* with path traversal protection.
 
     Every member is validated before extraction. On Python 3.12+ the
     ``filter="data"`` parameter provides additional defense-in-depth.
     """
+    ensure_extract_target_empty(target)
     target = target.resolve()
     target.mkdir(parents=True, exist_ok=True)
 

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -17,6 +17,7 @@ from ...archive import (
     collect_archive_files,
     collect_bundle_packages,
     create_archive,
+    ensure_extract_target_empty,
     extract_archive,
     inspect_archive,
     prime_package_cache,
@@ -148,29 +149,6 @@ def receipt_environment_prefixes(
     return prefixes
 
 
-def ensure_verified_target_empty(target: Path) -> None:
-    """Reject verified extraction into non-empty or unsafe targets."""
-    if not target.exists():
-        return
-    if target.is_symlink():
-        raise ArchiveError("Cannot verify receipt into an existing symlink target.")
-    if not target.is_dir():
-        raise ArchiveError(
-            "Cannot verify receipt into an existing non-directory target."
-        )
-    try:
-        target_has_files = any(target.iterdir())
-    except OSError as exc:
-        raise ArchiveError(
-            f"Cannot inspect target before verified extraction: {target}"
-        ) from exc
-    if target_has_files:
-        raise ArchiveError(
-            "Cannot verify receipt into a non-empty target.",
-            hints=["Choose an empty target directory or remove existing files first."],
-        )
-
-
 def extract_verified_archive(
     archive_path: Path,
     target: Path,
@@ -179,8 +157,8 @@ def extract_verified_archive(
     require_sha256: bool = False,
 ) -> None:
     """Extract to a staging directory, verify, then move into *target*."""
+    ensure_extract_target_empty(target)
     target = target.resolve()
-    ensure_verified_target_empty(target)
     target.parent.mkdir(parents=True, exist_ok=True)
     staged = Path(tempfile.mkdtemp(prefix=f".{target.name}.verify-", dir=target.parent))
     try:
@@ -391,7 +369,6 @@ def execute_unarchive(
                 stem = stem[: -len(suffix)]
                 break
         target = Path.cwd() / stem
-    target = target.resolve()
 
     info = inspect_archive(archive_path)
 
@@ -449,7 +426,7 @@ def execute_unarchive(
     )
 
     if receipt is None:
-        extract_archive(archive_path, target)
+        target = extract_archive(archive_path, target)
     else:
         extract_verified_archive(
             archive_path,
@@ -457,6 +434,7 @@ def execute_unarchive(
             receipt,
             require_sha256=getattr(args, "require_sha256", False),
         )
+        target = target.resolve()
 
     status.message(console, "Extracted", "archive", str(target))
     if receipt is not None:

--- a/docs/features.md
+++ b/docs/features.md
@@ -796,6 +796,9 @@ Extract an archive and install environments in one step:
 conda workspace unarchive my-project.tar.zst --target ./restored --install
 ```
 
+The extraction target must be empty or absent. Existing files are not
+overwritten.
+
 Install one archived environment to a final runtime prefix, optionally
 under a staged filesystem root:
 

--- a/docs/tutorials/archives.md
+++ b/docs/tutorials/archives.md
@@ -80,6 +80,9 @@ location:
 conda workspace unarchive my-project.tar.zst --target /path/to/destination
 ```
 
+The target directory must be empty or absent. `unarchive` refuses to
+extract over existing files.
+
 After extraction, install the environments from the lockfile:
 
 ```bash

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -6,6 +6,7 @@ import json
 import tarfile
 from io import StringIO
 from pathlib import Path, PureWindowsPath
+from typing import TYPE_CHECKING
 
 import pytest
 from rich.console import Console
@@ -25,6 +26,9 @@ from conda_workspaces.exceptions import ArchiveError
 from conda_workspaces.receipts import ArchiveReceipt
 
 from ..conftest import make_args
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _ARCHIVE_DEFAULTS = {
     "file": None,
@@ -492,15 +496,18 @@ def test_execute_unarchive_receipt_detects_tampered_archive(
         )
 
 
+@pytest.mark.parametrize("receipt", [False, True], ids=["unsigned", "receipt"])
 @pytest.mark.parametrize(
     "target_setup",
     ["non-empty", "file-target", "symlink-target"],
     ids=["non-empty", "file-target", "symlink-target"],
 )
-def test_execute_unarchive_receipt_rejects_existing_target(
+def test_execute_unarchive_rejects_existing_target(
     archive_workspace: Path,
+    existing_extract_target: Callable[[str], Path],
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    receipt: bool,
     target_setup: str,
 ) -> None:
     monkeypatch.chdir(archive_workspace)
@@ -508,28 +515,26 @@ def test_execute_unarchive_receipt_rejects_existing_target(
     console = Console(file=StringIO(), width=200, highlight=False)
 
     execute_archive(
-        make_args(_ARCHIVE_DEFAULTS, output=archive, receipt=True),
+        make_args(_ARCHIVE_DEFAULTS, output=archive, receipt=receipt),
         console=console,
     )
-    target = tmp_path / "extracted"
-    if target_setup == "non-empty":
-        target.mkdir()
-        (target / "existing.txt").write_text("x", encoding="utf-8")
-    elif target_setup == "file-target":
-        target.write_text("x", encoding="utf-8")
-    else:
-        target.symlink_to(tmp_path)
+    target = existing_extract_target(target_setup)
 
-    with pytest.raises(ArchiveError, match="Cannot verify receipt"):
+    with pytest.raises(ArchiveError, match="Cannot extract archive"):
         execute_unarchive(
             make_args(
                 _UNARCHIVE_DEFAULTS,
                 archive_path=archive,
                 target=target,
-                receipt=True,
+                receipt=receipt,
             ),
             console=console,
         )
+
+    if target_setup == "non-empty":
+        assert (target / "conda.toml").read_text(encoding="utf-8") == "trusted = true\n"
+    elif target_setup == "file-target":
+        assert target.read_text(encoding="utf-8") == "trusted file\n"
 
 
 def test_execute_unarchive_require_sha256_requires_receipt(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,12 @@ class CreateWorkspaceEnv(Protocol):
     def __call__(self, workspace: Path, name: str, *, pkg_count: int = 0) -> Path: ...
 
 
+class ExistingExtractTarget(Protocol):
+    """Callable signature for creating pre-existing extraction targets."""
+
+    def __call__(self, kind: str, *, name: str = "extracted") -> Path: ...
+
+
 @pytest.fixture
 def sample_pixi_toml(tmp_path: Path) -> Path:
     """Create a minimal pixi.toml in tmp_path and return its path."""
@@ -160,6 +166,31 @@ def tmp_workspace_env(tmp_env: TmpEnvFixture) -> Iterator[CreateWorkspaceEnv]:
 def tmp_project(tmp_path: Path) -> Path:
     """A temporary directory acting as a project root."""
     return tmp_path
+
+
+@pytest.fixture
+def existing_extract_target(tmp_path: Path) -> ExistingExtractTarget:
+    """Factory fixture for unsafe archive extraction targets."""
+
+    def _create(kind: str, *, name: str = "extracted") -> Path:
+        target = tmp_path / name
+        if kind == "non-empty":
+            target.mkdir()
+            (target / "conda.toml").write_text("trusted = true\n", encoding="utf-8")
+        elif kind == "file-target":
+            target.write_text("trusted file\n", encoding="utf-8")
+        elif kind == "symlink-target":
+            destination = tmp_path / f"{name}-destination"
+            destination.mkdir()
+            try:
+                target.symlink_to(destination, target_is_directory=True)
+            except (NotImplementedError, OSError) as exc:
+                pytest.skip(f"symlink target setup unavailable: {exc}")
+        else:
+            raise AssertionError(f"unknown extraction target setup: {kind}")
+        return target
+
+    return _create
 
 
 @pytest.fixture

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -32,6 +32,7 @@ from conda_workspaces.exceptions import (
 from conda_workspaces.models import ArchiveConfig
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 
@@ -263,6 +264,47 @@ def test_extract_archive_basic(project_dir: Path, tmp_path: Path) -> None:
     assert (target / "conda.toml").is_file()
     assert (target / "conda.lock").is_file()
     assert (target / "src" / "main.py").is_file()
+
+
+def test_extract_archive_allows_existing_empty_target(
+    project_dir: Path,
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / "test.tar.gz"
+    config = ArchiveConfig()
+    create_archive(project_dir, archive_path, config)
+    target = tmp_path / "extracted"
+    target.mkdir()
+
+    result = extract_archive(archive_path, target)
+
+    assert result == target
+    assert (target / "conda.toml").is_file()
+
+
+@pytest.mark.parametrize(
+    "target_setup",
+    ["non-empty", "file-target", "symlink-target"],
+    ids=["non-empty", "file-target", "symlink-target"],
+)
+def test_extract_archive_rejects_existing_target(
+    project_dir: Path,
+    tmp_path: Path,
+    existing_extract_target: Callable[[str], Path],
+    target_setup: str,
+) -> None:
+    archive_path = tmp_path / "test.tar.gz"
+    config = ArchiveConfig()
+    create_archive(project_dir, archive_path, config)
+    target = existing_extract_target(target_setup)
+
+    with pytest.raises(ArchiveError, match="Cannot extract archive"):
+        extract_archive(archive_path, target)
+
+    if target_setup == "non-empty":
+        assert (target / "conda.toml").read_text(encoding="utf-8") == "trusted = true\n"
+    elif target_setup == "file-target":
+        assert target.read_text(encoding="utf-8") == "trusted file\n"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Reject unarchive targets that already point to a file, symlink, or non-empty directory.
- Share the target validation between regular and receipt-verified extraction paths.
- Add regression coverage for direct extraction and CLI unarchive flows.

## Security
- Prevent archive extraction from overwriting existing files or following unsafe target paths.

## Validation
- `pixi run -e test pytest`
- `pixi run ruff check`
- `pixi run ruff format --check`