### PR TITLE
Support Pixi named rich platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Pixi-compatible rich platform entries in `[workspace].platforms` now
+  preserve named platforms such as `linux-64-cuda`, generate Pixi-style
+  names for unnamed rich entries, and write lockfile package sections
+  under the declared platform name while solving against the backing
+  conda subdir. (<gh-pr:106>)
 - `conda workspace archive --receipt` now fails before writing an
   archive when archive filters would omit the workspace manifest or
   `conda.lock`, avoiding archive/receipt pairs that cannot verify.

--- a/conda_workspaces/cli/workspace/lock.py
+++ b/conda_workspaces/cli/workspace/lock.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from conda.exceptions import CondaValueError
 from rich.console import Console
 
-from ...exceptions import EnvironmentNotFoundError, PlatformError
+from ...exceptions import EnvironmentNotFoundError
 from ...lockfile import generate_lockfile, merge_lockfiles
 from ...resolver import known_platforms, resolve_all_environments, resolve_environment
 from . import workspace_context_from_args
@@ -93,10 +93,12 @@ def execute_lock(args: argparse.Namespace, *, console: Console | None = None) ->
         # platform set — workspace + feature declarations surfaced via
         # resolved_envs.
         known = known_platforms(config, resolved_envs.values())
+        resolved_platforms: list[str] = []
         for platform in requested_platforms:
