### PR TITLE
Validate lockfile merge package metadata

### DIFF
--- a/conda_workspaces/lockfile.py
+++ b/conda_workspaces/lockfile.py
@@ -756,8 +756,9 @@ def merge_lockfiles(paths: Sequence[Path], ctx: WorkspaceContext) -> Path:
     are walked in first-seen order across fragments, platforms in
     alphabetical order within each environment, and top-level
     ``packages`` are emitted in the same order
-    :meth:`CondaLockLoader.compose` would produce (first encounter of
-    each URL wins, iterating env-by-env then platform-by-platform).
+    :meth:`CondaLockLoader.compose` would produce. Duplicate top-level
+    records for the same package URL are accepted only when their
+    metadata matches exactly.
 
     Returns the path to the merged lockfile.
     """
@@ -769,9 +770,10 @@ def merge_lockfiles(paths: Sequence[Path], ctx: WorkspaceContext) -> Path:
 
     env_order: list[str] = []
     env_channels: dict[str, list[dict[str, Any]]] = {}
-    env_platforms: dict[str, dict[str, list[dict[str, str]]]] = {}
+    env_platforms: dict[str, dict[str, list[dict[str, Any]]]] = {}
     seen_pairs: dict[tuple[str, str], Path] = {}
     packages_by_url: dict[str, dict[str, Any]] = {}
+    package_sources_by_url: dict[str, Path] = {}
     manifest_env_channels: dict[str, list[dict[str, str]]] = {}
     manifest_env_channel_urls: dict[str, list[str]] = {}
 
@@ -796,7 +798,20 @@ def merge_lockfiles(paths: Sequence[Path], ctx: WorkspaceContext) -> Path:
             url = record.get("url") or record.get("conda") or record.get("pypi")
             if not url:
                 continue
-            packages_by_url.setdefault(url, record)
+            existing = packages_by_url.get(url)
+            if existing is None:
+                packages_by_url[url] = record
+                package_sources_by_url[url] = path
+            elif existing != record:
+                raise LockfileMergeError(
+                    f"fragment '{path}' has a conflicting package record for "
+                    f"URL '{url}'",
+                    hints=[
+                        "The same package URL must have identical top-level"
+                        " metadata in every fragment.",
+                        f"The first record came from '{package_sources_by_url[url]}'.",
+                    ],
+                )
 
         for env_name, env_data in (data.get("environments") or {}).items():
             channels = list(env_data.get("channels") or [])
@@ -848,13 +863,53 @@ def merge_lockfiles(paths: Sequence[Path], ctx: WorkspaceContext) -> Path:
                         ],
                     )
                 seen_pairs[pair] = path
-                env_platforms[env_name][platform] = list(refs or [])
+                try:
+                    channel_urls = CondaLockLoader.channel_urls_for_env_data(
+                        {"channels": channels},
+                        platform,
+                    )
+                except ValueError as exc:
+                    raise LockfileMergeError(
+                        f"environment '{env_name}' channels in fragment "
+                        f"'{path}' cannot be resolved"
+                    ) from exc
+
+                validated_refs: list[dict[str, Any]] = []
+                for ref in refs or []:
+                    if not isinstance(ref, dict):
+                        continue
+                    url = ref.get("conda")
+                    if not url:
+                        validated_refs.append(ref)
+                        continue
+                    if not isinstance(url, str):
+                        raise LockfileMergeError(
+                            f"environment '{env_name}' contains an invalid "
+                            f"package ref on '{platform}' in fragment '{path}'"
+                        )
+                    if not CondaLockLoader.url_matches_channel(url, channel_urls):
+                        raise LockfileMergeError(
+                            f"package URL '{url}' in environment '{env_name}' "
+                            f"on '{platform}' is not under any declared channel"
+                        )
+                    record = packages_by_url.get(url)
+                    if record is None:
+                        raise LockfileMergeError(
+                            f"package URL '{url}' in environment '{env_name}' "
+                            f"on '{platform}' has no top-level package record"
+                        )
+                    try:
+                        CondaLockLoader.digest_fragment_for_record(record, url)
+                    except ValueError as exc:
+                        raise LockfileMergeError(str(exc)) from exc
+                    validated_refs.append(ref)
+                env_platforms[env_name][platform] = validated_refs
 
     # Rebuild top-level ``packages`` in the same order
     # :meth:`CondaLockLoader.compose` would produce for a single-run
     # solve: iterate envs in first-seen order, platforms alphabetically,
     # then each platform's refs (already sorted by package name by the
-    # producing fragment).  First occurrence of a URL wins.
+    # producing fragment).
     merged_packages: list[dict[str, Any]] = []
     emitted_urls: set[str] = set()
     for env_name in env_order:

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -300,6 +300,8 @@ class _FakePkg:
         self.url = url
 
     def get(self, key: str, default: object = None) -> object:
+        if key == "sha256":
+            return "a" * 64
         return default
 
 
@@ -324,7 +326,8 @@ def fake_solver_factory(monkeypatch: pytest.MonkeyPatch):
             return [
                 _FakePkg(
                     "python",
-                    f"https://example.com/python-{self.name}-{platform}.conda",
+                    "https://conda.anaconda.org/conda-forge/"
+                    f"{platform}/python-{self.name}-{platform}.conda",
                 ),
             ]
 
@@ -1393,9 +1396,10 @@ environments:
     - url: https://conda.anaconda.org/conda-forge
     packages:
       linux-64:
-      - conda: https://example.com/python-linux-64.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-linux-64.conda
 packages:
-- conda: https://example.com/python-linux-64.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-linux-64.conda
+  sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 """,
         encoding="utf-8",
     )
