### PR TITLE
Fix conda-forge README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/conda-incubator/conda-workspaces/actions/workflows/tests.yml/badge.svg)](https://github.com/conda-incubator/conda-workspaces/actions/workflows/tests.yml)
 [![Docs](https://github.com/conda-incubator/conda-workspaces/actions/workflows/docs.yml/badge.svg)](https://conda-incubator.github.io/conda-workspaces/)
 [![PyPI](https://img.shields.io/pypi/v/conda-workspaces)](https://pypi.org/project/conda-workspaces/)
-[![conda-forge](https://img.shields.io/conda-forge/vn/conda-workspaces)](https://anaconda.org/conda-forge/conda-workspaces)
+[![conda-forge](https://img.shields.io/conda/vn/conda-forge/conda-workspaces)](https://anaconda.org/conda-forge/conda-workspaces)
 [![Codecov](https://img.shields.io/codecov/c/github/conda-incubator/conda-workspaces)](https://codecov.io/gh/conda-incubator/conda-workspaces)
 [![License](https://img.shields.io/github/license/conda-incubator/conda-workspaces)](https://github.com/conda-incubator/conda-workspaces/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%E2%80%933.14-blue)](https://github.com/conda-incubator/conda-workspaces)


### PR DESCRIPTION
## Summary
- Update the README conda-forge badge to use the working Shields conda endpoint.
- Keep the badge target pointing at the conda-forge package page.

## Validation
- `curl -LfsS -o /tmp/badge-readme-fixed.svg -w '%{http_code} %{url_effective}\n' https://img.shields.io/conda/vn/conda-forge/conda-workspaces`
- Confirmed the returned SVG contains `conda-forge` and `v0.6.0` instead of `404 badge not found`.
- `git diff --check`