-            if platform not in known:
-                raise PlatformError(platform, sorted(known))
-        platforms = tuple(requested_platforms)
+            resolved_platform = config.resolve_platform_name(platform, sorted(known))
+            if resolved_platform not in resolved_platforms:
+                resolved_platforms.append(resolved_platform)
+        platforms = tuple(resolved_platforms)
 
     def _progress(env: str, platform: str) -> None:
         console.print(

--- a/conda_workspaces/export.py
+++ b/conda_workspaces/export.py
@@ -127,6 +127,7 @@ def envs_from_manifest(
     envs: list[Environment] = []
     for platform in targets:
         resolved = resolve_environment(config, env_name, platform)
+        package_platform = resolved.platform_subdir(platform)
 
         requested_packages = [
             MatchSpec(dep.conda_build_form())
@@ -145,7 +146,7 @@ def envs_from_manifest(
         envs.append(
             Environment(
                 name=env_name,
-                platform=platform,
+                platform=package_platform,
                 config=CondaEnvConfig(
                     channels=tuple(ch.canonical_name for ch in resolved.channels),
                 ),

--- a/conda_workspaces/lockfile.py
+++ b/conda_workspaces/lockfile.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 import io
 import sys
 from contextlib import nullcontext
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -54,9 +55,11 @@ from conda.plugins.types import EnvironmentSpecBase
 
 from .exceptions import (
     AllTargetsUnsolvableError,
+    EnvironmentNotFoundError,
     LockfileIntegrityError,
     LockfileMergeError,
     LockfileNotFoundError,
+    PlatformError,
     SolveError,
 )
 from .models import LockfileStatus
@@ -66,7 +69,8 @@ if TYPE_CHECKING:
     from typing import Any, ClassVar, Final
 
     from conda.common.path import PathType
-    from conda.models.environment import Environment
+    from conda.models.environment import Environment, EnvironmentConfig
+    from conda.models.records import PackageRecord
 
     from .context import WorkspaceContext
     from .models import Environment as WorkspaceEnvironment
@@ -92,6 +96,18 @@ ALIASES: Final = ("conda-workspaces-lock", "workspace-lock")
 
 #: Default filenames this plugin handles.
 DEFAULT_FILENAMES: Final = (LOCKFILE_NAME,)
+
+
+@dataclass
+class _SolvedEnvironment:
+    """Solved lockfile row that can carry a Pixi rich-platform name."""
+
+    name: str
+    platform: str
+    package_platform: str
+    config: EnvironmentConfig
+    explicit_packages: Sequence[PackageRecord]
+    external_packages: dict[str, list[str]] = field(default_factory=dict)
 
 
 def lockfile_path(ctx: WorkspaceContext) -> Path:
@@ -165,8 +181,9 @@ def check_lockfile_satisfiability(
             ),
         )
 
-    lock_envs = lockfile_data.get("environments", {})
+    from .resolver import resolve_environment
 
+    lock_envs = lockfile_data.get("environments", {})
     for env_name, env_obj in config.environments.items():
         if env_name not in lock_envs:
             return LockfileStatus(
@@ -198,7 +215,9 @@ def check_lockfile_satisfiability(
             )
 
         lock_platforms = set(lock_env.get("packages", {}))
-        for platform in config.platforms:
+        resolved_platforms = resolve_environment(config, env_name).platforms
+        manifest_platforms = resolved_platforms or config.platforms
+        for platform in manifest_platforms:
             if platform not in lock_platforms:
                 return LockfileStatus(
                     status=_stale,
@@ -210,15 +229,23 @@ def check_lockfile_satisfiability(
                 )
 
         lock_packages = lock_env.get("packages", {})
-        platform_refs = lock_packages.get(current_platform)
+        try:
+            current_lock_platform = config.resolve_platform_name(
+                current_platform,
+                manifest_platforms,
+            )
+        except PlatformError:
+            current_lock_platform = current_platform
+        platform_refs = lock_packages.get(current_lock_platform)
         if platform_refs is None:
             continue
+        package_platform = config.platform_subdir(current_lock_platform)
 
         records_by_url = CondaLockLoader.package_records_by_url_from_data(lockfile_data)
         try:
             channel_urls = CondaLockLoader.channel_urls_for_env_data(
                 lock_env,
-                current_platform,
+                package_platform,
             )
         except ValueError as exc:
             return LockfileStatus(status=_stale, reason=str(exc))
@@ -235,7 +262,7 @@ def check_lockfile_satisfiability(
                     status=_stale,
                     reason=(
                         f"Environment '{env_name}' contains an invalid "
-                        f"package ref on '{current_platform}'"
+                        f"package ref on '{current_lock_platform}'"
                     ),
                 )
             if not CondaLockLoader.url_matches_channel(url, channel_urls):
@@ -243,7 +270,7 @@ def check_lockfile_satisfiability(
                     status=_stale,
                     reason=(
                         f"Package URL '{url}' in environment '{env_name}' "
-                        f"on '{current_platform}' is not under a declared "
+                        f"on '{current_lock_platform}' is not under a declared "
                         "channel"
                     ),
                 )
@@ -263,7 +290,10 @@ def check_lockfile_satisfiability(
             dist = Dist(url)
             locked_versions.setdefault(dist.name, []).append(dist.version)
 
-        manifest_deps = config.merged_conda_dependencies(env_obj, current_platform)
+        manifest_deps = config.merged_conda_dependencies(
+            env_obj,
+            current_lock_platform,
+        )
 
         for dep_name, spec in manifest_deps.items():
             versions = locked_versions.get(dep_name)
@@ -274,7 +304,7 @@ def check_lockfile_satisfiability(
                         f"Dependency '{dep_name}' is required by "
                         f"environment '{env_name}' but not found in "
                         f"the lockfile for platform "
-                        f"'{current_platform}'"
+                        f"'{current_lock_platform}'"
                     ),
                 )
             if not any(VersionSpec(spec.version).match(v) for v in versions):
@@ -283,7 +313,7 @@ def check_lockfile_satisfiability(
                     reason=(
                         f"Dependency '{dep_name}' in environment "
                         f"'{env_name}' requires '{spec}' but no "
-                        f"locked package on '{current_platform}' "
+                        f"locked package on '{current_lock_platform}' "
                         f"satisfies it"
                     ),
                 )
@@ -397,6 +427,8 @@ class CondaLockLoader(EnvironmentSpecBase):
         self,
         platform: str,
         name: str = "default",
+        *,
+        package_platform: str | None = None,
     ) -> list[str]:
         """Return hash-bearing explicit conda specs for *name* on *platform*."""
         env_data = self._env_data(name)
@@ -407,7 +439,10 @@ class CondaLockLoader(EnvironmentSpecBase):
             )
 
         records_by_url = self.package_records_by_url()
-        channel_urls = self.channel_urls_for(env_data, platform)
+        channel_urls = self.channel_urls_for(
+            env_data,
+            package_platform or platform,
+        )
         explicit_specs: list[str] = []
         for ref in platform_refs:
             if not isinstance(ref, dict) or "conda" not in ref:
@@ -546,7 +581,10 @@ class CondaLockLoader(EnvironmentSpecBase):
         return True
 
     @classmethod
-    def compose(cls, envs: Iterable[Environment]) -> dict[str, Any]:
+    def compose(
+        cls,
+        envs: Iterable[Environment | _SolvedEnvironment],
+    ) -> dict[str, Any]:
         """Compose ``Environment`` objects into a ``conda.lock`` dict.
 
         The write-side companion to :meth:`env_for`: same loader class
@@ -559,6 +597,7 @@ class CondaLockLoader(EnvironmentSpecBase):
         different serialiser can reuse the same composition logic
         without re-implementing it.
         """
+        from conda.models.environment import Environment, EnvironmentConfig
         from conda_lockfiles.rattler_lock.v6 import RattlerLockV6Package
         from conda_lockfiles.validate_urls import validate_urls
 
@@ -567,7 +606,6 @@ class CondaLockLoader(EnvironmentSpecBase):
         environments: dict[str, dict[str, Any]] = {}
 
         for env in envs:
-            validate_urls(env, FORMAT)
             # ruamel.yaml dispatches representers by exact type on dict
             # keys, so any ``str`` subclass reaching this point (e.g. a
             # leaked ``tomlkit.items.String``) raises ``TypeError:
@@ -578,6 +616,17 @@ class CondaLockLoader(EnvironmentSpecBase):
             # tests, third parties).
             env_name = str(env.name or "default")
             platform = str(env.platform)
+            package_platform = str(getattr(env, "package_platform", platform))
+            validation_env = env
+            if package_platform != platform:
+                validation_env = Environment(
+                    name=env_name,
+                    platform=package_platform,
+                    config=EnvironmentConfig(channels=tuple(env.config.channels)),
+                    explicit_packages=list(env.explicit_packages),
+                    external_packages=dict(env.external_packages),
+                )
+            validate_urls(validation_env, FORMAT)
 
             if env_name not in environments:
                 environments[env_name] = {
@@ -668,21 +717,28 @@ def generate_lockfile(
 
     Returns the path to the generated lockfile.
     """
-    from conda.models.environment import Environment, EnvironmentConfig
+    from conda.models.environment import EnvironmentConfig
 
     from .export import multiplatform_export
     from .resolver import resolve_environment
 
     host_platform = ctx.platform
-    envs: list[Environment] = []
+    envs: list[_SolvedEnvironment] = []
     failures: list[SolveError] = []
 
     for name, resolved in resolved_envs.items():
-        # Intersect declared platforms with the requested subset.
-        # ``requested=None`` means "lock everything the env declares";
-        # an env with no declared platforms falls back to the host.
-        declared = set(resolved.platforms or [host_platform])
-        targets = sorted(declared if platforms is None else declared & set(platforms))
+        declared = sorted(set(resolved.platforms or [host_platform]))
+        if platforms is None:
+            targets = declared
+        else:
+            targets = []
+            for requested in platforms:
+                try:
+                    target = resolved.resolve_platform_name(requested, declared)
+                except PlatformError:
+                    continue
+                if target not in targets:
+                    targets.append(target)
         if not targets:
             continue
         for target in targets:
@@ -693,10 +749,12 @@ def generate_lockfile(
                 if config is not None
                 else resolved
             )
+            package_platform = target_resolved.platform_subdir(target)
             channels = tuple(str(ch) for ch in target_resolved.channels)
             try:
                 records = target_resolved.solve_for_platform(
-                    target, prefix=ctx.env_prefix(target_resolved.name)
+                    package_platform,
+                    prefix=ctx.env_prefix(target_resolved.name),
                 )
             except SolveError as exc:
                 if not skip_unsolvable:
@@ -706,9 +764,10 @@ def generate_lockfile(
                     on_skip(name, target, exc)
                 continue
             envs.append(
-                Environment(
+                _SolvedEnvironment(
                     name=name,
                     platform=target,
+                    package_platform=package_platform,
                     config=EnvironmentConfig(channels=channels),
                     explicit_packages=records,
                 )
@@ -863,10 +922,11 @@ def merge_lockfiles(paths: Sequence[Path], ctx: WorkspaceContext) -> Path:
                         ],
                     )
                 seen_pairs[pair] = path
+                package_platform = ctx.config.platform_subdir(platform)
                 try:
                     channel_urls = CondaLockLoader.channel_urls_for_env_data(
                         {"channels": channels},
-                        platform,
+                        package_platform,
                     )
                 except ValueError as exc:
                     raise LockfileMergeError(
@@ -969,13 +1029,30 @@ def install_from_lockfile(
         install_explicit_packages,
     )
 
+    from .resolver import resolve_environment
+
     path = lockfile_path(ctx)
     if not path.is_file():
         raise LockfileNotFoundError("(all)", path)
 
     loader = CondaLockLoader(path)
+    lock_platform = ctx.platform
+    package_platform = ctx.platform
     try:
-        urls = loader.explicit_package_specs_for(ctx.platform, env_name)
+        resolved = resolve_environment(ctx.config, env_name)
+        lock_platform = ctx.config.resolve_platform_name(
+            ctx.platform,
+            resolved.platforms or ctx.config.platforms,
+        )
+        package_platform = ctx.config.platform_subdir(lock_platform)
+    except (EnvironmentNotFoundError, PlatformError):
+        pass
+    try:
+        urls = loader.explicit_package_specs_for(
+            lock_platform,
+            env_name,
+            package_platform=package_platform,
+        )
     except (ValueError, OSError) as exc:
         raise LockfileNotFoundError(env_name, path) from exc
 

--- a/conda_workspaces/manifests/base.py
+++ b/conda_workspaces/manifests/base.py
@@ -9,9 +9,11 @@ from functools import lru_cache
 from typing import TYPE_CHECKING
 
 import tomlkit
+from conda.base.constants import KNOWN_SUBDIRS
 from packaging.requirements import InvalidRequirement, Requirement
 
 from ..exceptions import ManifestExistsError, WorkspaceParseError
+from ..models import WorkspaceConfig
 
 _PYPI_NAME_TAIL_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)(.*)$")
 
@@ -24,7 +26,7 @@ if TYPE_CHECKING:
     from tomlkit.container import Container
     from tomlkit.items import InlineTable, Table
 
-    from ..models import Task, WorkspaceConfig
+    from ..models import Task
 
 
 class ManifestParser(ABC):
@@ -241,22 +243,38 @@ class ManifestParser(ABC):
         self,
         raw: Iterable[Any],
         path: Path,
-    ) -> tuple[list[str], dict[str, dict[str, str]]]:
+    ) -> tuple[list[str], dict[str, str], dict[str, dict[str, str]]]:
         """Parse Pixi-compatible workspace platform entries.
 
-        Bare strings remain plain conda subdirs.  Inline tables can add
-        virtual package requirements to that subdir, e.g.
-        ``{ platform = "linux-64", libc = "2.28" }``.  Pixi also
-        supports custom rich-platform names; conda-workspaces still
-        stores lockfile entries by conda subdir, so custom names are
-        rejected instead of being silently discarded.
+        Bare strings remain plain conda subdirs.  Inline tables can
+        add virtual package requirements and optional Pixi rich-platform
+        names, e.g. ``{ name = "linux-64-cuda", platform = "linux-64",
+        cuda = "12" }``.  The returned platform list contains the
+        declared names used by features and lockfiles; ``platform_subdirs``
+        records the concrete conda subdir each name solves against.
         """
         platforms: list[str] = []
+        platform_subdirs: dict[str, str] = {}
         platform_system_requirements: dict[str, dict[str, str]] = {}
+
+        def add_platform(
+            name: str,
+            subdir: str,
+            requirements: dict[str, str],
+        ) -> None:
+            if name in platform_subdirs:
+                raise WorkspaceParseError(
+                    path,
+                    f"Duplicate workspace platform name {name!r}.",
+                )
+            platforms.append(name)
+            platform_subdirs[name] = subdir
+            if requirements:
+                platform_system_requirements[name] = requirements
 
         for item in raw:
             if isinstance(item, str):
-                platforms.append(item)
+                add_platform(item, item, {})
                 continue
             if not isinstance(item, dict):
                 raise WorkspaceParseError(
@@ -264,36 +282,51 @@ class ManifestParser(ABC):
                     "[workspace].platforms entries must be strings or inline tables",
                 )
 
-            subdir = item.get("platform") or item.get("name")
-            if not subdir:
+            raw_subdir = item.get("platform")
+            raw_name = item.get("name")
+            if raw_subdir is None and raw_name is None:
                 raise WorkspaceParseError(
                     path,
                     "Rich platform entries must set `platform` or `name`.",
                 )
-            platform = str(subdir)
-
-            name = item.get("name")
-            if name is not None and "platform" in item and str(name) != platform:
-                raise WorkspaceParseError(
-                    path,
-                    "Custom rich platform names are not supported yet; "
-                    "omit `name` or set it equal to `platform`.",
-                )
-
-            platforms.append(platform)
-
             requirements = {
                 key: value
                 for key, value in item.items()
                 if key in self.rich_platform_system_requirement_keys
                 or str(key).startswith("__")
             }
-            if requirements:
-                platform_system_requirements[platform] = self.parse_system_requirements(
-                    requirements
+            parsed_requirements = self.parse_system_requirements(requirements)
+
+            if raw_subdir is None:
+                subdir = str(raw_name)
+                if subdir not in KNOWN_SUBDIRS:
+                    raise WorkspaceParseError(
+                        path,
+                        "Rich platform entries with custom `name` values "
+                        "must also set `platform`.",
+                    )
+                name = subdir
+            else:
+                subdir = str(raw_subdir)
+                name = (
+                    str(raw_name)
+                    if raw_name is not None
+                    else WorkspaceConfig.synthesize_platform_name(
+                        subdir,
+                        parsed_requirements,
+                    )
                 )
 
-        return platforms, platform_system_requirements
+            if name in KNOWN_SUBDIRS and name != subdir:
+                raise WorkspaceParseError(
+                    path,
+                    "Rich platform entries named after a conda subdir must "
+                    "use the same `platform` value.",
+                )
+
+            add_platform(name, subdir, parsed_requirements)
+
+        return platforms, platform_subdirs, platform_system_requirements
 
     @classmethod
     def for_exporter_format(cls, name: str) -> ManifestParser | None:

--- a/conda_workspaces/manifests/pixi_toml.py
+++ b/conda_workspaces/manifests/pixi_toml.py
@@ -61,7 +61,11 @@ class PixiTomlParser(ManifestParser):
         if not ws:
             raise WorkspaceParseError(path, "No [workspace] or [project] table found")
 
-        platforms, platform_system_requirements = self.parse_workspace_platforms(
+        (
+            platforms,
+            platform_subdirs,
+            platform_system_requirements,
+        ) = self.parse_workspace_platforms(
             ws.get("platforms", []),
             path,
         )
@@ -72,6 +76,7 @@ class PixiTomlParser(ManifestParser):
             description=ws.get("description"),
             channels=parse_channels(ws.get("channels", [])),
             platforms=platforms,
+            platform_subdirs=platform_subdirs,
             platform_system_requirements=platform_system_requirements,
             root=root,
             manifest_path=str(path),

--- a/conda_workspaces/manifests/pyproject_toml.py
+++ b/conda_workspaces/manifests/pyproject_toml.py
@@ -180,7 +180,11 @@ class PyprojectTomlParser(ManifestParser):
 
         ws = source.get("workspace", {})
 
-        platforms, platform_system_requirements = self.parse_workspace_platforms(
+        (
+            platforms,
+            platform_subdirs,
+            platform_system_requirements,
+        ) = self.parse_workspace_platforms(
             ws.get("platforms", []),
             path,
         )
@@ -191,6 +195,7 @@ class PyprojectTomlParser(ManifestParser):
             description=data.get("project", {}).get("description"),
             channels=parse_channels(ws.get("channels", [])),
             platforms=platforms,
+            platform_subdirs=platform_subdirs,
             platform_system_requirements=platform_system_requirements,
             root=root,
             manifest_path=str(path),

--- a/conda_workspaces/models.py
+++ b/conda_workspaces/models.py
@@ -13,10 +13,12 @@ resolution, and spec parsing.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field, fields
 from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from typing import Any
 
 from conda.base.constants import KNOWN_SUBDIRS
@@ -163,6 +165,7 @@ class WorkspaceConfig:
 
     channels: list[Channel] = field(default_factory=list)
     platforms: list[str] = field(default_factory=list)
+    platform_subdirs: dict[str, str] = field(default_factory=dict)
     platform_system_requirements: dict[str, dict[str, str]] = field(
         default_factory=dict
     )
@@ -190,11 +193,33 @@ class WorkspaceConfig:
     channel_priority: str | None = None  # "strict" | "flexible" | "disabled"
     archive: ArchiveConfig = field(default_factory=ArchiveConfig)
 
+    platform_requirement_toml_aliases: ClassVar[dict[str, str]] = {
+        "glibc": "libc",
+        "__glibc": "__glibc",
+        "osx": "macos",
+        "__osx": "__osx",
+        "win": "windows",
+        "__win": "__win",
+    }
+    rich_platform_name_order: ClassVar[tuple[str, ...]] = (
+        "cuda",
+        "archspec",
+        "glibc",
+        "linux",
+        "osx",
+        "win",
+    )
+    _platform_name_segment_re: ClassVar[re.Pattern[str]] = re.compile(r"[^A-Za-z0-9]+")
+
     def __post_init__(self) -> None:
         """Ensure the default feature and environment always exist.
 
-        Also validates that all declared platforms are recognised
-        conda subdirs (e.g. ``linux-64``, ``osx-arm64``).
+        Also validates that all declared platforms map to recognised
+        conda subdirs (e.g. ``linux-64``, ``osx-arm64``).  Pixi rich
+        platforms may use workspace-scoped names such as
+        ``linux-64-cuda``; those names stay in :attr:`platforms`, while
+        :attr:`platform_subdirs` records the concrete conda subdir the
+        solver should use.
         """
         if Feature.DEFAULT_NAME not in self.features:
             self.features[Feature.DEFAULT_NAME] = Feature(name=Feature.DEFAULT_NAME)
@@ -203,12 +228,101 @@ class WorkspaceConfig:
                 name=Environment.DEFAULT_NAME
             )
 
-        invalid = [p for p in self.platforms if p not in KNOWN_SUBDIRS]
+        for platform in self.platforms:
+            self.platform_subdirs.setdefault(platform, platform)
+
+        invalid = [
+            subdir
+            for platform in self.platforms
+            if (subdir := self.platform_subdirs[platform]) not in KNOWN_SUBDIRS
+        ]
         if invalid:
             raise PlatformError(
                 ", ".join(invalid),
                 sorted(KNOWN_SUBDIRS),
             )
+
+    @staticmethod
+    def default_system_requirements_for_subdir(subdir: str) -> dict[str, str]:
+        """Return Pixi's default rich-platform requirements for *subdir*."""
+        if subdir.startswith("linux-"):
+            return {"glibc": "2.28", "linux": "4.18"}
+        if subdir.startswith("osx-"):
+            return {"osx": "13.0"}
+        return {}
+
+    @classmethod
+    def platform_name_segment(cls, value: str) -> str:
+        """Sanitize one rich-platform name segment the way Pixi does."""
+        return cls._platform_name_segment_re.sub("-", value).strip("-")
+
+    @classmethod
+    def synthesize_platform_name(
+        cls,
+        subdir: str,
+        requirements: dict[str, str],
+    ) -> str:
+        """Return Pixi's generated name for an unnamed rich platform."""
+        defaults = cls.default_system_requirements_for_subdir(subdir)
+        segments = [subdir]
+
+        canonical_requirements: dict[str, str] = {}
+        raw_requirements: dict[str, str] = {}
+        for name, value in requirements.items():
+            bare_name = name.removeprefix("__")
+            if bare_name in cls.rich_platform_name_order:
+                canonical_requirements[bare_name] = value
+            else:
+                raw_requirements[name] = value
+
+        for name in cls.rich_platform_name_order:
+            value = canonical_requirements.get(name)
+            if value is None or defaults.get(name) == value:
+                continue
+            key = cls.platform_name_segment(name)
+            val = cls.platform_name_segment(value)
+            if key and val:
+                segments.extend((key, val))
+
+        for name in sorted(raw_requirements):
+            value = raw_requirements[name]
+            key = cls.platform_name_segment(name.removeprefix("__"))
+            val = cls.platform_name_segment(value)
+            if key and val:
+                segments.extend((key, val))
+
+        return "-".join(segment for segment in segments if segment)
+
+    def platform_subdir(self, platform: str) -> str:
+        """Return the concrete conda subdir for a declared platform name."""
+        return self.platform_subdirs.get(platform, platform)
+
+    def platform_names_for_subdir(
+        self,
+        subdir: str,
+        platforms: Iterable[str] | None = None,
+    ) -> list[str]:
+        """Return declared platform names that solve against *subdir*."""
+        candidates = list(platforms or self.platforms)
+        return [
+            platform
+            for platform in candidates
+            if self.platform_subdir(platform) == subdir
+        ]
+
+    def resolve_platform_name(
+        self,
+        requested: str,
+        platforms: Iterable[str] | None = None,
+    ) -> str:
+        """Resolve a requested name or subdir to a declared platform name."""
+        candidates = list(platforms or self.platforms)
+        if requested in candidates:
+            return requested
+        matches = self.platform_names_for_subdir(requested, candidates)
+        if matches:
+            return matches[0]
+        raise PlatformError(requested, sorted(candidates))
 
     def get_environment(self, name: str) -> Environment:
         """Return the environment with *name*, raising if not found."""
@@ -246,10 +360,12 @@ class WorkspaceConfig:
         target-specific dependencies are also merged in.
         """
         merged: dict[str, MatchSpec] = {}
+        platform_keys = self.target_platform_keys(platform)
         for feature in self.resolve_features(environment):
             merged.update(feature.conda_dependencies)
-            if platform and platform in feature.target_conda_dependencies:
-                merged.update(feature.target_conda_dependencies[platform])
+            for key in platform_keys:
+                if key in feature.target_conda_dependencies:
+                    merged.update(feature.target_conda_dependencies[key])
         return merged
 
     def merged_pypi_dependencies(
@@ -259,10 +375,12 @@ class WorkspaceConfig:
     ) -> dict[str, PyPIDependency]:
         """Merge PyPI dependencies across features for *environment*."""
         merged: dict[str, PyPIDependency] = {}
+        platform_keys = self.target_platform_keys(platform)
         for feature in self.resolve_features(environment):
             merged.update(feature.pypi_dependencies)
-            if platform and platform in feature.target_pypi_dependencies:
-                merged.update(feature.target_pypi_dependencies[platform])
+            for key in platform_keys:
+                if key in feature.target_pypi_dependencies:
+                    merged.update(feature.target_pypi_dependencies[key])
         return merged
 
     def merged_system_requirements(
@@ -278,25 +396,35 @@ class WorkspaceConfig:
             merged.update(self.platform_system_requirements[platform])
         return merged
 
+    def target_platform_keys(self, platform: str | None) -> tuple[str, ...]:
+        """Return target table keys that apply to *platform* in merge order."""
+        if platform is None:
+            return ()
+        subdir = self.platform_subdir(platform)
+        if subdir == platform:
+            return (platform,)
+        return (subdir, platform)
+
     def platforms_for_toml(self) -> list[str | dict[str, str]]:
         """Return platforms in a TOML shape compatible with Pixi."""
-        aliases = {
-            "glibc": "libc",
-            "__glibc": "__glibc",
-            "osx": "macos",
-            "__osx": "__osx",
-            "win": "windows",
-            "__win": "__win",
-        }
         result: list[str | dict[str, str]] = []
         for platform in self.platforms:
+            subdir = self.platform_subdir(platform)
             requirements = self.platform_system_requirements.get(platform)
             if not requirements:
-                result.append(platform)
+                if platform == subdir:
+                    result.append(platform)
+                else:
+                    result.append({"name": platform, "platform": subdir})
                 continue
-            entry = {"platform": platform}
+            entry = {"platform": subdir}
+            if platform != self.synthesize_platform_name(subdir, requirements):
+                entry["name"] = platform
             entry.update(
-                {aliases.get(name, name): value for name, value in requirements.items()}
+                {
+                    self.platform_requirement_toml_aliases.get(name, name): value
+                    for name, value in requirements.items()
+                }
             )
             result.append(entry)
         return result

--- a/conda_workspaces/resolver.py
+++ b/conda_workspaces/resolver.py
@@ -41,10 +41,33 @@ class ResolvedEnvironment:
     pypi_dependencies: dict[str, PyPIDependency] = field(default_factory=dict)
     channels: list[Channel] = field(default_factory=list)
     platforms: list[str] = field(default_factory=list)
+    platform_subdirs: dict[str, str] = field(default_factory=dict)
     activation_scripts: list[str] = field(default_factory=list)
     activation_env: dict[str, str] = field(default_factory=dict)
     system_requirements: dict[str, str] = field(default_factory=dict)
     channel_priority: str | None = None
+
+    def platform_subdir(self, platform: str) -> str:
+        """Return the concrete conda subdir for a declared platform name."""
+        return self.platform_subdirs.get(platform, platform)
+
+    def resolve_platform_name(
+        self,
+        requested: str,
+        platforms: Iterable[str] | None = None,
+    ) -> str:
+        """Resolve a requested platform name or subdir to a declared name."""
+        candidates = list(platforms or self.platforms)
+        if requested in candidates:
+            return requested
+        matches = [
+            platform
+            for platform in candidates
+            if self.platform_subdir(platform) == requested
+        ]
+        if matches:
+            return matches[0]
+        raise PlatformError(requested, sorted(candidates))
 
     def system_requirement_version(self, name: str) -> str | None:
         """Look up a system requirement by conda or Pixi-facing virtual name."""
@@ -267,12 +290,15 @@ class ResolvedEnvironment:
         by any caller that needs the same policy.
         """
         declared_set = set(self.platforms) or {fallback}
+        declared = sorted(declared_set)
         if not requested:
-            return tuple(sorted(declared_set))
-        unknown = [p for p in requested if p not in declared_set]
-        if unknown:
-            raise PlatformError(unknown[0], sorted(declared_set))
-        return tuple(p for p in requested if p in declared_set)
+            return tuple(declared)
+        targets: list[str] = []
+        for platform in requested:
+            target = self.resolve_platform_name(platform, declared)
+            if target not in targets:
+                targets.append(target)
+        return tuple(targets)
 
 
 def resolve_environment(
@@ -313,20 +339,34 @@ def resolve_environment(
             )
         resolved_platforms = list(config.platforms)
 
-    if platform and resolved_platforms and platform not in resolved_platforms:
-        raise PlatformError(platform, resolved_platforms)
+    selected_platform = platform
+    if platform and resolved_platforms:
+        selected_platform = config.resolve_platform_name(platform, resolved_platforms)
 
     resolved = ResolvedEnvironment(
         name=env_name,
         channel_priority=config.channel_priority,
         platforms=resolved_platforms,
+        platform_subdirs={
+            platform: config.platform_subdir(platform)
+            for platform in resolved_platforms
+        },
     )
 
     # Merge dependencies
-    resolved.conda_dependencies = config.merged_conda_dependencies(env, platform)
-    resolved.pypi_dependencies = config.merged_pypi_dependencies(env, platform)
+    resolved.conda_dependencies = config.merged_conda_dependencies(
+        env,
+        selected_platform,
+    )
+    resolved.pypi_dependencies = config.merged_pypi_dependencies(
+        env,
+        selected_platform,
+    )
     resolved.channels = config.merged_channels(env)
-    resolved.system_requirements = config.merged_system_requirements(env, platform)
+    resolved.system_requirements = config.merged_system_requirements(
+        env,
+        selected_platform,
+    )
 
     # Merge activation settings
     for feat in features:

--- a/docs/reference/conda-toml-spec.md
+++ b/docs/reference/conda-toml-spec.md
@@ -103,9 +103,30 @@ A *channel* is either:
 - an inline table `{ channel = "<name-or-url>" }`.  Other keys (e.g.
   `priority`) are reserved and currently ignored by this version.
 
-A *platform* is a conda subdir string from the closed enum defined in
-the [JSON schema][schema] under `$defs.platform` (e.g. `linux-64`,
-`osx-arm64`, `win-64`, `noarch`).
+A *platform* is either a conda subdir string from the closed enum
+defined in the [JSON schema][schema] under `$defs.platform` (e.g.
+`linux-64`, `osx-arm64`, `win-64`, `noarch`) or a Pixi-compatible
+rich-platform inline table. Rich-platform tables may set
+`platform = "<subdir>"`, an optional workspace-scoped `name`, and
+virtual package constraints such as `cuda`, `archspec`, `glibc` /
+`libc`, `linux`, `macos` / `osx`, `windows` / `win`, or raw
+`__<virtual-package>` keys.
+
+```toml
+[workspace]
+platforms = [
+  "linux-64",
+  { name = "linux-64-cuda", platform = "linux-64", cuda = "12.0" },
+]
+```
+
+When `name` is omitted, conda-workspaces follows Pixi's
+generated-name style, for example
+`{ platform = "linux-64", cuda = "12.0" }` becomes
+`linux-64-cuda-12-0`. The declared name is used by feature
+`platforms` restrictions and as the `conda.lock` platform key; the
+backing `platform` subdir is used for conda solves and package URL
+validation.
 
 ### `[workspace.dependencies]`
 
@@ -200,8 +221,10 @@ constraints.  Recognised keys mirror conda's virtual-package names
 
 ### `[target.<platform>]`
 
-Per-platform overrides for the default feature.  `<platform>` MUST be
-one of the *platform* values listed above.
+Per-platform overrides for the default feature.  `<platform>` may be
+a declared platform name or the backing conda subdir of a declared rich
+platform. When both match, the subdir target is merged first and the
+declared rich-platform name can override it.
 
 | Field | Type | Description |
 |---|---|---|
@@ -218,7 +241,7 @@ arbitrary identifier referenced from `[environments]`.
 | `dependencies` | conda deps | Conda dependencies for this feature. |
 | `pypi-dependencies` | PyPI deps | PyPI dependencies for this feature. |
 | `channels` | array of *channel* | Additional channels. |
-| `platforms` | array of *platform* | Restrict the feature to these platforms. |
+| `platforms` | array of *platform* | Restrict the feature to these platform names. |
 | `system-requirements` | table | Per-feature system requirements. |
 | `activation` | table | Per-feature activation. |
 | `target` | table of `[target.<platform>]` | Per-platform dep overrides for the feature. |

--- a/docs/tutorials/coming-from/pixi.md
+++ b/docs/tutorials/coming-from/pixi.md
@@ -174,6 +174,21 @@ most cross-compiles resolve without any manifest changes.
 conda's `context._subdir` at the target so `__linux` / `__osx` /
 `__win` virtual packages line up with the target platform.
 
+Pixi-style rich platform entries are accepted in `workspace.platforms`.
+The declared name is used for feature restrictions and lockfile keys,
+while conda solves against the backing subdir:
+
+```toml
+[workspace]
+platforms = [
+  "linux-64",
+  { name = "linux-64-cuda", platform = "linux-64", cuda = "12.0" },
+]
+
+[feature.gpu]
+platforms = ["linux-64-cuda"]
+```
+
 Conservative virtual package baselines are applied automatically:
 solving `linux-64` from macOS seeds `CONDA_OVERRIDE_GLIBC=2.17` for
 the solve, `osx-arm64` targets get `CONDA_OVERRIDE_OSX=11.0`, `osx-64`

--- a/tests/cli/workspace/test_export.py
+++ b/tests/cli/workspace/test_export.py
@@ -299,6 +299,40 @@ def test_export_workspace_lock_multiplatform(
     assert "environments" in data
 
 
+def test_export_workspace_lock_rich_platform_uses_conda_subdir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    export_console: Console,
+) -> None:
+    (tmp_path / "pixi.toml").write_text(
+        """\
+[workspace]
+name = "rich-platform-export"
+channels = ["conda-forge"]
+platforms = [
+  { name = "linux-64-cuda", platform = "linux-64", cuda = "12.0" },
+]
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    output = tmp_path / "conda.lock"
+
+    result = execute_export(
+        make_args(
+            _DEFAULTS,
+            file=output,
+            format="conda-workspaces-lock-v1",
+            export_platforms=["linux-64-cuda"],
+        ),
+        console=export_console,
+    )
+
+    assert result == 0
+    data = yaml_loads(output.read_text(encoding="utf-8"))
+    assert data["environments"]["default"]["packages"] == {"linux-64": []}
+
+
 def test_export_from_lockfile_missing_raises(
     pixi_workspace: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/manifests/test_pixi_toml.py
+++ b/tests/manifests/test_pixi_toml.py
@@ -161,6 +161,95 @@ platforms = [
     }
 
 
+def test_parse_named_rich_platforms(tmp_path):
+    content = """\
+[workspace]
+name = "rich-platform-name-test"
+channels = ["conda-forge"]
+platforms = [
+  { platform = "linux-64", cuda = "12.0", glibc = "2.28" },
+  {name="jetson-nano", platform="linux-aarch64", cuda="12.8", archspec="armv8-a"},
+  { name = "osx-arm64" },
+]
+
+[feature.gpu]
+platforms = ["linux-64-cuda-12-0", "jetson-nano"]
+"""
+    path = tmp_path / "pixi.toml"
+    path.write_text(content, encoding="utf-8")
+
+    config = PixiTomlParser().parse(path)
+
+    assert config.platforms == [
+        "linux-64-cuda-12-0",
+        "jetson-nano",
+        "osx-arm64",
+    ]
+    assert config.platform_subdirs == {
+        "linux-64-cuda-12-0": "linux-64",
+        "jetson-nano": "linux-aarch64",
+        "osx-arm64": "osx-arm64",
+    }
+    assert config.platform_system_requirements == {
+        "linux-64-cuda-12-0": {"cuda": "12.0", "glibc": "2.28"},
+        "jetson-nano": {"cuda": "12.8", "archspec": "armv8-a"},
+    }
+    assert config.features["gpu"].platforms == [
+        "linux-64-cuda-12-0",
+        "jetson-nano",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("platform_entries", "match"),
+    [
+        pytest.param(
+            '  "linux-64",\n  { name = "linux-64", platform = "linux-64" },',
+            "Duplicate workspace platform name",
+            id="duplicate-name",
+        ),
+        pytest.param(
+            "  42,",
+            "strings or inline tables",
+            id="non-table-entry",
+        ),
+        pytest.param(
+            '  { cuda = "12.0" },',
+            "must set `platform` or `name`",
+            id="missing-name-and-platform",
+        ),
+        pytest.param(
+            '  { name = "linux-64-cuda", cuda = "12.0" },',
+            "must also set `platform`",
+            id="custom-name-without-platform",
+        ),
+        pytest.param(
+            '  { name = "osx-arm64", platform = "linux-64" },',
+            "must use the same `platform` value",
+            id="subdir-name-mismatch",
+        ),
+    ],
+)
+def test_parse_invalid_rich_platform_entries(
+    tmp_path,
+    platform_entries: str,
+    match: str,
+) -> None:
+    content = f"""\
+[workspace]
+name = "rich-platform-name-test"
+channels = ["conda-forge"]
+platforms = [
+{platform_entries}
+]
+"""
+    path = tmp_path / "pixi.toml"
+    path.write_text(content, encoding="utf-8")
+
+    with pytest.raises(WorkspaceParseError, match=match):
+        PixiTomlParser().parse(path)
+
+
 def test_parse_target_system_requirements_rejected(tmp_path):
     content = """\
 [workspace]

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -576,6 +576,56 @@ def test_generate_lockfile_resolves_rich_platform_system_requirements(
         assert "CONDA_OVERRIDE_GLIBC" not in observed_overrides[platform]
 
 
+def test_generate_lockfile_uses_named_rich_platform_as_lock_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Named rich platforms solve with the subdir but lock under the name."""
+    config = WorkspaceConfig(
+        name="named-rich-platform-lock",
+        channels=[Channel("conda-forge")],
+        platforms=["linux-64-cuda"],
+        platform_subdirs={"linux-64-cuda": "linux-64"},
+        platform_system_requirements={"linux-64-cuda": {"cuda": "12.0"}},
+        features={"default": Feature(name="default")},
+        environments={"default": Environment(name="default")},
+        root=str(tmp_path),
+        manifest_path=str(tmp_path / "conda.toml"),
+    )
+    ctx = WorkspaceContext(config)
+    ctx._cache["platform"] = "linux-64"
+    resolved_envs = {
+        "default": resolve_environment(config, "default", platform=ctx.platform)
+    }
+    observed: list[tuple[str, dict[str, str]]] = []
+
+    def fake_solve(
+        self: ResolvedEnvironment,
+        platform: str,
+        *,
+        prefix: str | Path,
+    ) -> list[_FakePkg]:
+        observed.append((platform, dict(self.system_requirements)))
+        return [
+            _FakePkg(
+                "python",
+                f"https://conda.anaconda.org/conda-forge/{platform}/python-rich.conda",
+            )
+        ]
+
+    monkeypatch.setattr(ResolvedEnvironment, "solve_for_platform", fake_solve)
+
+    result = generate_lockfile(ctx, resolved_envs, config=config)
+
+    assert observed == [("linux-64", {"cuda": "12.0"})]
+    data = load_yaml(result)
+    packages = data["environments"]["default"]["packages"]
+    assert set(packages) == {"linux-64-cuda"}
+    assert packages["linux-64-cuda"] == [
+        {"conda": ("https://conda.anaconda.org/conda-forge/linux-64/python-rich.conda")}
+    ]
+
+
 def test_generate_lockfile_progress_callback(
     workspace_ctx_factory: Callable[..., WorkspaceContext],
     fake_solver_factory,
@@ -1762,6 +1812,51 @@ def test_satisfiability(
     else:
         assert result.status == LockfileStatus.OUT_OF_DATE
         assert reason_fragment in result.reason.lower()
+
+
+def test_satisfiability_uses_resolved_environment_platforms() -> None:
+    """Feature platform restrictions define required lockfile keys per env."""
+    package_url = (
+        "https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0.conda"
+    )
+    config = WorkspaceConfig(
+        name="rich-platform-sat",
+        channels=[Channel("conda-forge")],
+        platforms=["linux-64", "linux-64-cuda"],
+        platform_subdirs={"linux-64-cuda": "linux-64"},
+        features={
+            "default": Feature(name="default"),
+            "gpu": Feature(name="gpu", platforms=["linux-64-cuda"]),
+        },
+        environments={
+            "default": Environment(name="default"),
+            "gpu": Environment(name="gpu", features=["gpu"]),
+        },
+    )
+    data = {
+        "version": LOCKFILE_VERSION,
+        "environments": {
+            "default": {
+                "channels": [{"url": "https://conda.anaconda.org/conda-forge"}],
+                "packages": {
+                    "linux-64": [{"conda": package_url}],
+                    "linux-64-cuda": [{"conda": package_url}],
+                },
+            },
+            "gpu": {
+                "channels": [{"url": "https://conda.anaconda.org/conda-forge"}],
+                "packages": {
+                    "linux-64-cuda": [{"conda": package_url}],
+                },
+            },
+        },
+        "packages": [{"conda": package_url, "sha256": "a" * 64}],
+    }
+
+    result = check_lockfile_satisfiability(config, data, "linux-64")
+
+    assert result.status == LockfileStatus.UP_TO_DATE
+    assert result.reason == ""
 
 
 def test_satisfiability_ignores_extra_lockfile_envs(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -106,6 +106,37 @@ def test_config_post_init_creates_defaults():
     assert "default" in config.environments
 
 
+@pytest.mark.parametrize(
+    ("subdir", "requirements", "expected"),
+    [
+        pytest.param(
+            "linux-64",
+            {"cuda": "12.0", "glibc": "2.28"},
+            "linux-64-cuda-12-0",
+            id="linux-default-glibc-elided",
+        ),
+        pytest.param(
+            "osx-arm64",
+            {"osx": "13.0"},
+            "osx-arm64",
+            id="osx-default-elided",
+        ),
+        pytest.param(
+            "linux-aarch64",
+            {"archspec": "armv8-a", "__custom": "1.2"},
+            "linux-aarch64-archspec-armv8-a-custom-1-2",
+            id="archspec-and-raw-virtual",
+        ),
+    ],
+)
+def test_config_synthesize_platform_name(
+    subdir: str,
+    requirements: dict[str, str],
+    expected: str,
+) -> None:
+    assert WorkspaceConfig.synthesize_platform_name(subdir, requirements) == expected
+
+
 def test_config_get_environment(sample_config):
     env = sample_config.get_environment("test")
     assert env.name == "test"

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -276,6 +276,40 @@ def test_resolve_system_requirements_with_rich_platform(
     assert resolved.system_requirements == expected
 
 
+def test_resolve_named_rich_platform_from_subdir() -> None:
+    """A host subdir can select a Pixi-named rich platform."""
+    default_feat = Feature(
+        name="default",
+        conda_dependencies={"python": MatchSpec("python")},
+        target_conda_dependencies={"linux-64": {"gcc": MatchSpec("gcc")}},
+    )
+    gpu_feat = Feature(
+        name="gpu",
+        platforms=["linux-64-cuda"],
+        target_conda_dependencies={
+            "linux-64-cuda": {"cuda-version": MatchSpec("cuda-version=12")}
+        },
+    )
+    config = WorkspaceConfig(
+        channels=[Channel("conda-forge")],
+        platforms=["linux-64-cuda"],
+        platform_subdirs={"linux-64-cuda": "linux-64"},
+        platform_system_requirements={"linux-64-cuda": {"cuda": "12.0"}},
+        features={"default": default_feat, "gpu": gpu_feat},
+        environments={
+            "default": Environment(name="default"),
+            "gpu": Environment(name="gpu", features=["gpu"]),
+        },
+    )
+
+    resolved = resolve_environment(config, "gpu", platform="linux-64")
+
+    assert resolved.platforms == ["linux-64-cuda"]
+    assert resolved.platform_subdir("linux-64-cuda") == "linux-64"
+    assert set(resolved.conda_dependencies) == {"python", "gcc", "cuda-version"}
+    assert resolved.system_requirements == {"cuda": "12.0"}
+
+
 @pytest.mark.parametrize(
     "priority, expected",
     [


### PR DESCRIPTION
## Summary
- Preserve Pixi named rich platforms from `[workspace].platforms`, including explicit `name` values and Pixi-style generated names for unnamed rich platform entries.
- Solve named rich platforms against their backing conda subdir while writing `conda.lock` package sections under the declared platform name.
- Update docs, changelog, and regression coverage for parsing, resolving, exporting, locking, and lockfile freshness.

## Upstream context
- Pixi added rich platform support in [prefix-dev/pixi#6178](https://github.com/prefix-dev/pixi/pull/6178) and moved lockfile package records to declared rich platform names in [prefix-dev/pixi#6315](https://github.com/prefix-dev/pixi/pull/6315).

## Testing
- `pixi run ruff check`
- `pixi run ruff format --check conda_workspaces tests`
- `pixi run -e test pytest` (`1287 passed, 1 skipped`)
- `pixi run -e test test-cov` (`1287 passed, 1 skipped`, total coverage `87%`)
- `pixi run ruff format --check` still reports the unrelated untracked `demos/generate-voiceover.py` file would be reformatted.