@@ -1409,9 +1413,10 @@ environments:
     - url: https://conda.anaconda.org/different-channel
     packages:
       osx-arm64:
-      - conda: https://example.com/python-osx-arm64.conda
+      - conda: https://conda.anaconda.org/different-channel/osx-arm64/python-osx-arm64.conda
 packages:
-- conda: https://example.com/python-osx-arm64.conda
+- conda: https://conda.anaconda.org/different-channel/osx-arm64/python-osx-arm64.conda
+  sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 """,
         encoding="utf-8",
     )
@@ -1438,6 +1443,137 @@ def test_merge_lockfiles_duplicate_platform(
 
     with pytest.raises(LockfileMergeError, match="present in both"):
         merge_lockfiles([frag_a, frag_b], ctx)
+
+
+@pytest.mark.parametrize(
+    ("second_digest", "match"),
+    [
+        pytest.param("a" * 64, None, id="identical-record"),
+        pytest.param("b" * 64, "conflicting package record", id="conflicting-record"),
+    ],
+)
+def test_merge_lockfiles_package_record_consistency(
+    tmp_path: Path,
+    workspace_ctx_factory: Callable[..., WorkspaceContext],
+    second_digest: str,
+    match: str | None,
+) -> None:
+    """Same-URL package records from fragments must agree exactly."""
+    ctx = workspace_ctx_factory(env_names=["default"])
+    channel = str(Channel("conda-forge"))
+    package_url = f"{channel}/noarch/demo-1.0-0.tar.bz2"
+    frag_a = tmp_path / "conda.lock.linux-64"
+    frag_a.write_text(
+        f"""\
+version: 1
+environments:
+  default:
+    channels:
+    - url: {channel}
+    packages:
+      linux-64:
+      - conda: {package_url}
+packages:
+- conda: {package_url}
+  sha256: {"a" * 64}
+  depends:
+  - python >=3.11
+""",
+        encoding="utf-8",
+    )
+    frag_b = tmp_path / "conda.lock.osx-64"
+    frag_b.write_text(
+        f"""\
+version: 1
+environments:
+  default:
+    channels:
+    - url: {channel}
+    packages:
+      osx-64:
+      - conda: {package_url}
+packages:
+- conda: {package_url}
+  sha256: {second_digest}
+  depends:
+  - python >=3.11
+""",
+        encoding="utf-8",
+    )
+    load_yaml.cache_clear()
+
+    if match is not None:
+        with pytest.raises(LockfileMergeError, match=match):
+            merge_lockfiles([frag_a, frag_b], ctx)
+        return
+
+    merged_path = merge_lockfiles([frag_a, frag_b], ctx)
+    merged = load_yaml(merged_path)
+
+    assert merged["packages"] == [
+        {
+            "conda": package_url,
+            "sha256": "a" * 64,
+            "depends": ["python >=3.11"],
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("packages_block", "package_url", "match"),
+    [
+        pytest.param(
+            "packages: []\n",
+            "https://conda.anaconda.org/conda-forge/linux-64/demo-1.0-0.tar.bz2",
+            "no top-level package record",
+            id="missing-record",
+        ),
+        pytest.param(
+            "packages:\n"
+            "- conda: https://conda.anaconda.org/conda-forge/linux-64/"
+            "demo-1.0-0.tar.bz2\n",
+            "https://conda.anaconda.org/conda-forge/linux-64/demo-1.0-0.tar.bz2",
+            "missing a sha256 or md5 digest",
+            id="missing-digest",
+        ),
+        pytest.param(
+            "packages:\n"
+            "- conda: https://attacker.example/pkgs/linux-64/demo-1.0-0.tar.bz2\n"
+            f"  sha256: {'0' * 64}\n",
+            "https://attacker.example/pkgs/linux-64/demo-1.0-0.tar.bz2",
+            "not under any declared channel",
+            id="off-channel",
+        ),
+    ],
+)
+def test_merge_lockfiles_rejects_unbound_package_refs(
+    tmp_path: Path,
+    workspace_ctx_factory: Callable[..., WorkspaceContext],
+    packages_block: str,
+    package_url: str,
+    match: str,
+) -> None:
+    """Merged env refs must be bound to channel-valid hashed package records."""
+    ctx = workspace_ctx_factory(env_names=["default"])
+    channel = str(Channel("conda-forge"))
+    fragment = tmp_path / "conda.lock.linux-64"
+    fragment.write_text(
+        f"""\
+version: 1
+environments:
+  default:
+    channels:
+    - url: {channel}
+    packages:
+      linux-64:
+      - conda: {package_url}
+{packages_block}""",
+        encoding="utf-8",
+    )
+    load_yaml.cache_clear()
+
+    with pytest.raises(LockfileMergeError, match=match):
+        merge_lockfiles([fragment], ctx)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Validate merged conda package references before writing a combined lockfile.
- Reject conflicting package metadata for the same URL.
- Require merged package references to resolve under a declared channel with complete metadata.

## Validation
- `pixi run -e test pytest`
- `pixi run ruff check`
- `pixi run ruff format --check`