### PR TITLE
Preserve task command argument boundaries

### DIFF
--- a/conda_workspaces/cache.py
+++ b/conda_workspaces/cache.py
@@ -85,13 +85,18 @@ def _fingerprint_files(paths: list[str]) -> dict[str, dict[str, Any]]:
 
 
 def _compute_entry(
-    cmd: str,
+    cmd: str | list[str],
     env: dict[str, str],
     input_files: list[str],
     output_files: list[str],
 ) -> dict[str, Any]:
     """Compute a cache entry from current state."""
-    cmd_hash = hashlib.sha256(cmd.encode()).hexdigest()
+    cmd_data = (
+        cmd
+        if isinstance(cmd, str)
+        else json.dumps(cmd, ensure_ascii=True, separators=(",", ":"))
+    )
+    cmd_hash = hashlib.sha256(cmd_data.encode()).hexdigest()
     env_hash = hashlib.sha256(json.dumps(env, sort_keys=True).encode()).hexdigest()
     return {
         "cmd_hash": cmd_hash,
@@ -104,7 +109,7 @@ def _compute_entry(
 def is_cached(
     project_root: Path,
     task_name: str,
-    cmd: str,
+    cmd: str | list[str],
     env: dict[str, str],
     input_patterns: list[str],
     output_patterns: list[str],
@@ -165,7 +170,7 @@ def _files_match(cached: dict[str, Any], current: dict[str, Any]) -> bool:
 def save_cache(
     project_root: Path,
     task_name: str,
-    cmd: str,
+    cmd: str | list[str],
     env: dict[str, str],
     input_patterns: list[str],
     output_patterns: list[str],

--- a/conda_workspaces/cli/task/run.py
+++ b/conda_workspaces/cli/task/run.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from conda.base.context import context
+from conda.utils import quote_for_shell
 from rich.console import Console
 from rich.tree import Tree
 
@@ -14,7 +15,7 @@ from ...exceptions import CondaWorkspacesError, TaskExecutionError
 from ...graph import resolve_execution_order
 from ...manifests import detect_and_parse_tasks
 from ...runner import SubprocessShell
-from ...template import render, render_list
+from ...template import render, render_command, render_list
 from .. import status
 
 if TYPE_CHECKING:
@@ -189,10 +190,16 @@ def execute_run(args: argparse.Namespace, *, console: Console | None = None) -> 
         cmd = task.cmd
         if cmd is None:
             continue
-        if isinstance(cmd, list):
-            cmd = " ".join(cmd)
 
-        cmd = render(cmd, manifest_path=task_file, task_args=current_args)
+        if isinstance(cmd, list):
+            cmd = [
+                render(item, manifest_path=task_file, task_args=current_args)
+                for item in cmd
+            ]
+            display_cmd = quote_for_shell(*cmd)
+        else:
+            cmd = render_command(cmd, manifest_path=task_file, task_args=current_args)
+            display_cmd = cmd
 
         task_env = {
             k: render(v, manifest_path=task_file, task_args=current_args)
@@ -246,7 +253,7 @@ def execute_run(args: argparse.Namespace, *, console: Console | None = None) -> 
                 name,
                 style="bold blue",
                 ellipsis=True,
-                detail=cmd if verbose else None,
+                detail=display_cmd if verbose else None,
             )
         task_count += 1
 
@@ -335,10 +342,16 @@ def _execute_dry_run(
         if cmd is None:
             continue
         if isinstance(cmd, list):
-            cmd = " ".join(cmd)
-        rendered_cmds[name] = render(
-            cmd, manifest_path=task_file, task_args=current_args
-        )
+            rendered_cmds[name] = quote_for_shell(
+                *(
+                    render(item, manifest_path=task_file, task_args=current_args)
+                    for item in cmd
+                )
+            )
+        else:
+            rendered_cmds[name] = render_command(
+                cmd, manifest_path=task_file, task_args=current_args
+            )
 
     if not quiet:
         tree = _build_dry_run_tree(target_name, tasks, rendered_cmds)

--- a/conda_workspaces/runner.py
+++ b/conda_workspaces/runner.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import os
-import subprocess
+import tempfile
 from pathlib import Path
 
 from conda.base.constants import on_win
 from conda.base.context import context
+from conda.gateways.subprocess import subprocess_call
 from conda.utils import wrap_subprocess_call
+
+Command = str | list[str]
 
 
 class SubprocessShell:
@@ -21,7 +24,7 @@ class SubprocessShell:
 
     def run(
         self,
-        cmd: str | list[str],
+        cmd: Command,
         env: dict[str, str],
         cwd: Path,
         conda_prefix: Path | None = None,
@@ -29,9 +32,6 @@ class SubprocessShell:
     ) -> int:
         """Execute *cmd* and return the process exit code."""
         run_env = self._build_env(env, clean_env)
-
-        if isinstance(cmd, list):
-            cmd = " ".join(cmd)
 
         if conda_prefix is not None:
             return self._run_in_env(cmd, run_env, cwd, conda_prefix)
@@ -62,15 +62,25 @@ class SubprocessShell:
         base.update(extra)
         return base
 
-    def _run_direct(self, cmd: str, env: dict[str, str], cwd: Path) -> int:
-        """Run *cmd* in the native shell without conda activation."""
-        shell_cmd = self._shell_command(cmd)
-        result = subprocess.run(shell_cmd, env=env, cwd=str(cwd))
-        return result.returncode
+    def _run_direct(self, cmd: Command, env: dict[str, str], cwd: Path) -> int:
+        """Run *cmd* without conda activation."""
+        script: Path | None = None
+        try:
+            command, script = self._direct_command(cmd)
+            result = subprocess_call(
+                command,
+                env=env,
+                path=cwd,
+                raise_on_error=False,
+                capture_output=False,
+            )
+            return result.rc
+        finally:
+            self._unlink_script(script)
 
     def _run_in_env(
         self,
-        cmd: str,
+        cmd: Command,
         env: dict[str, str],
         cwd: Path,
         conda_prefix: Path,
@@ -85,17 +95,66 @@ class SubprocessShell:
             str(conda_prefix),
             dev_mode,
             debug_wrapper_scripts,
-            self._shell_command(cmd),
+            self._activation_command(cmd),
         )
         try:
-            result = subprocess.run(command, env=env, cwd=str(cwd))
-            return result.returncode
+            result = subprocess_call(
+                command,
+                env=env,
+                path=cwd,
+                raise_on_error=False,
+                capture_output=False,
+            )
+            return result.rc
         finally:
-            if script and Path(script).exists():
-                try:
-                    Path(script).unlink()
-                except OSError:
-                    pass
+            self._unlink_script(Path(script) if script else None)
+
+    @classmethod
+    def _direct_command(cls, cmd: Command) -> tuple[list[str], Path | None]:
+        """Return subprocess argv for a direct command and an optional temp script."""
+        if isinstance(cmd, list):
+            return cmd, None
+        if on_win:
+            script = cls._write_windows_batch(cmd)
+            return ["cmd", "/d", "/c", str(script)], script
+        return cls._shell_command(cmd), None
+
+    @classmethod
+    def _activation_command(cls, cmd: Command) -> list[str]:
+        """Return command arguments for conda's activation wrapper."""
+        if isinstance(cmd, list):
+            return cmd
+        if on_win:
+            return [cls._batch_body(cmd)]
+        return cls._shell_command(cmd)
+
+    @classmethod
+    def _write_windows_batch(cls, cmd: str) -> Path:
+        """Write *cmd* to a temporary batch script and return its path."""
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            suffix=".bat",
+            delete=False,
+        ) as handle:
+            handle.write("@ECHO OFF\n")
+            handle.write(cls._batch_body(cmd))
+            handle.write('SET "_CONDA_WORKSPACES_RC=%ERRORLEVEL%"\n')
+            handle.write("EXIT /B %_CONDA_WORKSPACES_RC%\n")
+            return Path(handle.name)
+
+    @staticmethod
+    def _batch_body(cmd: str) -> str:
+        """Return *cmd* with a final newline for raw batch-script insertion."""
+        return cmd if cmd.endswith("\n") else f"{cmd}\n"
+
+    @staticmethod
+    def _unlink_script(script: Path | None) -> None:
+        if script and script.exists():
+            try:
+                script.unlink()
+            except OSError:
+                pass
 
     @staticmethod
     def _shell_command(cmd: str) -> list[str]:

--- a/conda_workspaces/template.py
+++ b/conda_workspaces/template.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
+from conda.utils import quote_for_shell
+
 from .context import build_template_context
 
 if TYPE_CHECKING:
@@ -42,6 +44,25 @@ def render(
         ctx.update(extra_context)
     tpl = env.from_string(template_str)
     return tpl.render(ctx)
+
+
+def render_command(
+    template_str: str,
+    manifest_path: Path | None = None,
+    task_args: dict[str, str] | None = None,
+) -> str:
+    """Render a shell command template with task arguments shell-quoted.
+
+    Command strings are executed through the native shell, so named task
+    arguments are data values that must occupy one shell word when they
+    are interpolated.
+    """
+    quoted_args = (
+        {key: quote_for_shell(str(value)) for key, value in task_args.items()}
+        if task_args
+        else None
+    )
+    return render(template_str, manifest_path=manifest_path, task_args=quoted_args)
 
 
 def render_list(

--- a/tests/cli/task/test_run.py
+++ b/tests/cli/task/test_run.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 
 import pytest
+from conda.utils import quote_for_shell
 
 import conda_workspaces.cli.task.run as run_mod
 from conda_workspaces.cli.task.run import _resolve_task_args, execute_run
@@ -187,15 +189,98 @@ def test_execute_run_alias_quiet(tmp_path, capsys, fake_shell):
     assert capsys.readouterr().out == ""
 
 
-def test_execute_run_list_command(tmp_path, capsys):
-    """List-form commands are joined for dry-run display."""
+@pytest.mark.parametrize(
+    ("task_body", "expected"),
+    [
+        ('[tasks]\nbuild = "cmake --build ."\n', "cmake --build ."),
+        ('[tasks.build]\ncmd = ["cmake", "--build", "."]\n', "cmake --build ."),
+    ],
+    ids=["shell-string", "argv-list"],
+)
+def test_execute_run_dry_run_command_display(tmp_path, capsys, task_body, expected):
+    """Dry-run shows shell strings and list-form argv commands readably."""
     task_file = tmp_path / "conda.toml"
-    task_file.write_text('[tasks]\nbuild = "cmake --build ."\n')
+    task_file.write_text(task_body)
 
     result = execute_run(_run_args(task_file, task_name="build", dry_run=True))
     assert result == 0
     output = capsys.readouterr().out
-    assert "cmake --build ." in output
+    assert expected in output
+
+
+@pytest.mark.parametrize(
+    ("task_body", "task_name", "task_args", "expected_cmd"),
+    [
+        (
+            (
+                '[tasks.test]\ncmd = "python -m pytest {{ target }}"\n'
+                'args = [{ arg = "target" }]\n'
+            ),
+            "test",
+            ["tests/unit; echo ARG_PWN"],
+            f"python -m pytest {quote_for_shell('tests/unit; echo ARG_PWN')}",
+        ),
+        (
+            '[tasks.build]\ncmd = ["python", "-c", "print(1); echo ARRAY_PWN"]\n',
+            "build",
+            [],
+            ["python", "-c", "print(1); echo ARRAY_PWN"],
+        ),
+    ],
+    ids=["shell-template-arg-quoted", "argv-list-preserved"],
+)
+def test_execute_run_command_contract(
+    tmp_path,
+    fake_shell,
+    task_body,
+    task_name,
+    task_args,
+    expected_cmd,
+):
+    """Task run quotes shell-template args and preserves argv-list commands."""
+    task_file = tmp_path / "conda.toml"
+    task_file.write_text(task_body)
+
+    result = execute_run(_run_args(task_file, task_name=task_name, task_args=task_args))
+
+    assert result == 0
+    assert fake_shell.calls[0][0] == expected_cmd
+
+
+@pytest.mark.parametrize(
+    "command_form",
+    ["shell-template-arg", "argv-list"],
+    ids=["shell-template-arg", "argv-list"],
+)
+def test_execute_run_treats_task_values_as_data(tmp_path, command_form):
+    """Task values with shell metacharacters are passed as data."""
+    recorder = (
+        "from pathlib import Path; import sys; Path('seen.txt').write_text(sys.argv[1])"
+    )
+    pwned = "from pathlib import Path; Path('pwned.txt').write_text('bad')"
+    payload = f'safe & python -c "{pwned}"'
+    task_file = tmp_path / "conda.toml"
+    if command_form == "shell-template-arg":
+        command = f'python -c "{recorder}" {{{{ value }}}}'
+        task_file.write_text(
+            "[tasks.probe]\n"
+            f"cmd = {json.dumps(command)}\n"
+            'args = [{ arg = "value" }]\n'
+        )
+        task_args = [payload]
+    else:
+        task_file.write_text(
+            f"[tasks.probe]\ncmd = {json.dumps(['python', '-c', recorder, payload])}\n"
+        )
+        task_args = []
+
+    result = execute_run(
+        _run_args(task_file, task_name="probe", task_args=task_args, cwd=tmp_path)
+    )
+
+    assert result == 0
+    assert (tmp_path / "seen.txt").read_text() == payload
+    assert not (tmp_path / "pwned.txt").exists()
 
 
 def test_execute_run_single_zero_chrome(tmp_path, capsys, fake_shell):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -99,7 +99,15 @@ def test_not_cached_initially(tmp_path):
     )
 
 
-def test_save_and_check(tmp_path):
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "make",
+        ["python", "-c", "print(1); echo ARRAY_PWN"],
+    ],
+    ids=["shell-string", "argv-list"],
+)
+def test_save_and_check(tmp_path, cmd):
     src = tmp_path / "main.py"
     src.write_text("print('hello')")
     dist = tmp_path / "dist"
@@ -109,7 +117,7 @@ def test_save_and_check(tmp_path):
     save_cache(
         tmp_path,
         "build",
-        "make",
+        cmd,
         {},
         ["main.py"],
         ["dist/*.whl"],
@@ -118,7 +126,7 @@ def test_save_and_check(tmp_path):
     assert is_cached(
         tmp_path,
         "build",
-        "make",
+        cmd,
         {},
         ["main.py"],
         ["dist/*.whl"],
@@ -131,12 +139,20 @@ def test_save_and_check(tmp_path):
     [
         ("make", {}, "make", {}, "input"),
         ("make", {}, "make all", {}, None),
+        (
+            ["python", "-m", "pytest"],
+            {},
+            ["python", "-m", "pytest", "tests/unit"],
+            {},
+            None,
+        ),
         ("make", {"CC": "gcc"}, "make", {"CC": "clang"}, None),
         ("make", {}, "make", {}, "delete_output"),
     ],
     ids=[
         "input-change",
         "cmd-change",
+        "argv-cmd-change",
         "env-change",
         "missing-output",
     ],

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from conda.base.constants import on_win
 
@@ -89,6 +91,77 @@ def test_list_command(tmp_path):
     assert exit_code == 0
 
 
+@pytest.mark.parametrize(
+    ("cmd", "expected_command"),
+    [
+        ("echo hi", SubprocessShell._shell_command("echo hi")),
+        (
+            ["python", "-c", "print(1); echo ARRAY_PWN"],
+            ["python", "-c", "print(1); echo ARRAY_PWN"],
+        ),
+    ],
+    ids=["shell-string", "argv-list"],
+)
+def test_run_direct_command_contract(tmp_path, monkeypatch, cmd, expected_command):
+    import types
+
+    import conda_workspaces.runner as runner_mod
+
+    calls: list[tuple] = []
+    script_bodies: list[str] = []
+
+    def fake_subprocess_call(command, **kwargs):
+        calls.append((command, kwargs))
+        if isinstance(cmd, str) and on_win:
+            script_bodies.append(Path(command[3]).read_text())
+        return types.SimpleNamespace(rc=0)
+
+    monkeypatch.setattr(runner_mod, "subprocess_call", fake_subprocess_call)
+
+    shell = SubprocessShell()
+    exit_code = shell.run(cmd, {}, tmp_path)
+
+    assert exit_code == 0
+    if isinstance(cmd, str) and on_win:
+        assert calls[0][0][:3] == ["cmd", "/d", "/c"]
+        assert script_bodies[0].startswith("@ECHO OFF\n")
+        assert "echo hi\n" in script_bodies[0]
+        assert not Path(calls[0][0][3]).exists()
+    else:
+        assert calls[0][0] == expected_command
+    assert calls[0][1]["capture_output"] is False
+
+
+def test_run_direct_windows_string_uses_batch_script(tmp_path, monkeypatch):
+    import types
+
+    import conda_workspaces.runner as runner_mod
+
+    calls: list[tuple] = []
+    script_bodies: list[str] = []
+
+    def fake_subprocess_call(command, **kwargs):
+        calls.append((command, kwargs))
+        script_bodies.append(Path(command[3]).read_text())
+        return types.SimpleNamespace(rc=0)
+
+    monkeypatch.setattr(runner_mod, "on_win", True)
+    monkeypatch.setattr(runner_mod, "subprocess_call", fake_subprocess_call)
+
+    shell = SubprocessShell()
+    code = shell.run('python -c "print(1)"', {}, tmp_path)
+
+    assert code == 0
+    assert calls[0][0][:3] == ["cmd", "/d", "/c"]
+    assert script_bodies[0] == (
+        "@ECHO OFF\n"
+        'python -c "print(1)"\n'
+        'SET "_CONDA_WORKSPACES_RC=%ERRORLEVEL%"\n'
+        "EXIT /B %_CONDA_WORKSPACES_RC%\n"
+    )
+    assert not Path(calls[0][0][3]).exists()
+
+
 @pytest.mark.skipif(on_win, reason="Unix-only test")
 def test_shell_command_unix():
     result = SubprocessShell._shell_command("echo hi")
@@ -103,9 +176,24 @@ def test_shell_command_windows():
     assert "/c" in result
 
 
-def test_run_in_env(tmp_path, monkeypatch):
-    """_run_in_env delegates to wrap_subprocess_call."""
-    import subprocess as subprocess_mod
+@pytest.mark.parametrize(
+    ("cmd", "expected_arguments"),
+    [
+        ("echo hi", SubprocessShell._shell_command("echo hi")),
+        (
+            ["python", "-c", "print(1); echo ARRAY_PWN"],
+            ["python", "-c", "print(1); echo ARRAY_PWN"],
+        ),
+    ],
+    ids=["shell-string", "argv-list"],
+)
+def test_run_in_env_delegates_to_conda_wrapper(
+    tmp_path,
+    monkeypatch,
+    cmd,
+    expected_arguments,
+):
+    """_run_in_env delegates activation wrapping to conda."""
     import types
 
     import conda_workspaces.runner as runner_mod
@@ -124,24 +212,66 @@ def test_run_in_env(tmp_path, monkeypatch):
         wrap_calls.append(args)
         return (str(script_file), ["echo", "hi"])
 
+    def fake_subprocess_call(*args, **kwargs):
+        return types.SimpleNamespace(rc=0)
+
     monkeypatch.setattr(runner_mod, "context", fake_context)
     monkeypatch.setattr(runner_mod, "wrap_subprocess_call", fake_wrap)
-    monkeypatch.setattr(
-        subprocess_mod,
-        "run",
-        lambda *a, **kw: types.SimpleNamespace(returncode=0),
-    )
+    monkeypatch.setattr(runner_mod, "subprocess_call", fake_subprocess_call)
 
     shell = SubprocessShell()
-    code = shell._run_in_env("echo hi", {}, tmp_path, tmp_path / "envs/test")
+    code = shell._run_in_env(cmd, {}, tmp_path, tmp_path / "envs/test")
 
     assert code == 0
     assert len(wrap_calls) == 1
+    if isinstance(cmd, str) and on_win:
+        assert wrap_calls[0][4] == [SubprocessShell._batch_body(cmd)]
+    else:
+        assert wrap_calls[0][4] == expected_arguments
+
+
+def test_run_in_env_windows_string_uses_activation_script_body(tmp_path, monkeypatch):
+    import types
+
+    import conda_workspaces.runner as runner_mod
+
+    script_file = tmp_path / "activate.bat"
+    script_file.write_text("@ECHO OFF\n")
+
+    fake_context = types.SimpleNamespace(
+        root_prefix=str(tmp_path / "root"),
+        dev=False,
+    )
+    wrap_calls: list[tuple] = []
+
+    def fake_wrap(*args):
+        wrap_calls.append(args)
+        return (str(script_file), ["cmd", "/d", "/c", str(script_file)])
+
+    monkeypatch.setattr(runner_mod, "on_win", True)
+    monkeypatch.setattr(runner_mod, "context", fake_context)
+    monkeypatch.setattr(runner_mod, "wrap_subprocess_call", fake_wrap)
+    monkeypatch.setattr(
+        runner_mod,
+        "subprocess_call",
+        lambda *a, **kw: types.SimpleNamespace(rc=0),
+    )
+
+    shell = SubprocessShell()
+    code = shell._run_in_env(
+        'python -c "print(1)"',
+        {},
+        tmp_path,
+        tmp_path / "envs/test",
+    )
+
+    assert code == 0
+    assert wrap_calls[0][4] == ['python -c "print(1)"\n']
+    assert not script_file.exists()
 
 
 def test_run_in_env_cleans_up_script(tmp_path, monkeypatch):
     """_run_in_env removes the wrapper script after execution."""
-    import subprocess as subprocess_mod
     import types
 
     import conda_workspaces.runner as runner_mod
@@ -161,9 +291,9 @@ def test_run_in_env_cleans_up_script(tmp_path, monkeypatch):
         lambda *a: (str(script_file), ["echo", "hi"]),
     )
     monkeypatch.setattr(
-        subprocess_mod,
-        "run",
-        lambda *a, **kw: types.SimpleNamespace(returncode=0),
+        runner_mod,
+        "subprocess_call",
+        lambda *a, **kw: types.SimpleNamespace(rc=0),
     )
 
     shell = SubprocessShell()

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import pytest
 from conda.base.constants import on_win
 from conda.base.context import context
+from conda.utils import quote_for_shell
 
-from conda_workspaces.template import render, render_list
+import conda_workspaces.template as template_mod
+from conda_workspaces.template import render, render_command, render_list
 
 
 def test_render_no_template_fast_path():
@@ -16,6 +18,65 @@ def test_render_no_template_fast_path():
 def test_render_simple_variable():
     result = render("echo {{ greeting }}", task_args={"greeting": "hi"})
     assert result == "echo hi"
+
+
+@pytest.mark.parametrize(
+    ("template", "task_args", "expected"),
+    [
+        (
+            "python -m pytest {{ target }}",
+            {"target": "tests/unit; echo ARG_PWN"},
+            f"python -m pytest {quote_for_shell('tests/unit; echo ARG_PWN')}",
+        ),
+        (
+            "echo {{ name }}",
+            {"name": "simple"},
+            "echo simple",
+        ),
+    ],
+    ids=["metacharacters", "simple"],
+)
+def test_render_command_quotes_task_args(template, task_args, expected):
+    result = render_command(template, task_args=task_args)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "tests/unit; echo ARG_PWN",
+        '100%^"done',
+    ],
+    ids=["posix-metacharacters", "windows-sensitive"],
+)
+def test_render_command_delegates_task_arg_quoting_to_conda(monkeypatch, value):
+    calls: list[tuple[str, ...]] = []
+
+    def fake_quote_for_shell(*arguments):
+        calls.append(arguments)
+        return f"quoted:{arguments[0]}"
+
+    monkeypatch.setattr(template_mod, "quote_for_shell", fake_quote_for_shell)
+
+    assert (
+        template_mod.render_command(
+            "echo {{ value }}",
+            task_args={"value": value},
+        )
+        == f"echo quoted:{value}"
+    )
+    assert calls == [(value,)]
+
+
+def test_render_command_quotes_multiple_task_args():
+    result = render_command(
+        "cp {{ source }} {{ destination }}",
+        task_args={"source": "dist/app.whl", "destination": "tmp/out; echo ARG_PWN"},
+    )
+    assert result == (
+        f"cp {quote_for_shell('dist/app.whl')} "
+        f"{quote_for_shell('tmp/out; echo ARG_PWN')}"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Preserve list task commands as argv instead of converting them into shell strings.
- Quote templated task arguments when rendering string commands.
- Use stable display and cache keys for string and list command forms.

## Validation
- `pixi run -e test pytest`
- `pixi run ruff check`
- `pixi run ruff format --check`
