### PR TITLE
Exclude sensitive files from non-git archives

### DIFF
--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -70,6 +70,16 @@ BUILTIN_EXCLUDE_DIRS: frozenset[str] = frozenset(
 )
 """Directories excluded from archives regardless of user configuration."""
 
+BUILTIN_SENSITIVE_EXCLUDE_PATTERNS: tuple[str, ...] = (
+    ".env",
+    "*/.env",
+    ".env.local",
+    "*/.env.local",
+    ".env.*.local",
+    "*/.env.*.local",
+)
+"""Credential-bearing dotenv files excluded from archives by default."""
+
 
 def parse_relative_archive_path(
     path: str,
@@ -130,7 +140,7 @@ def is_excluded_by_builtins(rel_path: str) -> bool:
     for excl in BUILTIN_EXCLUDE_DIRS:
         if rel_path == excl or rel_path.startswith(excl + "/"):
             return True
-    return False
+    return is_excluded_by_patterns(rel_path, BUILTIN_SENSITIVE_EXCLUDE_PATTERNS)
 
 
 def is_excluded_by_patterns(rel_path: str, patterns: tuple[str, ...]) -> bool:

--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -73,12 +73,73 @@ BUILTIN_EXCLUDE_DIRS: frozenset[str] = frozenset(
 BUILTIN_SENSITIVE_EXCLUDE_PATTERNS: tuple[str, ...] = (
     ".env",
     "*/.env",
-    ".env.local",
-    "*/.env.local",
-    ".env.*.local",
-    "*/.env.*.local",
+    ".env.*",
+    "*/.env.*",
+    ".aws",
+    "*/.aws",
+    ".azure",
+    "*/.azure",
+    ".config/gcloud",
+    "*/.config/gcloud",
+    ".docker",
+    "*/.docker",
+    ".gnupg",
+    "*/.gnupg",
+    ".kube",
+    "*/.kube",
+    ".ssh",
+    "*/.ssh",
+    ".terraform",
+    "*/.terraform",
+    ".condarc",
+    "*/.condarc",
+    ".git-credentials",
+    "*/.git-credentials",
+    ".netrc",
+    "*/.netrc",
+    ".npmrc",
+    "*/.npmrc",
+    ".pypirc",
+    "*/.pypirc",
+    "id_dsa",
+    "*/id_dsa",
+    "id_ecdsa",
+    "*/id_ecdsa",
+    "id_ed25519",
+    "*/id_ed25519",
+    "id_rsa",
+    "*/id_rsa",
+    "kubeconfig",
+    "*/kubeconfig",
+    "*.kubeconfig",
+    "*.key",
+    "*.keystore",
+    "*.jks",
+    "*.p12",
+    "*.pem",
+    "*.pfx",
+    "*.secret",
+    "*.secrets",
+    "*.tfstate",
+    "*.tfstate.*",
+    "secrets",
+    "*/secrets",
+    "secrets.*",
+    "*/secrets.*",
 )
-"""Credential-bearing dotenv files excluded from archives by default."""
+"""Common credential material excluded from archives by default."""
+
+BUILTIN_SENSITIVE_EXCLUDE_EXCEPTIONS: tuple[str, ...] = (
+    ".env.dist",
+    "*/.env.dist",
+    ".env.example",
+    "*/.env.example",
+    ".env.sample",
+    "*/.env.sample",
+    ".env.template",
+    "*/.env.template",
+)
+"""Documented dotenv examples that are safe to keep in archives."""
 
 
 def parse_relative_archive_path(
@@ -140,6 +201,8 @@ def is_excluded_by_builtins(rel_path: str) -> bool:
     for excl in BUILTIN_EXCLUDE_DIRS:
         if rel_path == excl or rel_path.startswith(excl + "/"):
             return True
+    if is_excluded_by_patterns(rel_path, BUILTIN_SENSITIVE_EXCLUDE_EXCEPTIONS):
+        return False
     return is_excluded_by_patterns(rel_path, BUILTIN_SENSITIVE_EXCLUDE_PATTERNS)
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -417,6 +417,8 @@ Built-in exclusions always apply regardless of this setting:
 - `.conda/envs`
 - `.pixi`
 - `__pycache__`
+- common dotenv secret files such as `.env`, `.env.local`, and
+  `.env.*.local`
 
 CLI `--exclude` flags are combined with manifest exclusions. In git
 repos, only tracked files are considered regardless of exclusion

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -417,8 +417,13 @@ Built-in exclusions always apply regardless of this setting:
 - `.conda/envs`
 - `.pixi`
 - `__pycache__`
-- common dotenv secret files such as `.env`, `.env.local`, and
-  `.env.*.local`
+- common credential material such as `.env`, `.ssh`, `.aws`, `.azure`,
+  `.config/gcloud`, `.docker`, `.gnupg`, `.kube`, `.terraform`,
+  `.npmrc`, `.pypirc`, `.netrc`, private keys, certificate/key bundles,
+  and Terraform state files
+
+Dotenv templates such as `.env.example`, `.env.sample`, `.env.template`,
+and `.env.dist` remain eligible for archives unless excluded explicitly.
 
 CLI `--exclude` flags are combined with manifest exclusions. In git
 repos, only tracked files are considered regardless of exclusion

--- a/docs/features.md
+++ b/docs/features.md
@@ -776,8 +776,8 @@ root using the workspace name as the filename stem. That default name
 must be a single filename segment; use `-o/--output` for other paths.
 
 In git repos, only tracked files are included. Built-in exclusions
-(`.git`, `__pycache__`, `.conda/envs`, `.pixi`, and common dotenv
-secret files such as `.env`) always apply.
+(`.git`, `__pycache__`, `.conda/envs`, `.pixi`, and common credential
+material such as `.env`, `.ssh`, `.aws`, and `.npmrc`) always apply.
 Configure additional exclusions in the manifest:
 
 ```toml

--- a/docs/features.md
+++ b/docs/features.md
@@ -776,7 +776,8 @@ root using the workspace name as the filename stem. That default name
 must be a single filename segment; use `-o/--output` for other paths.
 
 In git repos, only tracked files are included. Built-in exclusions
-(`.git`, `__pycache__`, `.conda/envs`, `.pixi`) always apply.
+(`.git`, `__pycache__`, `.conda/envs`, `.pixi`, and common dotenv
+secret files such as `.env`) always apply.
 Configure additional exclusions in the manifest:
 
 ```toml

--- a/docs/tutorials/archives.md
+++ b/docs/tutorials/archives.md
@@ -62,7 +62,8 @@ conda workspace archive --exclude "benchmarks/**" --exclude "*.csv"
 ```
 
 Both sources are combined. Built-in exclusions (`.git`, `__pycache__`,
-`.conda/envs`, `.pixi`) always apply regardless of configuration.
+`.conda/envs`, `.pixi`, and common dotenv secret files such as `.env`)
+always apply regardless of configuration.
 
 ## Extract an archive
 

--- a/docs/tutorials/archives.md
+++ b/docs/tutorials/archives.md
@@ -62,8 +62,8 @@ conda workspace archive --exclude "benchmarks/**" --exclude "*.csv"
 ```
 
 Both sources are combined. Built-in exclusions (`.git`, `__pycache__`,
-`.conda/envs`, `.pixi`, and common dotenv secret files such as `.env`)
-always apply regardless of configuration.
+`.conda/envs`, `.pixi`, and common credential material such as `.env`,
+`.ssh`, `.aws`, and `.npmrc`) always apply regardless of configuration.
 
 ## Extract an archive
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -155,7 +155,65 @@ def test_collect_files_non_git(project_dir: Path) -> None:
     assert "conda.toml" in rel_paths
     assert "src/main.py" in rel_paths
     assert "data/big.bin" in rel_paths
-    assert ".env" in rel_paths
+    assert ".env" not in rel_paths
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        ".env",
+        ".env.local",
+        ".env.production.local",
+        "nested/.env",
+        "nested/.env.local",
+        "nested/.env.production.local",
+    ],
+    ids=[
+        "dotenv",
+        "dotenv-local",
+        "dotenv-env-local",
+        "nested-dotenv",
+        "nested-dotenv-local",
+        "nested-dotenv-env-local",
+    ],
+)
+def test_collect_files_excludes_default_sensitive_dotenv_files(
+    project_dir: Path,
+    relative_path: str,
+) -> None:
+    path = project_dir / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("SECRET=abc\n", encoding="utf-8")
+
+    config = ArchiveConfig()
+    files = collect_archive_files(project_dir, config)
+    rel_paths = {f.relative_to(project_dir).as_posix() for f in files}
+
+    assert relative_path not in rel_paths
+    assert "conda.toml" in rel_paths
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        ".env.example",
+        "nested/.env.example",
+    ],
+    ids=["example", "nested-example"],
+)
+def test_collect_files_keeps_dotenv_examples(
+    project_dir: Path,
+    relative_path: str,
+) -> None:
+    path = project_dir / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("TOKEN=\n", encoding="utf-8")
+
+    config = ArchiveConfig()
+    files = collect_archive_files(project_dir, config)
+    rel_paths = {f.relative_to(project_dir).as_posix() for f in files}
+
+    assert relative_path in rel_paths
 
 
 def test_collect_files_builtin_exclusions(project_dir: Path) -> None:

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -162,22 +162,74 @@ def test_collect_files_non_git(project_dir: Path) -> None:
     "relative_path",
     [
         ".env",
+        ".env.production",
         ".env.local",
         ".env.production.local",
+        ".aws/credentials",
+        ".azure/msal_token_cache.json",
+        ".config/gcloud/application_default_credentials.json",
+        ".condarc",
+        ".docker/config.json",
+        ".git-credentials",
+        ".gnupg/private-keys-v1.d/key",
+        ".kube/config",
+        ".netrc",
+        ".npmrc",
+        ".pypirc",
+        ".ssh/id_rsa",
+        ".terraform/terraform.tfstate",
+        "app.key",
+        "credentials.p12",
+        "credentials.pfx",
+        "credentials.pem",
+        "identity.jks",
+        "identity.keystore",
+        "kubeconfig",
+        "secret.secret",
+        "secrets",
+        "secrets.yaml",
+        "terraform.tfstate",
+        "terraform.tfstate.backup",
         "nested/.env",
-        "nested/.env.local",
-        "nested/.env.production.local",
+        "nested/.ssh/id_ed25519",
+        "nested/secrets/token.txt",
     ],
     ids=[
         "dotenv",
+        "dotenv-environment",
         "dotenv-local",
         "dotenv-env-local",
+        "aws-credentials",
+        "azure-config",
+        "gcloud-config",
+        "condarc",
+        "docker-config",
+        "git-credentials",
+        "gnupg",
+        "kube-config",
+        "netrc",
+        "npmrc",
+        "pypirc",
+        "ssh-key",
+        "terraform-dir",
+        "key-file",
+        "p12-file",
+        "pfx-file",
+        "pem-file",
+        "jks-file",
+        "keystore-file",
+        "kubeconfig",
+        "secret-extension",
+        "secrets-file",
+        "secrets-yaml",
+        "terraform-state",
+        "terraform-state-backup",
         "nested-dotenv",
-        "nested-dotenv-local",
-        "nested-dotenv-env-local",
+        "nested-ssh-key",
+        "nested-secrets-dir",
     ],
 )
