### PR TITLE
Add WorkspaceArchive public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- Added `conda_workspaces.archive.WorkspaceArchive`, a public Python
+  API for creating, inspecting, verifying, extracting, and installing
+  workspace archives without importing CLI handlers.
 - `conda workspace archive --receipt [PATH]` writes an external
   in-toto Statement JSON receipt for a workspace archive, binding the
   archive, workspace manifest, `conda.lock`, and per-environment

--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -13,8 +13,11 @@ import importlib
 import shutil
 import subprocess
 import tarfile
+import tempfile
 from contextlib import contextmanager
-from pathlib import Path
+from dataclasses import dataclass
+from os.path import expanduser
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
@@ -25,14 +28,15 @@ from .exceptions import (
     ArchiveHashMismatchError,
     ArchivePathTraversalError,
 )
-from .paths import parse_relative_posix_path
+from .paths import has_absolute_path_syntax, is_path_segment, parse_relative_posix_path
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-    from pathlib import PurePosixPath
+    from collections.abc import Callable, Iterator
     from typing import Any
 
+    from .context import WorkspaceContext
     from .models import ArchiveConfig
+    from .receipts import ArchiveReceipt
 
 ARCHIVE_SUFFIXES: tuple[str, ...] = (
     ".tar.zst",
@@ -140,6 +144,561 @@ BUILTIN_SENSITIVE_EXCLUDE_EXCEPTIONS: tuple[str, ...] = (
     "*/.env.template",
 )
 """Documented dotenv examples that are safe to keep in archives."""
+
+
+@dataclass(frozen=True)
+class WorkspaceArchiveExtractResult:
+    """Result returned by :meth:`WorkspaceArchive.extract`."""
+
+    target: Path
+    receipt_path: Path | None
+    verified: bool
+    info: dict[str, object]
+    primed_packages: int = 0
+    cache_priming_skipped: bool = False
+
+
+@dataclass(frozen=True)
+class WorkspaceArchiveInstallResult:
+    """Result returned by :meth:`WorkspaceArchive.install`."""
+
+    target: Path
+    environment: str | None
+    install_prefix: Path | None
+    runtime_prefix: str | None
+    receipt_path: Path | None
+    verified: bool
+    info: dict[str, object]
+    return_code: int = 0
+    primed_packages: int = 0
+    cache_priming_skipped: bool = False
+    prefix_reference_matches: tuple[Path, ...] = ()
+    prefix_reference_matches_truncated: bool = False
+
+
+@dataclass(frozen=True)
+class WorkspaceArchive:
+    """High-level API for creating, extracting, and installing archives."""
+
+    path: Path
+    receipt: bool | str | Path | None = None
+
+    def __init__(self, path: str | Path, receipt: bool | str | Path | None = None):
+        object.__setattr__(self, "path", Path(path).expanduser().resolve())
+        object.__setattr__(self, "receipt", receipt)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        workspace: str | Path | None = None,
+        output: str | Path | None = None,
+        lock: bool = False,
+        bundle: bool = False,
+        exclude: tuple[str, ...] = (),
+        receipt: bool | str | Path | None = None,
+    ) -> WorkspaceArchive:
+        """Create an archive for *workspace* and return its handle."""
+        from .context import WorkspaceContext
+        from .lockfile import generate_lockfile, lockfile_path
+        from .manifests import detect_and_parse
+        from .models import ArchiveConfig
+
+        _, config = detect_and_parse(workspace)
+        ctx = WorkspaceContext(config)
+
+        if lock:
+            from .resolver import resolve_all_environments
+
+            resolved_envs = resolve_all_environments(config, ctx.platform)
+            generate_lockfile(ctx, resolved_envs, config=config)
+
+        archive_config = ArchiveConfig(
+            include=config.archive.include,
+            exclude=config.archive.exclude + tuple(exclude),
+            compression=config.archive.compression,
+            compression_level=config.archive.compression_level,
+        )
+        output_path = cls.default_output_path(ctx, output)
+        archive = cls(output_path, receipt=receipt)
+        receipt_path = archive.receipt_path
+        manifest_path = Path(config.manifest_path)
+        lock_path = lockfile_path(ctx)
+
+        if receipt_path is not None:
+            archive.validate_receipt_inputs(
+                root=ctx.root,
+                output=output_path,
+                archive_config=archive_config,
+                manifest_path=manifest_path,
+                lockfile_path=lock_path,
+                receipt_path=receipt_path,
+            )
+
+        bundle_packages = None
+        if bundle:
+            from conda.base.context import context as conda_context
+
+            if not lock_path.is_file():
+                raise ArchiveError(
+                    "Cannot bundle packages: no conda.lock found.",
+                    hints=["Run 'conda workspace lock' first."],
+                )
+            cache_dirs = [Path(d) for d in conda_context.pkgs_dirs]
+            bundle_packages = collect_bundle_packages(lock_path, cache_dirs)
+            verify_package_hashes(bundle_packages, lock_path)
+
+        archive_path = create_archive(
+            ctx.root,
+            output_path,
+            archive_config,
+            bundle_packages=bundle_packages,
+        )
+
+        if receipt_path is not None:
+            receipt_obj = cls.build_receipt(
+                ctx=ctx,
+                archive_path=archive_path,
+                archive_config=archive_config,
+                manifest_path=manifest_path,
+                lockfile_path=lock_path,
+                options={
+                    "bundle": bundle,
+                    "lock": lock,
+                    "include": list(archive_config.include),
+                    "exclude": list(archive_config.exclude),
+                    "compressionLevel": archive_config.compression_level,
+                },
+            )
+            receipt_obj.write(receipt_path)
+
+        return cls(archive_path, receipt=receipt_path)
+
+    @staticmethod
+    def default_output_path(ctx: WorkspaceContext, output: str | Path | None) -> Path:
+        """Return the explicit or workspace-name-derived output path."""
+        if output is not None:
+            return Path(output)
+
+        name = ctx.config.name or ctx.root.name
+        if not is_path_segment(name):
+            raise ArchiveError(
+                "Workspace name cannot be used as a default archive filename.",
+                hints=[
+                    "Use a simple workspace name without path separators,",
+                    "or pass -o/--output to choose the archive path explicitly.",
+                ],
+            )
+        ext = {"zst": ".tar.zst", "gz": ".tar.gz", "bz2": ".tar.bz2"}.get(
+            ctx.config.archive.compression,
+            ".tar.zst",
+        )
+        return ctx.root / f"{name}{ext}"
+
+    @staticmethod
+    def validate_receipt_inputs(
+        *,
+        root: Path,
+        output: Path,
+        archive_config: ArchiveConfig,
+        manifest_path: Path,
+        lockfile_path: Path,
+        receipt_path: Path,
+    ) -> None:
+        """Validate inputs required to write a receipt for a new archive."""
+        if receipt_path.resolve() == output.resolve():
+            raise ArchiveError(
+                "Receipt path cannot be the archive path.",
+                hints=["Choose a separate JSON path for --receipt."],
+            )
+        if not manifest_path.is_file():
+            raise ArchiveError(
+                "Cannot write receipt: workspace manifest was not found."
+            )
+        if not lockfile_path.is_file():
+            raise ArchiveError(
+                "Cannot write receipt: no conda.lock found.",
+                hints=["Run 'conda workspace lock' first."],
+            )
+
+        archive_members = {
+            path.relative_to(root).as_posix()
+            for path in collect_archive_files(root, archive_config)
+            if path.resolve() != output.resolve()
+        }
+        required_members: dict[str, Path] = {
+            "workspace manifest": manifest_path,
+            "workspace lockfile": lockfile_path,
+        }
+        missing = []
+        for label, path in required_members.items():
+            try:
+                archive_name = path.relative_to(root).as_posix()
+            except ValueError:
+                missing.append(label)
+                continue
+            if archive_name not in archive_members:
+                missing.append(f"{label} ({archive_name})")
+        if missing:
+            raise ArchiveError(
+                f"Cannot write receipt: archive would not include {missing[0]}.",
+                hints=[
+                    "Receipt verification requires the workspace manifest and"
+                    " conda.lock to be included in the archive.",
+                    "Remove matching include/exclude filters or run without --receipt.",
+                ],
+            )
+
+    @staticmethod
+    def build_receipt(
+        *,
+        ctx: WorkspaceContext,
+        archive_path: Path,
+        archive_config: ArchiveConfig,
+        manifest_path: Path,
+        lockfile_path: Path,
+        options: dict[str, object],
+    ) -> ArchiveReceipt:
+        """Build the external receipt for a newly created archive."""
+        from .receipts import ArchiveReceipt
+
+        return ArchiveReceipt.build(
+            root=ctx.root,
+            archive_path=archive_path,
+            archive_config=archive_config,
+            manifest_path=manifest_path,
+            lockfile_path=lockfile_path,
+            environment_prefixes=receipt_environment_prefixes(
+                config_environments=list(ctx.config.environments),
+                ctx_root=ctx.root,
+                env_prefix=ctx.env_prefix,
+            ),
+            options=options,
+        )
+
+    @property
+    def receipt_path(self) -> Path | None:
+        """Return the configured external receipt path, if any."""
+        return resolve_receipt_path(self.path, self.receipt)
+
+    def default_target(self, cwd: str | Path | None = None) -> Path:
+        """Return the default extraction target derived from the archive name."""
+        stem = self.path.name
+        for suffix in ARCHIVE_SUFFIXES:
+            if stem.endswith(suffix):
+                stem = stem[: -len(suffix)]
+                break
+        return Path.cwd() / stem if cwd is None else Path(cwd) / stem
+
+    def inspect(self) -> dict[str, object]:
+        """Return archive metadata without extracting it."""
+        archive_path = self.require_existing_archive()
+        return inspect_archive(archive_path)
+
+    def verify(self) -> ArchiveReceipt:
+        """Verify the archive against its external receipt."""
+        receipt_path = self.receipt_path
+        if receipt_path is None:
+            raise ArchiveError("--receipt is required to verify an archive.")
+        from .receipts import ArchiveReceipt
+
+        receipt = ArchiveReceipt.load(receipt_path)
+        receipt.verify_archive(self.require_existing_archive())
+        return receipt
+
+    def extract(
+        self,
+        *,
+        target: str | Path | None = None,
+        require_sha256: bool = False,
+        prime_cache: bool = True,
+        package_cache: str | Path | None = None,
+    ) -> WorkspaceArchiveExtractResult:
+        """Extract the archive and optionally prime bundled package cache files."""
+        if require_sha256 and self.receipt_path is None:
+            raise ArchiveError("--require-sha256 requires --receipt.")
+
+        archive_path = self.require_existing_archive()
+        info = inspect_archive(archive_path)
+        if not info["has_manifest"]:
+            raise ArchiveError(
+                "Not a workspace archive: no manifest found.",
+                hints=["This does not appear to be a conda workspace archive."],
+            )
+
+        target_path = (
+            Path(target).expanduser() if target is not None else self.default_target()
+        )
+        receipt = self.verify() if self.receipt_path is not None else None
+        if receipt is None:
+            extracted = extract_archive(archive_path, target_path)
+        else:
+            extracted = extract_verified_archive(
+                archive_path,
+                target_path,
+                receipt,
+                require_sha256=require_sha256,
+            )
+
+        primed_packages = 0
+        cache_priming_skipped = False
+        if info["has_packages"] and prime_cache:
+            if receipt is None:
+                cache_priming_skipped = True
+            else:
+                if package_cache is None:
+                    from conda.base.context import context as conda_context
+
+                    package_cache = conda_context.pkgs_dirs[0]
+                primed_packages = prime_package_cache(
+                    extracted,
+                    Path(package_cache),
+                    verified=True,
+                )
+
+        return WorkspaceArchiveExtractResult(
+            target=extracted,
+            receipt_path=self.receipt_path,
+            verified=receipt is not None,
+            info=info,
+            primed_packages=primed_packages,
+            cache_priming_skipped=cache_priming_skipped,
+        )
+
+    def install(
+        self,
+        *,
+        target: str | Path | None = None,
+        environment: str | None = None,
+        prefix: str | Path | None = None,
+        dest: str | Path | None = None,
+        require_sha256: bool = False,
+        prime_cache: bool = True,
+        package_cache: str | Path | None = None,
+        install_handler: Callable[[Path, str | None, Path | None, str | None], int]
+        | None = None,
+    ) -> WorkspaceArchiveInstallResult:
+        """Extract the archive and install environments from its lockfile."""
+        final_prefix = str(prefix) if prefix is not None else None
+        if final_prefix is not None and not environment:
+            raise ArchiveError(
+                "--prefix requires an explicit environment.",
+                hints=["Pass -e/--environment with --prefix."],
+            )
+        if dest is not None and final_prefix is None:
+            raise ArchiveError(
+                "--dest requires --prefix.",
+                hints=[
+                    "Pass --prefix to declare the final runtime prefix for"
+                    " the selected environment.",
+                ],
+            )
+        if final_prefix is not None:
+            final_prefix = expanduser(final_prefix)
+            if not is_absolute_runtime_prefix(final_prefix):
+                raise ArchiveError(
+                    "--prefix must be an absolute path.",
+                    hints=["Pass an absolute runtime prefix such as /opt/runtime."],
+                )
+
+        extract_result = self.extract(
+            target=target,
+            require_sha256=require_sha256,
+            prime_cache=prime_cache,
+            package_cache=package_cache,
+        )
+
+        install_prefix = Path(final_prefix) if final_prefix is not None else None
+        runtime_prefix = None
+        if final_prefix is not None:
+            if dest is not None:
+                dest_path = Path(dest).expanduser().resolve()
+                install_prefix = dest_path / runtime_prefix_relative_path(final_prefix)
+                runtime_prefix = final_prefix
+            elif str(install_prefix) != final_prefix:
+                runtime_prefix = final_prefix
+
+        handler = install_handler or self.install_from_lockfile
+        return_code = handler(
+            extract_result.target,
+            environment,
+            install_prefix,
+            runtime_prefix,
+        )
+
+        prefix_matches: tuple[Path, ...] = ()
+        prefix_matches_truncated = False
+        if (
+            return_code == 0
+            and install_prefix is not None
+            and runtime_prefix is not None
+        ):
+            matches, prefix_matches_truncated = scan_prefix_references(
+                install_prefix,
+                install_prefix,
+            )
+            prefix_matches = tuple(matches)
+
+        return WorkspaceArchiveInstallResult(
+            target=extract_result.target,
+            environment=environment,
+            install_prefix=install_prefix,
+            runtime_prefix=runtime_prefix,
+            receipt_path=extract_result.receipt_path,
+            verified=extract_result.verified,
+            info=extract_result.info,
+            return_code=return_code,
+            primed_packages=extract_result.primed_packages,
+            cache_priming_skipped=extract_result.cache_priming_skipped,
+            prefix_reference_matches=prefix_matches,
+            prefix_reference_matches_truncated=prefix_matches_truncated,
+        )
+
+    @staticmethod
+    def install_from_lockfile(
+        workspace: Path,
+        environment: str | None,
+        prefix: Path | None,
+        target_prefix_override: str | None,
+    ) -> int:
+        """Install workspace environments from ``conda.lock`` without the CLI."""
+        from .context import WorkspaceContext
+        from .lockfile import install_from_lockfile
+        from .manifests import detect_and_parse
+
+        _, config = detect_and_parse(workspace)
+        ctx = WorkspaceContext(config)
+        if environment is not None:
+            install_from_lockfile(
+                ctx,
+                environment,
+                prefix=prefix,
+                target_prefix_override=target_prefix_override,
+            )
+            return 0
+
+        for name in config.environments:
+            install_from_lockfile(ctx, name)
+        return 0
+
+    def require_existing_archive(self) -> Path:
+        """Return *path* after verifying that it points to an archive file."""
+        if not self.path.is_file():
+            raise ArchiveError(f"Archive not found: {self.path}")
+        return self.path
+
+
+def is_absolute_runtime_prefix(prefix: str) -> bool:
+    """Return whether *prefix* is absolute as a POSIX or Windows path."""
+    return has_absolute_path_syntax(prefix)
+
+
+def runtime_prefix_relative_path(prefix: str) -> Path:
+    """Return *prefix* relative to its root using host path separators."""
+    posix_prefix = PurePosixPath(prefix)
+    if posix_prefix.is_absolute():
+        return Path(*posix_prefix.relative_to(posix_prefix.anchor).parts)
+
+    windows_prefix = PureWindowsPath(prefix)
+    return Path(*windows_prefix.relative_to(windows_prefix.anchor).parts)
+
+
+def file_contains_bytes(
+    path: Path, needle: bytes, *, chunk_size: int = 1024 * 1024
+) -> bool:
+    """Return whether *path* contains *needle* without loading it all at once."""
+    if not needle:
+        return False
+
+    overlap = b""
+    try:
+        with path.open("rb") as fh:
+            while chunk := fh.read(chunk_size):
+                data = overlap + chunk
+                if needle in data:
+                    return True
+                overlap = data[-(len(needle) - 1) :] if len(needle) > 1 else b""
+    except OSError:
+        return False
+    return False
+
+
+def scan_prefix_references(
+    root: Path,
+    prefix: Path,
+    *,
+    limit: int = 10,
+) -> tuple[list[Path], bool]:
+    """Find files below *root* that still contain *prefix* as bytes."""
+    if not root.is_dir():
+        return [], False
+
+    needle = str(prefix).encode()
+    matches: list[Path] = []
+    for path in root.rglob("*"):
+        if path.is_symlink() or not path.is_file():
+            continue
+        if file_contains_bytes(path, needle):
+            matches.append(path)
+            if len(matches) > limit:
+                return matches[:limit], True
+    return matches, False
+
+
+def resolve_receipt_path(archive_path: Path, receipt: object) -> Path | None:
+    """Resolve an optional ``--receipt [PATH]`` style value."""
+    if receipt in (None, False):
+        return None
+    if receipt is True:
+        from .receipts import ArchiveReceipt
+
+        return ArchiveReceipt.default_path(archive_path)
+    if isinstance(receipt, Path):
+        return receipt
+    if isinstance(receipt, str):
+        return Path(receipt)
+    raise ArchiveError("Invalid --receipt value.")
+
+
+def receipt_environment_prefixes(
+    *,
+    config_environments: list[str],
+    ctx_root: Path,
+    env_prefix: Callable[[str], Path],
+) -> dict[str, str]:
+    """Return environment prefixes to record in a receipt predicate."""
+    prefixes: dict[str, str] = {}
+    for name in config_environments:
+        prefix = env_prefix(name)
+        try:
+            prefixes[name] = prefix.relative_to(ctx_root).as_posix()
+        except ValueError:
+            prefixes[name] = prefix.as_posix()
+    return prefixes
+
+
+def extract_verified_archive(
+    archive_path: Path,
+    target: Path,
+    receipt: ArchiveReceipt,
+    *,
+    require_sha256: bool = False,
+) -> Path:
+    """Extract to a staging directory, verify, then move into *target*."""
+    ensure_extract_target_empty(target)
+    target = target.resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    staged = Path(tempfile.mkdtemp(prefix=f".{target.name}.verify-", dir=target.parent))
+    try:
+        extract_archive(archive_path, staged)
+        receipt.verify_extracted(staged, require_sha256=require_sha256)
+        if target.exists():
+            target.rmdir()
+        staged.rename(target)
+    except BaseException:
+        shutil.rmtree(staged, ignore_errors=True)
+        raise
+    return target
 
 
 def parse_relative_archive_path(

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -3,93 +3,38 @@
 from __future__ import annotations
 
 import argparse
-import shutil
-import tempfile
-from os.path import expanduser
-from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING
 
 from rich.console import Console
 from rich.markup import escape
 
 from ...archive import (
-    ARCHIVE_SUFFIXES,
-    collect_archive_files,
-    collect_bundle_packages,
-    create_archive,
-    ensure_extract_target_empty,
-    extract_archive,
-    inspect_archive,
-    prime_package_cache,
-    verify_package_hashes,
+    WorkspaceArchive,
+    extract_verified_archive,
+    file_contains_bytes,
+    is_absolute_runtime_prefix,
+    receipt_environment_prefixes,
+    resolve_receipt_path,
+    runtime_prefix_relative_path,
+    scan_prefix_references,
 )
 from ...exceptions import ArchiveError
-from ...lockfile import lockfile_path as _lockfile_path
-from ...models import ArchiveConfig
-from ...paths import has_absolute_path_syntax, is_path_segment
-from ...receipts import ArchiveReceipt
 from .. import status
-from . import workspace_context_from_args
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from pathlib import Path
 
-
-def is_absolute_runtime_prefix(prefix: str) -> bool:
-    """Return whether *prefix* is absolute as a POSIX or Windows path."""
-    return has_absolute_path_syntax(prefix)
-
-
-def runtime_prefix_relative_path(prefix: str) -> Path:
-    """Return *prefix* relative to its root using host path separators."""
-    posix_prefix = PurePosixPath(prefix)
-    if posix_prefix.is_absolute():
-        return Path(*posix_prefix.relative_to(posix_prefix.anchor).parts)
-
-    windows_prefix = PureWindowsPath(prefix)
-    return Path(*windows_prefix.relative_to(windows_prefix.anchor).parts)
-
-
-def file_contains_bytes(
-    path: Path, needle: bytes, *, chunk_size: int = 1024 * 1024
-) -> bool:
-    """Return whether *path* contains *needle* without loading it all at once."""
-    if not needle:
-        return False
-
-    overlap = b""
-    try:
-        with path.open("rb") as fh:
-            while chunk := fh.read(chunk_size):
-                data = overlap + chunk
-                if needle in data:
-                    return True
-                overlap = data[-(len(needle) - 1) :] if len(needle) > 1 else b""
-    except OSError:
-        return False
-    return False
-
-
-def scan_prefix_references(
-    root: Path,
-    prefix: Path,
-    *,
-    limit: int = 10,
-) -> tuple[list[Path], bool]:
-    """Find files below *root* that still contain *prefix* as bytes."""
-    if not root.is_dir():
-        return [], False
-
-    needle = str(prefix).encode()
-    matches: list[Path] = []
-    for path in root.rglob("*"):
-        if path.is_symlink() or not path.is_file():
-            continue
-        if file_contains_bytes(path, needle):
-            matches.append(path)
-            if len(matches) > limit:
-                return matches[:limit], True
-    return matches, False
+__all__ = (
+    "execute_archive",
+    "execute_unarchive",
+    "extract_verified_archive",
+    "file_contains_bytes",
+    "is_absolute_runtime_prefix",
+    "receipt_environment_prefixes",
+    "resolve_receipt_path",
+    "runtime_prefix_relative_path",
+    "scan_prefix_references",
+)
 
 
 def warn_staging_prefix_references(
@@ -97,9 +42,13 @@ def warn_staging_prefix_references(
     *,
     install_prefix: Path,
     runtime_prefix: str,
+    matches: tuple[Path, ...] | None = None,
+    truncated: bool = False,
 ) -> None:
     """Warn when a staged install still contains the physical staging prefix."""
-    matches, truncated = scan_prefix_references(install_prefix, install_prefix)
+    if matches is None:
+        found, truncated = scan_prefix_references(install_prefix, install_prefix)
+        matches = tuple(found)
     if not matches:
         return
 
@@ -119,59 +68,6 @@ def warn_staging_prefix_references(
         console.print("  [dim]additional matches omitted[/dim]")
 
 
-def resolve_receipt_path(archive_path: Path, receipt: object) -> Path | None:
-    """Resolve the optional ``--receipt [PATH]`` argparse value."""
-    if receipt in (None, False):
-        return None
-    if receipt is True:
-        return ArchiveReceipt.default_path(archive_path)
-    if isinstance(receipt, Path):
-        return receipt
-    if isinstance(receipt, str):
-        return Path(receipt)
-    raise ArchiveError("Invalid --receipt value.")
-
-
-def receipt_environment_prefixes(
-    *,
-    config_environments: list[str],
-    ctx_root: Path,
-    env_prefix: Callable[[str], Path],
-) -> dict[str, str]:
-    """Return environment prefixes to record in a receipt predicate."""
-    prefixes: dict[str, str] = {}
-    for name in config_environments:
-        prefix = env_prefix(name)
-        try:
-            prefixes[name] = prefix.relative_to(ctx_root).as_posix()
-        except ValueError:
-            prefixes[name] = prefix.as_posix()
-    return prefixes
-
-
-def extract_verified_archive(
-    archive_path: Path,
-    target: Path,
-    receipt: ArchiveReceipt,
-    *,
-    require_sha256: bool = False,
-) -> None:
-    """Extract to a staging directory, verify, then move into *target*."""
-    ensure_extract_target_empty(target)
-    target = target.resolve()
-    target.parent.mkdir(parents=True, exist_ok=True)
-    staged = Path(tempfile.mkdtemp(prefix=f".{target.name}.verify-", dir=target.parent))
-    try:
-        extract_archive(archive_path, staged)
-        receipt.verify_extracted(staged, require_sha256=require_sha256)
-        if target.exists():
-            target.rmdir()
-        staged.rename(target)
-    except BaseException:
-        shutil.rmtree(staged, ignore_errors=True)
-        raise
-
-
 def execute_archive(
     args: argparse.Namespace,
     *,
@@ -181,14 +77,7 @@ def execute_archive(
     if console is None:
         console = Console(highlight=False)
 
-    config, ctx = workspace_context_from_args(args)
-
     if args.lock:
-        from ...lockfile import generate_lockfile
-        from ...resolver import resolve_all_environments
-
-        resolved_envs = resolve_all_environments(config, ctx.platform)
-
         status.message(
             console,
             "Locking",
@@ -197,145 +86,50 @@ def execute_archive(
             style="bold blue",
             ellipsis=True,
         )
-        generate_lockfile(ctx, resolved_envs, config=config)
+    archive = WorkspaceArchive.create(
+        workspace=getattr(args, "file", None),
+        output=args.output,
+        lock=args.lock,
+        bundle=args.bundle,
+        exclude=tuple(args.exclude or ()),
+        receipt=getattr(args, "receipt", None),
+    )
+
+    if args.lock:
         status.message(console, "Updated", "lockfile", "conda.lock")
-
-    cli_excludes = tuple(args.exclude or [])
-    archive_config = ArchiveConfig(
-        include=config.archive.include,
-        exclude=config.archive.exclude + cli_excludes,
-        compression=config.archive.compression,
-        compression_level=config.archive.compression_level,
-    )
-
-    output: Path | None = args.output
-    if output is None:
-        name = config.name or ctx.root.name
-        if not is_path_segment(name):
-            raise ArchiveError(
-                "Workspace name cannot be used as a default archive filename.",
-                hints=[
-                    "Use a simple workspace name without path separators,",
-                    "or pass -o/--output to choose the archive path explicitly.",
-                ],
-            )
-        ext = {"zst": ".tar.zst", "gz": ".tar.gz", "bz2": ".tar.bz2"}.get(
-            config.archive.compression, ".tar.zst"
-        )
-        output = ctx.root / f"{name}{ext}"
-
-    receipt_path = resolve_receipt_path(
-        output.resolve(), getattr(args, "receipt", None)
-    )
-    manifest_path = Path(config.manifest_path)
-    lockfile_path = _lockfile_path(ctx)
-    if receipt_path is not None:
-        if receipt_path.resolve() == output.resolve():
-            raise ArchiveError(
-                "Receipt path cannot be the archive path.",
-                hints=["Choose a separate JSON path for --receipt."],
-            )
-        if not manifest_path.is_file():
-            raise ArchiveError(
-                "Cannot write receipt: workspace manifest was not found."
-            )
-        if not lockfile_path.is_file():
-            raise ArchiveError(
-                "Cannot write receipt: no conda.lock found.",
-                hints=["Run 'conda workspace lock' first."],
-            )
-
-        archive_members = {
-            path.relative_to(ctx.root).as_posix()
-            for path in collect_archive_files(ctx.root, archive_config)
-            if path.resolve() != output.resolve()
-        }
-        required_members: dict[str, Path] = {
-            "workspace manifest": manifest_path,
-            "workspace lockfile": lockfile_path,
-        }
-        missing = []
-        for label, path in required_members.items():
-            try:
-                archive_name = path.relative_to(ctx.root).as_posix()
-            except ValueError:
-                missing.append(label)
-                continue
-            if archive_name not in archive_members:
-                missing.append(f"{label} ({archive_name})")
-        if missing:
-            raise ArchiveError(
-                f"Cannot write receipt: archive would not include {missing[0]}.",
-                hints=[
-                    "Receipt verification requires the workspace manifest and"
-                    " conda.lock to be included in the archive.",
-                    "Remove matching include/exclude filters or run without --receipt.",
-                ],
-            )
-
-    bundle_packages = None
-    if args.bundle:
-        from conda.base.context import context as conda_context
-
-        if not lockfile_path.is_file():
-            raise ArchiveError(
-                "Cannot bundle packages: no conda.lock found.",
-                hints=["Run 'conda workspace lock' first."],
-            )
-        cache_dirs = [Path(d) for d in conda_context.pkgs_dirs]
-        bundle_packages = collect_bundle_packages(lockfile_path, cache_dirs)
-        verify_package_hashes(bundle_packages, lockfile_path)
-
-        status.message(
-            console,
-            "Bundling",
-            "packages",
-            str(len(bundle_packages)),
-            style="bold blue",
-            ellipsis=True,
-        )
-
-    status.message(
-        console,
-        "Creating",
-        "archive",
-        str(output.name),
-        style="bold blue",
-        ellipsis=True,
-    )
-
-    output = create_archive(
-        ctx.root,
-        output,
-        archive_config,
-        bundle_packages=bundle_packages,
-    )
-
-    status.message(console, "Created", "archive", str(output))
-
-    if receipt_path is not None:
-        receipt = ArchiveReceipt.build(
-            root=ctx.root,
-            archive_path=output,
-            archive_config=archive_config,
-            manifest_path=manifest_path,
-            lockfile_path=lockfile_path,
-            environment_prefixes=receipt_environment_prefixes(
-                config_environments=list(config.environments),
-                ctx_root=ctx.root,
-                env_prefix=ctx.env_prefix,
-            ),
-            options={
-                "bundle": bool(args.bundle),
-                "lock": bool(args.lock),
-                "include": list(archive_config.include),
-                "exclude": list(archive_config.exclude),
-                "compressionLevel": archive_config.compression_level,
-            },
-        )
-        receipt.write(receipt_path)
-        status.message(console, "Created", "receipt", str(receipt_path))
+    status.message(console, "Created", "archive", str(archive.path))
+    if archive.receipt_path is not None:
+        status.message(console, "Created", "receipt", str(archive.receipt_path))
     return 0
+
+
+def install_from_archive_cli(
+    console: Console,
+):
+    """Return an install handler that preserves the CLI install path."""
+
+    def install(
+        workspace: Path,
+        environment: str | None,
+        prefix: Path | None,
+        target_prefix_override: str | None,
+    ) -> int:
+        from .install import execute_install
+
+        install_args = argparse.Namespace(
+            file=str(workspace),
+            environment=environment,
+            force_reinstall=False,
+            locked=True,
+            frozen=False,
+            dry_run=False,
+            json=False,
+            prefix=prefix,
+            target_prefix_override=target_prefix_override,
+        )
+        return execute_install(install_args, console=console)
+
+    return install
 
 
 def execute_unarchive(
@@ -347,155 +141,81 @@ def execute_unarchive(
     if console is None:
         console = Console(highlight=False)
 
-    archive_path = Path(args.archive_path).resolve()
-    if not archive_path.is_file():
-        raise ArchiveError(f"Archive not found: {archive_path}")
-
-    receipt_path = resolve_receipt_path(archive_path, getattr(args, "receipt", None))
-    if getattr(args, "require_sha256", False) and receipt_path is None:
-        raise ArchiveError("--require-sha256 requires --receipt.")
-
-    receipt = None
-    if receipt_path is not None:
-        receipt = ArchiveReceipt.load(receipt_path)
-        receipt.verify_archive(archive_path)
-        status.message(console, "Verified", "archive", str(archive_path.name))
-
-    target: Path | None = args.target
-    if target is None:
-        stem = archive_path.name
-        for suffix in ARCHIVE_SUFFIXES:
-            if stem.endswith(suffix):
-                stem = stem[: -len(suffix)]
-                break
-        target = Path.cwd() / stem
-
-    info = inspect_archive(archive_path)
-
-    if not info["has_manifest"]:
-        raise ArchiveError(
-            "Not a workspace archive: no manifest found.",
-            hints=["This does not appear to be a conda workspace archive."],
-        )
-
-    env_name = getattr(args, "environment", None)
-    final_prefix_arg = getattr(args, "prefix", None)
-    final_prefix = str(final_prefix_arg) if final_prefix_arg is not None else None
-    dest = getattr(args, "dest", None)
-
-    if final_prefix is not None and not args.install:
+    if getattr(args, "prefix", None) is not None and not args.install:
         raise ArchiveError(
             "--prefix requires --install.",
             hints=["Pass --install when installing to an explicit prefix."],
         )
-    if dest is not None and not args.install:
+    if getattr(args, "dest", None) is not None and not args.install:
         raise ArchiveError(
             "--dest requires --install.",
             hints=["Pass --install when using a staging destination."],
         )
 
-    if args.install:
-        if final_prefix is not None and not env_name:
-            raise ArchiveError(
-                "--prefix requires an explicit environment.",
-                hints=["Pass -e/--environment with --prefix."],
-            )
-        if dest is not None and final_prefix is None:
-            raise ArchiveError(
-                "--dest requires --prefix.",
-                hints=[
-                    "Pass --prefix to declare the final runtime prefix for"
-                    " the selected environment.",
-                ],
-            )
-        if final_prefix is not None:
-            final_prefix = expanduser(final_prefix)
-            if not is_absolute_runtime_prefix(final_prefix):
-                raise ArchiveError(
-                    "--prefix must be an absolute path.",
-                    hints=["Pass an absolute runtime prefix such as /opt/runtime."],
-                )
-
+    archive = WorkspaceArchive(
+        args.archive_path,
+        receipt=getattr(args, "receipt", None),
+    )
     status.message(
         console,
         "Extracting",
         "archive",
-        str(archive_path.name),
+        str(archive.path.name),
         style="bold blue",
         ellipsis=True,
     )
 
-    if receipt is None:
-        target = extract_archive(archive_path, target)
-    else:
-        extract_verified_archive(
-            archive_path,
-            target,
-            receipt,
+    if args.install:
+        result = archive.install(
+            target=args.target,
+            environment=getattr(args, "environment", None),
+            prefix=getattr(args, "prefix", None),
+            dest=getattr(args, "dest", None),
             require_sha256=getattr(args, "require_sha256", False),
+            prime_cache=not args.no_install,
+            install_handler=install_from_archive_cli(console),
         )
-        target = target.resolve()
+    else:
+        result = archive.extract(
+            target=args.target,
+            require_sha256=getattr(args, "require_sha256", False),
+            prime_cache=not args.no_install,
+        )
 
-    status.message(console, "Extracted", "archive", str(target))
-    if receipt is not None:
-        status.message(console, "Verified", "receipt", str(receipt_path))
+    if result.verified:
+        status.message(console, "Verified", "archive", str(archive.path.name))
+    status.message(console, "Extracted", "archive", str(result.target))
+    if result.verified:
+        status.message(console, "Verified", "receipt", str(result.receipt_path))
 
-    if info["has_packages"]:
-        console.print(f"  Archive includes {info['package_count']} bundled packages")
-        if not args.no_install:
-            if receipt is None:
-                console.print(
-                    "  Skipping package cache priming without verified receipt"
-                )
-            else:
-                from conda.base.context import context as conda_context
-
-                cache_dir = Path(conda_context.pkgs_dirs[0])
-                count = prime_package_cache(target, cache_dir, verified=True)
-                if count > 0:
-                    status.message(
-                        console,
-                        "Primed",
-                        "packages",
-                        str(count),
-                        detail="into conda cache",
-                    )
+    if result.info["has_packages"]:
+        console.print(
+            f"  Archive includes {result.info['package_count']} bundled packages"
+        )
+        if result.cache_priming_skipped:
+            console.print("  Skipping package cache priming without verified receipt")
+        elif result.primed_packages > 0:
+            status.message(
+                console,
+                "Primed",
+                "packages",
+                str(result.primed_packages),
+                detail="into conda cache",
+            )
 
     if args.install:
-        install_prefix = Path(final_prefix) if final_prefix is not None else None
-        target_prefix_override = None
-        if final_prefix is not None:
-            if dest is not None:
-                dest = Path(dest).expanduser().resolve()
-                install_prefix = dest / runtime_prefix_relative_path(final_prefix)
-                target_prefix_override = final_prefix
-            elif str(install_prefix) != final_prefix:
-                target_prefix_override = final_prefix
-
-        from .install import execute_install
-
-        install_args = argparse.Namespace(
-            file=str(target),
-            environment=env_name,
-            force_reinstall=False,
-            locked=True,
-            frozen=False,
-            dry_run=False,
-            json=False,
-            prefix=install_prefix,
-            target_prefix_override=target_prefix_override,
-        )
-        result = execute_install(install_args, console=console)
         if (
-            result == 0
-            and install_prefix is not None
-            and target_prefix_override is not None
+            result.return_code == 0
+            and result.install_prefix is not None
+            and result.runtime_prefix is not None
         ):
             warn_staging_prefix_references(
                 console,
-                install_prefix=install_prefix,
-                runtime_prefix=target_prefix_override,
+                install_prefix=result.install_prefix,
+                runtime_prefix=result.runtime_prefix,
+                matches=result.prefix_reference_matches,
+                truncated=result.prefix_reference_matches_truncated,
             )
-        return result
+        return result.return_code
 
     return 0

--- a/docs/features.md
+++ b/docs/features.md
@@ -841,8 +841,12 @@ conda workspace archive --lock --receipt -o my-project.tar.zst
 conda workspace unarchive my-project.tar.zst --receipt --target ./verified
 ```
 
+Python integrations can use `conda_workspaces.archive.WorkspaceArchive`
+for the same archive operations without importing CLI handlers.
+
 See the [archive tutorial](tutorials/archives.md) for a
-full walkthrough and the [archive receipt reference](reference/archive-receipts.md)
+full CLI walkthrough, [Use workspace archives from Python](how-to/archive-api.md)
+for integration examples, and the [archive receipt reference](reference/archive-receipts.md)
 for the receipt JSON format.
 
 ---

--- a/docs/how-to/archive-api.md
+++ b/docs/how-to/archive-api.md
@@ -1,0 +1,159 @@
+# Use workspace archives from Python
+
+Use `conda_workspaces.archive.WorkspaceArchive` when another Python tool
+needs archive behavior without shelling out to `conda workspace archive`
+or importing CLI handlers.
+
+## Create an archive
+
+Create an archive from the current workspace:
+
+```python
+from conda_workspaces.archive import WorkspaceArchive
+
+archive = WorkspaceArchive.create(
+    output="dist/my-project.tar.zst",
+    receipt=True,
+)
+```
+
+Pass `workspace=` to archive a different workspace root:
+
+```python
+archive = WorkspaceArchive.create(
+    workspace="/path/to/workspace",
+    output="dist/my-project.tar.zst",
+    receipt="dist/my-project.receipt.json",
+)
+```
+
+Set `lock=True` to refresh `conda.lock` before writing the archive, and
+`bundle=True` to include resolved package archives from conda's package
+cache:
+
+```python
+archive = WorkspaceArchive.create(
+    output="dist/my-project-offline.tar.zst",
+    lock=True,
+    bundle=True,
+    receipt=True,
+)
+```
+
+## Inspect and verify an archive
+
+Inspect archive metadata without extracting files:
+
+```python
+archive = WorkspaceArchive("dist/my-project.tar.zst", receipt=True)
+info = archive.inspect()
+
+if not info["has_manifest"]:
+    raise RuntimeError("not a workspace archive")
+```
+
+Verify an archive against its receipt:
+
+```python
+receipt = archive.verify()
+print(receipt.workspace_paths)
+```
+
+Receipt verification checks the archive digest before extraction. It
+does not identify who created the archive or receipt.
+
+## Extract an archive
+
+Extract into an empty or missing target directory:
+
+```python
+result = archive.extract(target="/tmp/restored", require_sha256=True)
+
+print(result.target)
+print(result.verified)
+```
+
+When a bundled archive has a verified receipt, extraction can prime the
+local conda package cache from packages stored inside the archive. Without
+a receipt, bundled packages are left in the extracted workspace and cache
+priming is skipped.
+
+Pass `prime_cache=False` to disable cache priming:
+
+```python
+archive.extract(target="/tmp/restored", prime_cache=False)
+```
+
+## Install from an archive
+
+Install all archived environments after extraction:
+
+```python
+archive.install(target="/tmp/restored")
+```
+
+Install one environment to an explicit runtime prefix:
+
+```python
+archive.install(
+    target="/tmp/restored",
+    environment="runtime",
+    prefix="/opt/runtime",
+)
+```
+
+Stage files under a filesystem root while preserving the requested runtime
+prefix:
+
+```python
+result = archive.install(
+    target="/tmp/restored",
+    environment="runtime",
+    prefix="/opt/runtime",
+    dest="/tmp/rootfs",
+)
+
+if result.prefix_reference_matches:
+    print("Some files still reference the staging prefix")
+```
+
+`prefix_reference_matches` reports files that still contain the physical
+staging prefix after installation. It is a warning signal for relocation
+workflows, not an automatic prefix-rewrite feature.
+
+## Customize installation
+
+Pass `install_handler=` when an integration wants conda-workspaces to
+extract and verify an archive, but wants to control environment
+installation:
+
+```python
+from pathlib import Path
+
+
+def install_handler(
+    workspace: Path,
+    environment: str | None,
+    prefix: Path | None,
+    target_prefix_override: str | None,
+) -> int:
+    print(workspace, environment, prefix, target_prefix_override)
+    return 0
+
+
+archive.install(
+    target="/tmp/restored",
+    environment="runtime",
+    prefix="/opt/runtime",
+    dest="/tmp/rootfs",
+    install_handler=install_handler,
+)
+```
+
+The handler receives the extracted workspace path, the selected
+environment, the physical install prefix, and the runtime prefix override
+when staging under `dest`.
+
+## API reference
+
+See [](../reference/api/archive.md) for the formal API reference.

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,0 +1,17 @@
+# How-to guides
+
+Task-oriented guides for applying conda-workspaces in existing tools and
+automation.
+
+::::{grid} 1
+:gutter: 3
+
+:::{grid-item-card} {octicon}`code` Use workspace archives from Python
+:link: archive-api
+:link-type: doc
+
+Create, verify, extract, and install workspace archives through the public
+Python API.
+:::
+
+::::

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,6 +135,13 @@ Set up your first workspace and tasks in under a minute.
 Your first project, migrating from conda / pixi / anaconda-project / conda-project, CI setup.
 :::
 
+:::{grid-item-card} {octicon}`tools` How-to guides
+:link: how-to/index
+:link-type: doc
+
+Task-oriented guides for integrations and automation.
+:::
+
 :::{grid-item-card} {octicon}`list-unordered` Features
 :link: features
 :link-type: doc
@@ -203,6 +210,14 @@ tutorials/coming-from/index
 tutorials/lockfile-management
 tutorials/ci-pipeline
 tutorials/archives
+```
+
+```{toctree}
+:hidden:
+:caption: How-to guides
+
+how-to/index
+how-to/archive-api
 ```
 
 ```{toctree}

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -9,6 +9,7 @@ api/resolver
 api/context
 api/environments
 api/execution
+api/archive
 ```
 
 ::::{grid} 2
@@ -55,6 +56,13 @@ Environment creation, removal, and inspection via conda's APIs.
 :link-type: doc
 
 Task DAG resolution, shell backends, caching, and template rendering.
+:::
+
+:::{grid-item-card} Archives
+:link: api/archive
+:link-type: doc
+
+Workspace archive creation, receipt verification, extraction, and install.
 :::
 
 ::::

--- a/docs/reference/api/archive.md
+++ b/docs/reference/api/archive.md
@@ -1,0 +1,9 @@
+# Archives
+
+Public archive APIs for creating, inspecting, verifying, extracting, and
+installing workspace archives.
+
+```{eval-rst}
+.. automodule:: conda_workspaces.archive
+   :members: WorkspaceArchive, WorkspaceArchiveExtractResult, WorkspaceArchiveInstallResult
+```

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -584,7 +584,7 @@ def test_execute_unarchive_package_cache_priming_requires_receipt(
         return 1
 
     monkeypatch.setattr(
-        "conda_workspaces.cli.workspace.archive.prime_package_cache",
+        "conda_workspaces.archive.prime_package_cache",
         fake_prime_package_cache,
     )
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -4,13 +4,14 @@ import hashlib
 import io
 import subprocess
 import tarfile
-from pathlib import PureWindowsPath
+from pathlib import Path, PureWindowsPath
 from typing import TYPE_CHECKING
 
 import pytest
 
 from conda_workspaces.archive import (
     ALLOWED_TAR_TYPES,
+    WorkspaceArchive,
     add_files_to_tar,
     collect_archive_files,
     collect_bundle_packages,
@@ -33,7 +34,6 @@ from conda_workspaces.models import ArchiveConfig
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from pathlib import Path
 
 
 @pytest.fixture
@@ -135,6 +135,41 @@ def bundled_archive(lockfile_with_packages: Path, tmp_path: Path) -> tuple[Path,
     config = ArchiveConfig()
     create_archive(lockfile_with_packages, output, config, bundle_packages=packages)
     return output, lockfile_with_packages
+
+
+@pytest.fixture
+def workspace_archive_project(tmp_path: Path) -> Path:
+    """Create a workspace that can be archived through the public API."""
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "conda.toml").write_text(
+        """\
+[workspace]
+name = "archive-api-test"
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+[dependencies]
+python = ">=3.10"
+""",
+        encoding="utf-8",
+    )
+    (root / "conda.lock").write_text(
+        """\
+version: 1
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64: []
+packages: []
+""",
+        encoding="utf-8",
+    )
+    (root / "src").mkdir()
+    (root / "src" / "app.py").write_text("print('hello')\n", encoding="utf-8")
+    return root
 
 
 def test_collect_files_git_tracked(git_project: Path) -> None:
@@ -769,6 +804,156 @@ def test_inspect_archive_not_workspace(tmp_path: Path) -> None:
 
     result = inspect_archive(archive)
     assert result["has_manifest"] is False
+
+
+def test_workspace_archive_create_writes_receipt(
+    workspace_archive_project: Path,
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "workspace.tar.gz"
+
+    archive = WorkspaceArchive.create(
+        workspace=workspace_archive_project,
+        output=output,
+        receipt=True,
+    )
+
+    assert archive.path == output.resolve()
+    assert archive.receipt_path == output.resolve().with_name(
+        "workspace.tar.gz.receipt.json"
+    )
+    assert archive.path.is_file()
+    assert archive.receipt_path is not None
+    assert archive.receipt_path.is_file()
+    assert archive.inspect()["has_manifest"] is True
+    assert archive.verify().workspace_paths == ("conda.toml", "conda.lock")
+
+
+def test_workspace_archive_extract_uses_receipt(
+    workspace_archive_project: Path,
+    tmp_path: Path,
+) -> None:
+    archive = WorkspaceArchive.create(
+        workspace=workspace_archive_project,
+        output=tmp_path / "workspace.tar.gz",
+        receipt=True,
+    )
+
+    result = archive.extract(
+        target=tmp_path / "extracted",
+        require_sha256=True,
+    )
+
+    assert result.target == (tmp_path / "extracted").resolve()
+    assert result.verified is True
+    assert result.receipt_path == archive.receipt_path
+    assert (result.target / "src" / "app.py").is_file()
+
+
+@pytest.mark.parametrize(
+    ("runtime_prefix", "dest", "expected_staged_prefix", "expected_runtime_prefix"),
+    [
+        ("tmp-runtime", None, Path("direct-runtime"), None),
+        (
+            "/opt/runtime",
+            "rootfs",
+            Path("rootfs") / "opt" / "runtime",
+            "/opt/runtime",
+        ),
+    ],
+    ids=["direct-prefix", "staged-dest"],
+)
+def test_workspace_archive_install_uses_public_handler(
+    workspace_archive_project: Path,
+    tmp_path: Path,
+    runtime_prefix: str,
+    dest: str | None,
+    expected_staged_prefix: Path,
+    expected_runtime_prefix: str | None,
+) -> None:
+    archive = WorkspaceArchive.create(
+        workspace=workspace_archive_project,
+        output=tmp_path / "workspace.tar.gz",
+    )
+    calls: list[tuple[Path, str | None, Path | None, str | None]] = []
+
+    def install_handler(
+        workspace: Path,
+        environment: str | None,
+        install_prefix: Path | None,
+        target_prefix_override: str | None,
+    ) -> int:
+        calls.append((workspace, environment, install_prefix, target_prefix_override))
+        if install_prefix is not None:
+            install_prefix.mkdir(parents=True, exist_ok=True)
+            (install_prefix / "prefix.txt").write_text(
+                str(install_prefix),
+                encoding="utf-8",
+            )
+        return 0
+
+    dest_path = tmp_path / dest if dest is not None else None
+    prefix = (
+        str(tmp_path / "direct-runtime")
+        if runtime_prefix == "tmp-runtime"
+        else runtime_prefix
+    )
+    result = archive.install(
+        target=tmp_path / "extracted",
+        environment="default",
+        prefix=prefix,
+        dest=dest_path,
+        install_handler=install_handler,
+    )
+
+    resolved_install_prefix = tmp_path / expected_staged_prefix
+    assert calls == [
+        (
+            (tmp_path / "extracted").resolve(),
+            "default",
+            resolved_install_prefix,
+            expected_runtime_prefix,
+        )
+    ]
+    assert result.return_code == 0
+    assert result.install_prefix == resolved_install_prefix
+    assert result.runtime_prefix == expected_runtime_prefix
+    if expected_runtime_prefix is None:
+        assert result.prefix_reference_matches == ()
+    else:
+        assert result.prefix_reference_matches == (
+            resolved_install_prefix / "prefix.txt",
+        )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"prefix": "/opt/runtime"}, "--prefix requires an explicit environment"),
+        (
+            {"environment": "default", "prefix": "relative/runtime"},
+            "--prefix must be an absolute path",
+        ),
+        (
+            {"environment": "default", "dest": "rootfs"},
+            "--dest requires --prefix",
+        ),
+    ],
+    ids=["prefix-without-env", "relative-prefix", "dest-without-prefix"],
+)
+def test_workspace_archive_install_rejects_invalid_prefix_options(
+    workspace_archive_project: Path,
+    tmp_path: Path,
+    kwargs: dict[str, str],
+    message: str,
+) -> None:
+    archive = WorkspaceArchive.create(
+        workspace=workspace_archive_project,
+        output=tmp_path / "workspace.tar.gz",
+    )
+
+    with pytest.raises(ArchiveError, match=message):
+        archive.install(target=tmp_path / "extracted", **kwargs)
 
 
 def test_archive_roundtrip(git_project: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
Summary

- Add conda_workspaces.archive.WorkspaceArchive as the public class API for creating, inspecting, verifying, extracting, and installing workspace archives.

- Move reusable unarchive helpers into conda_workspaces.archive and keep the CLI module as a thin adapter.

- Add direct pytest coverage for receipt-backed create/extract, staged install handling, invalid prefix options, and cache-priming behavior.

- Add Diataxis-oriented docs: a Python archive how-to, API reference page, feature links, and changelog entry.

Validation

- pixi run -e test pytest

- pixi run ruff check

- pixi run ruff format --check

- pixi run -e docs docs