### PR TITLE
Require archive verification before cache priming

### DIFF
--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -582,15 +582,36 @@ def verify_package_hashes(
 def prime_package_cache(
     extracted_dir: Path,
     cache_dir: Path,
+    *,
+    verified: bool = False,
 ) -> int:
     """Copy bundled packages from an extracted archive into the conda cache.
 
-    Verifies SHA256 hashes against the lockfile before copying.
+    Only copies packages after the archive has been verified by an
+    external integrity record. Package SHA256 hashes are still verified
+    against the extracted lockfile before copying.
     Returns the number of packages added to the cache.
     """
     packages_dir = extracted_dir / "packages"
     if not packages_dir.is_dir():
         return 0
+
+    packages = sorted(
+        path
+        for suffix in CONDA_PACKAGE_SUFFIXES
+        for path in packages_dir.glob(f"*{suffix}")
+    )
+    if not packages:
+        return 0
+    if not verified:
+        raise ArchiveError(
+            "Cannot prime package cache from unverified archive packages.",
+            hints=[
+                "Verify the archive with an external receipt before cache priming.",
+                "Use 'conda workspace unarchive --receipt ...' or extract without"
+                " cache priming.",
+            ],
+        )
 
     lockfile = extracted_dir / "conda.lock"
     if not lockfile.is_file():
@@ -601,14 +622,6 @@ def prime_package_cache(
                 "or rebuild the archive with its lockfile included.",
             ],
         )