-def test_collect_files_excludes_default_sensitive_dotenv_files(
+def test_collect_files_excludes_default_sensitive_files(
     project_dir: Path,
     relative_path: str,
 ) -> None:
@@ -196,12 +248,25 @@ def test_collect_files_excludes_default_sensitive_dotenv_files(
 @pytest.mark.parametrize(
     "relative_path",
     [
+        ".env.dist",
         ".env.example",
+        ".env.sample",
+        ".env.template",
+        "docs/secrets-guide.md",
         "nested/.env.example",
+        "nested/id_rsa.pub",
     ],
-    ids=["example", "nested-example"],
+    ids=[
+        "dotenv-dist",
+        "dotenv-example",
+        "dotenv-sample",
+        "dotenv-template",
+        "secrets-doc",
+        "nested-dotenv-example",
+        "nested-public-key",
+    ],
 )
-def test_collect_files_keeps_dotenv_examples(
+def test_collect_files_keeps_safe_examples(
     project_dir: Path,
     relative_path: str,
 ) -> None:
@@ -262,6 +327,10 @@ def test_collect_files_custom_exclude(project_dir: Path) -> None:
 
 @pytest.mark.parametrize("suffix", [".tar.gz", ".tar.zst", ".tar.bz2"])
 def test_create_archive(project_dir: Path, tmp_path: Path, suffix: str) -> None:
+    (project_dir / ".npmrc").write_text("//registry.example/:_authToken=secret\n")
+    (project_dir / ".ssh").mkdir()
+    (project_dir / ".ssh" / "id_rsa").write_text("secret\n")
+
     output = tmp_path / "out" / f"project{suffix}"
     config = ArchiveConfig()
     create_archive(project_dir, output, config)
@@ -272,6 +341,9 @@ def test_create_archive(project_dir: Path, tmp_path: Path, suffix: str) -> None:
     assert "conda.toml" in names
     assert "conda.lock" in names
     assert "src/main.py" in names
+    assert ".env" not in names
+    assert ".npmrc" not in names
+    assert ".ssh/id_rsa" not in names
 
 
 def test_create_archive_excludes_self(project_dir: Path) -> None:


### PR DESCRIPTION
## Summary
- Exclude common credential material from non-git workspace archives by default.
- Keep documented template files eligible unless users exclude them explicitly.
- Add archive collection coverage for the archive creation path.

## Validation
- `pixi run -e test pytest`
- `pixi run ruff check`
- `pixi run ruff format --check`