-
-    packages = sorted(
-        path
-        for suffix in CONDA_PACKAGE_SUFFIXES
-        for path in packages_dir.glob(f"*{suffix}")
-    )
-    if not packages:
-        return 0
 
     verify_package_hashes(packages, lockfile)
 

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -443,18 +443,23 @@ def execute_unarchive(
     if info["has_packages"]:
         console.print(f"  Archive includes {info['package_count']} bundled packages")
         if not args.no_install:
-            from conda.base.context import context as conda_context
-
-            cache_dir = Path(conda_context.pkgs_dirs[0])
-            count = prime_package_cache(target, cache_dir)
-            if count > 0:
-                status.message(
-                    console,
-                    "Primed",
-                    "packages",
-                    str(count),
-                    detail="into conda cache",
+            if receipt is None:
+                console.print(
+                    "  Skipping package cache priming without verified receipt"
                 )
+            else:
+                from conda.base.context import context as conda_context
+
+                cache_dir = Path(conda_context.pkgs_dirs[0])
+                count = prime_package_cache(target, cache_dir, verified=True)
+                if count > 0:
+                    status.message(
+                        console,
+                        "Primed",
+                        "packages",
+                        str(count),
+                        detail="into conda cache",
+                    )
 
     if args.install:
         install_prefix = Path(final_prefix) if final_prefix is not None else None

--- a/docs/features.md
+++ b/docs/features.md
@@ -822,10 +822,12 @@ conda workspace archive --lock
 
 For offline deployment, `--bundle` includes resolved conda package
 archives (`.conda` or `.tar.bz2`) inside the archive. Package hashes
-are verified against the lockfile on both bundling and extraction:
+are verified against the lockfile on bundling and before receipt-verified
+cache priming:
 
 ```bash
-conda workspace archive --lock --bundle -o offline.tar.zst
+conda workspace archive --lock --bundle --receipt -o offline.tar.zst
+conda workspace unarchive offline.tar.zst --receipt
 ```
 
 For handoff workflows that need a separate integrity record, `--receipt`

--- a/docs/reference/archive-receipts.md
+++ b/docs/reference/archive-receipts.md
@@ -174,4 +174,5 @@ For provenance-sensitive workflows, distribute the receipt through an
 independent trusted channel or sign it with an external signing system.
 For air-gapped workflows, pair `--receipt` with `--bundle` so the
 archive carries the package artifacts and the receipt carries the
-lockfile inventory that should describe them.
+lockfile inventory that should describe them. `unarchive` only primes a
+conda package cache from bundled packages after receipt verification.

--- a/docs/tutorials/archives.md
+++ b/docs/tutorials/archives.md
@@ -230,18 +230,20 @@ conda workspace archive --lock --bundle -o my-project-offline.tar.zst
 This adds a `packages/` directory inside the archive. Package hashes
 are verified against the lockfile before bundling.
 
-On the receiving end, `conda workspace unarchive` detects the bundled
-packages, verifies their hashes, and copies them into the local conda
-cache before installation:
+On the receiving end, pair bundled archives with a receipt when you want
+`conda workspace unarchive` to verify the external integrity record and
+copy bundled packages into the local conda cache before installation:
 
 ```bash
-conda workspace unarchive my-project-offline.tar.zst
-# packages are primed into the conda cache automatically
+conda workspace archive --lock --bundle --receipt -o my-project-offline.tar.zst
+conda workspace unarchive my-project-offline.tar.zst --receipt
+# packages are primed into the conda cache after receipt verification
 cd my-project-offline
 conda workspace install --locked
 ```
 
-Pass `--no-install` to skip cache priming if you only want the files:
+Without a verified receipt, `unarchive` extracts the files but skips
+package cache priming. Pass `--no-install` when you only want the files:
 
 ```bash
 conda workspace unarchive my-project-offline.tar.zst --no-install
@@ -256,9 +258,9 @@ FIFOs) are all rejected. On Python 3.12+ the `filter="data"` parameter
 provides additional defense-in-depth.
 
 When `--bundle` is used, package hashes are verified against the
-lockfile's SHA256 entries both at archive creation and at extraction.
-Packages without a SHA256 entry in the lockfile are rejected instead of
-being copied into the conda package cache.
+lockfile's SHA256 entries at archive creation and before receipt-verified
+cache priming. Packages without a SHA256 entry in the lockfile are
+rejected instead of being copied into the conda package cache.
 
 ### Trust model for bundled archives
 
@@ -271,8 +273,8 @@ packages.
 To guard against this:
 
 - Obtain archives only from trusted sources.
-- When possible, compare the lockfile inside the archive against a
-  separately obtained copy (e.g. from version control).
+- Use `--receipt` and distribute the receipt through a separate trusted
+  channel when bundled packages should prime a conda package cache.
 - Use `conda workspace install --locked` so the solver does not
   silently add packages beyond what the lockfile specifies.
 

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import tarfile
 from io import StringIO
@@ -11,6 +12,7 @@ from typing import TYPE_CHECKING
 import pytest
 from rich.console import Console
 
+from conda_workspaces.archive import create_archive
 from conda_workspaces.cli.workspace.archive import (
     execute_archive,
     execute_unarchive,
@@ -23,6 +25,7 @@ from conda_workspaces.cli.workspace.archive import (
     scan_prefix_references,
 )
 from conda_workspaces.exceptions import ArchiveError
+from conda_workspaces.models import ArchiveConfig
 from conda_workspaces.receipts import ArchiveReceipt
 
 from ..conftest import make_args
@@ -202,6 +205,64 @@ python = ">=3.10"
     (tmp_path / "src").mkdir()
     (tmp_path / "src" / "app.py").write_text("print('hello')\n", encoding="utf-8")
     return tmp_path
+
+
+@pytest.fixture
+def bundled_cli_archive(tmp_path: Path) -> Path:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "conda.toml").write_text(
+        """\
+[workspace]
+name = "archive-test"
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+""",
+        encoding="utf-8",
+    )
+    package_name = "example-1.0-h123.conda"
+    package_content = b"example package"
+    sha256 = hashlib.sha256(package_content).hexdigest()
+    (root / "conda.lock").write_text(
+        f"""\
+version: 1
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/{package_name}
+packages:
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/{package_name}
+    sha256: {sha256}
+    name: example
+    version: "1.0"
+    build: h123
+    subdir: linux-64
+    depends: []
+""",
+        encoding="utf-8",
+    )
+    package_cache = tmp_path / "package-cache"
+    package_cache.mkdir()
+    package_path = package_cache / package_name
+    package_path.write_bytes(package_content)
+
+    archive = tmp_path / "bundled.tar.gz"
+    archive_config = ArchiveConfig()
+    create_archive(root, archive, archive_config, bundle_packages=[package_path])
+    receipt = ArchiveReceipt.build(
+        root=root,
+        archive_path=archive,
+        archive_config=archive_config,
+        manifest_path=root / "conda.toml",
+        lockfile_path=root / "conda.lock",
+        environment_prefixes={"default": ".conda/envs/default"},
+        options={"bundle": True, "lock": False},
+    )
+    receipt.write(ArchiveReceipt.default_path(archive))
+    return archive
 
 
 def test_execute_archive_default(
@@ -493,6 +554,63 @@ def test_execute_unarchive_receipt_detects_tampered_archive(
                 receipt=True,
             ),
             console=console,
+        )
+
+
+@pytest.mark.parametrize(
+    ("receipt", "expected_primed"),
+    [
+        (None, False),
+        (True, True),
+    ],
+    ids=["without-receipt", "with-receipt"],
+)
+def test_execute_unarchive_package_cache_priming_requires_receipt(
+    bundled_cli_archive: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    receipt: object,
+    expected_primed: bool,
+) -> None:
+    calls: list[tuple[Path, Path, bool]] = []
+
+    def fake_prime_package_cache(
+        extracted_dir: Path,
+        cache_dir: Path,
+        *,
+        verified: bool = False,
+    ) -> int:
+        calls.append((extracted_dir, cache_dir, verified))
+        return 1
+
+    monkeypatch.setattr(
+        "conda_workspaces.cli.workspace.archive.prime_package_cache",
+        fake_prime_package_cache,
+    )
+
+    target = tmp_path / f"extracted-{receipt or 'none'}"
+    stream = StringIO()
+    result = execute_unarchive(
+        make_args(
+            _UNARCHIVE_DEFAULTS,
+            archive_path=bundled_cli_archive,
+            target=target,
+            receipt=receipt,
+        ),
+        console=Console(file=stream, width=200, highlight=False),
+    )
+
+    assert result == 0
+    if expected_primed:
+        assert len(calls) == 1
+        extracted_dir, _, verified = calls[0]
+        assert extracted_dir == target.resolve()
+        assert verified is True
+        assert "Primed" in stream.getvalue()
+    else:
+        assert calls == []
+        assert "Skipping package cache priming without verified receipt" in (
+            stream.getvalue()
         )
 
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -613,11 +613,13 @@ def test_create_archive_with_bundle(
     ],
     ids=["conda", "tar-bz2-with-query"],
 )
-def test_prime_package_cache(
+@pytest.mark.parametrize("verified", [False, True], ids=["unverified", "verified"])
+def test_prime_package_cache_requires_verified_archive(
     tmp_path: Path,
     package_name: str,
     url_suffix: str,
     package_content: bytes,
+    verified: bool,
 ) -> None:
     pkg_content = package_content
     sha256 = hashlib.sha256(pkg_content).hexdigest()
@@ -650,7 +652,13 @@ packages:
     cache_dir = tmp_path / "pkgs"
     cache_dir.mkdir()
 
-    count = prime_package_cache(extracted, cache_dir)
+    if not verified:
+        with pytest.raises(ArchiveError, match="unverified archive packages"):
+            prime_package_cache(extracted, cache_dir)
+        assert not (cache_dir / package_name).exists()
+        return
+
+    count = prime_package_cache(extracted, cache_dir, verified=True)
 
     assert count == 1
     assert (cache_dir / package_name).read_bytes() == pkg_content
@@ -700,7 +708,7 @@ packages:
     cache_dir.mkdir()
 
     with pytest.raises(ArchiveHashMismatchError, match="bad-1.0-h000"):
-        prime_package_cache(extracted, cache_dir)
+        prime_package_cache(extracted, cache_dir, verified=True)
 
 
 def test_prime_package_cache_requires_lockfile(tmp_path: Path) -> None:
@@ -713,7 +721,7 @@ def test_prime_package_cache_requires_lockfile(tmp_path: Path) -> None:
     cache_dir.mkdir()
 
     with pytest.raises(ArchiveError, match="require conda.lock"):
-        prime_package_cache(extracted, cache_dir)
+        prime_package_cache(extracted, cache_dir, verified=True)
 
 
 def test_inspect_archive_lightweight(project_dir: Path, tmp_path: Path) -> None:
@@ -798,7 +806,7 @@ def test_archive_roundtrip_with_bundle(
 
     new_cache = tmp_path / "fresh_cache"
     new_cache.mkdir()
-    count = prime_package_cache(target, new_cache)
+    count = prime_package_cache(target, new_cache, verified=True)
     assert count == 2
 
     cached_files = {f.name for f in new_cache.iterdir()}


### PR DESCRIPTION
## Summary
- Skip package cache priming when an archive is extracted without a verified receipt.
- Require verified archive context before trusting bundled package metadata.
- Add regression coverage for cache priming paths.

## Validation
- `pixi run -e test pytest`
- `pixi run ruff check`
- `pixi run ruff format --check`
