### PR TITLE
Refresh conda integration docs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -30,8 +30,8 @@ shortcuts `cw` and `ct` are also available as aliases.
 3. **Multi-environment support** — define multiple named environments
    from composable features, matching pixi's feature/environment model.
 
-4. **Conda-native solver** — use conda's own solver (libmamba) rather
-   than bundling a separate resolver.
+4. **Conda-native solver** — use conda's configured solver backend
+   rather than bundling a separate resolver.
 
 5. **Plugin architecture** — integrate via conda's plugin system, adding
    no overhead to unrelated conda operations.
@@ -54,7 +54,7 @@ shortcuts `cw` and `ct` are also available as aliases.
 | `[target.<platform>]` | `target_conda_dependencies` | Per-platform overrides |
 | `channel-priority` | Mapped to conda setting | `strict` / `flexible` / `disabled` |
 | Inline tables `{version = "...", build = "..."}` | Parsed via tomlkit | Dict-form deps |
-| `pixi add` / `pixi remove` | `conda workspace add` / `conda workspace remove` | Solves and installs by default; `--no-install` / `--no-lockfile-update` opt-outs |
+| `pixi add` / `pixi remove` | `conda workspace add` / `conda workspace remove` | Solves and installs by default. `--no-install` / `--no-lockfile-update` opt-outs |
 
 ### Accepted but Ignored
 
@@ -78,7 +78,7 @@ shortcuts `cw` and `ct` are also available as aliases.
 ```
 project/
 ├── pixi.toml              # or pyproject.toml
-├── conda.lock             # lockfile (rattler-lock v6 format)
+├── conda.lock             # lockfile (rattler-lock-derived v1 format)
 ├── .conda/
 │   └── envs/
 │       ├── default/       # default environment
@@ -104,21 +104,24 @@ parsed by conda-workspaces.
 
 ### 3. Solver Strategy
 
-conda-workspaces delegates all solving to conda's solver (libmamba).
-For each environment:
+conda-workspaces delegates all solving to conda's configured solver
+backend. For each environment:
 
 1. Resolve all features into a merged dependency set
-2. Feed specs + channels to `conda create` / `conda install`
-3. Let libmamba handle constraint resolution
+2. Build the `MatchSpec` list, channel list, target subdirs, and any
+   virtual package overrides
+3. Instantiate conda's active solver backend through the plugin manager
+   and let it produce the solve/install transaction
 
 ### 4. conda-native Format (conda.toml)
 
-While pixi.toml is the primary format, a `conda.toml` is also
-supported.  This is structurally identical to pixi.toml but:
+While pixi.toml is the primary compatibility format, a `conda.toml` is
+also supported. Its core workspace, feature, environment, dependency,
+and task tables use the same shape as pixi.toml, but it:
 
 - Uses `[workspace]` exclusively (no `[project]` fallback)
-- May add conda-specific extensions in the future (e.g., custom solver
-  settings, conda-build integration)
+- Includes conda-workspaces-specific extensions such as
+  `default-environment` and `[workspace.archive]`
 - Provides a non-pixi-branded option for teams that only use conda
 
 ### 5. Standalone CLI Aliases (`cw` / `ct`)
@@ -210,21 +213,22 @@ equally to `conda workspace install`.
 
 ### Architectural
 
-1. **No bundled solver** — conda-workspaces uses conda's solver; pixi
-   bundles rattler (a Rust-based solver).  This means solving behavior
-   may differ slightly.
+1. **No bundled solver** — conda-workspaces uses conda's configured
+   solver backend. Pixi bundles rattler (a Rust-based solver), so
+   solving behavior may differ slightly.
 
 2. **No package installation** — conda-workspaces creates real conda
    environments using conda's install machinery.  Pixi uses rattler to
    install packages directly into `.pixi/envs/`, bypassing conda.
 
-3. **Lock files** — conda-workspaces generates a `conda.lock` in
-   rattler-lock v6 format (the same structure as `pixi.lock`) after
-   every install.  The `--locked` flag installs from the lockfile
-   without running the solver, and `conda workspace lock` regenerates
-   the lockfile on demand.
+3. **Lock files** — conda-workspaces generates a `conda.lock` using a
+   rattler-lock-derived schema after every install.  The YAML structure
+   is shared with `pixi.lock`, but `conda.lock` carries a conda-
+   workspaces-owned `version: 1` byte.  The `--locked` flag installs
+   from the lockfile after freshness validation, `--frozen` installs it
+   as-is, and `conda workspace lock` regenerates the lockfile on demand.
 
-4. **Plugin, not standalone** — conda-workspaces is a conda plugin;
+4. **Plugin, not standalone** — conda-workspaces is a conda plugin.
    pixi is a standalone tool that replaces conda entirely for its users.
 
 ### Behavioral
@@ -238,7 +242,7 @@ equally to `conda workspace install`.
    than pixi's system-requirements handling.
 
 3. **Environment activation** — conda environments are activated via
-   `conda activate`; pixi uses `pixi shell` or `pixi run`.
+   `conda activate`. pixi uses `pixi shell` or `pixi run`.
    conda-workspaces environments are standard conda prefixes and work
    with `conda activate <prefix>`.
 
@@ -271,25 +275,29 @@ parses the manifest, resolves the *default* environment's dependencies,
 and returns them as `requested_packages` (a list of `MatchSpec`
 objects).  conda's solver then resolves the full dependency tree.
 
-**`conda-workspaces-lock`** — handles `conda.lock` files (rattler-lock
-v6 format).  When a user runs `conda env create --file conda.lock`,
-the specifier parses the lockfile, extracts the exact package URLs for
-the default environment on the current platform, and returns them as
-`explicit_packages` (a list of `PackageRecord` objects).  The solver
-is bypassed entirely, producing a bit-for-bit reproducible install.
+**`conda-workspaces-lock-v1`** (aliases: `conda-workspaces-lock`,
+`workspace-lock`) — handles `conda.lock` files.  When a user runs
+`conda env create --file conda.lock`, the specifier parses the lockfile,
+selects the package URLs for the default environment on the requested
+platform, and returns them as `explicit_packages` (a list of
+`PackageRecord` objects).  The solver is bypassed entirely, producing a
+bit-for-bit reproducible install.
 
 Both specifiers set `detection_supported = True`, so conda can
-auto-detect the format from the filename without requiring
-`--env-spec=...`.
+auto-detect the format from the filename. On conda 26.5 and newer,
+users should select formats explicitly with `--format` when detection is
+not enough. `--env-spec` / `--environment-specifier` are pending
+deprecation upstream.
 
 ### Environment Exporter (`conda_environment_exporters`)
 
 One environment exporter is registered:
 
-**`conda-workspaces-lock`** (aliases: `workspace-lock`) — exports
-installed environments to `conda.lock` in the rattler-lock v6 format.
-This allows `conda export --format=conda-workspaces-lock --file=conda.lock`
-to produce a lockfile from any conda environment, not just workspace-
+**`conda-workspaces-lock-v1`** (aliases: `conda-workspaces-lock`,
+`workspace-lock`) — exports installed environments to `conda.lock` in
+the conda-workspaces lockfile format. This allows
+`conda export --format=conda-workspaces-lock-v1 --file=conda.lock` to
+produce a lockfile from any conda environment, not just workspace-
 managed ones.
 
 The exporter implements the `multiplatform_export` interface, accepting
@@ -300,21 +308,22 @@ built-in `conda workspace lock` command.
 ### Relationship with conda-lockfiles
 
 The `conda-lockfiles` plugin handles `pixi.lock` files under the
-`rattler-lock-v6` format name.  conda-workspaces extends coverage to
-`conda.lock` files under the `conda-workspaces-lock` format name.  The
-two plugins do not conflict — and neither collides with `conda-lock-v1`
-(the format name `conda-lockfiles` uses for `conda-lock.yml` files
-from the `conda/conda-lock` tool):
+`rattler-lock-v6` format name and `conda-lock.yml` files under
+`conda-lock-v1`. conda 26.5 can consume those formats directly when
+the plugin is installed. conda-workspaces extends coverage to
+`conda.lock` files under the `conda-workspaces-lock-v1` format name.
+The plugins do not conflict:
 
 | Plugin | Env-spec name | Filenames | Exporter name |
 |---|---|---|---|
 | conda-lockfiles | `conda-lock-v1` | `conda-lock.yml` | `conda-lock-v1` |
 | conda-lockfiles | `rattler-lock-v6` | `pixi.lock` | `rattler-lock-v6` |
-| conda-workspaces | `conda-workspaces-lock` | `conda.lock` | `conda-workspaces-lock` |
+| conda-workspaces | `conda-workspaces-lock-v1` | `conda.lock` | `conda-workspaces-lock-v1` |
 
-Both use the same rattler-lock v6 YAML structure, so a `conda.lock`
-can be renamed to `pixi.lock` (and vice versa) and handled by either
-plugin.
+Both use the same rattler-lock v6 YAML structure, but the on-disk
+version byte differs. A tool can translate between `conda.lock` and
+`pixi.lock` by changing the version field and filename. A plain rename
+is not enough.
 
 ### conda-pypi Integration
 
@@ -323,17 +332,20 @@ PyPI dependencies are handled in two phases:
 1. **Standard PyPI deps** (version-spec only) are translated to conda
    package names via `conda-pypi`'s `pypi_to_conda_name` (using the
    grayskull mapping) and merged directly into the solver call alongside
-   conda specs. The rattler solver + conda-pypi's wheel extractor
-   resolve and install everything in a single pass.
+   conda specs. With `conda-rattler-solver` configured and the
+   `conda-pypi` channel available, these resolve and install in the
+   conda transaction.
 
 2. **Path-based PyPI deps** (`path = ".", editable = true`) are built
    into `.conda` packages via `conda-pypi`'s `pypa_to_conda` after the
    main solve completes, then installed with `install_ephemeral_conda`.
 
-Git and URL PyPI dependencies are not yet supported and are skipped
-with a warning. If `conda-pypi` is not installed, all PyPI dependencies
-are skipped with a warning. This keeps conda-pypi as an optional
-dependency — workspaces that only use conda packages never need it.
+Git and URL PyPI dependencies are parsed for manifest compatibility but
+are not yet supported and are skipped with a warning. If `conda-pypi`
+is not installed, version-only and path PyPI dependencies are skipped
+with warnings. If `conda-rattler-solver` is missing, version-only PyPI
+dependencies still become specs, but `install` warns because the
+`conda-pypi` channel requires the rattler solver backend.
 
 The environment specifiers also surface PyPI dependencies as
 `external_packages` (under the `"pip"` key) so that conda's own
@@ -414,12 +426,12 @@ the spec that checks agree on the version. `__cuda` and `__archspec`
 are never auto-baselined — callers who need them must opt in via
 `[system-requirements]` or `CONDA_OVERRIDE_*`.
 
-Cross-platform solves are fail-fast: the first unsatisfiable
+Cross-platform solves are fail-fast by default: the first unsatisfiable
 `(environment, platform)` pair raises `SolveError` with the platform
-in the message, and no `conda.lock` is written. This matches conda's
-and conda-workspaces' convention of refusing to produce partial
-artifacts; a `--skip-failed-platforms` escape hatch is tracked as a
-follow-up.
+in the message, and no `conda.lock` is written. Pass
+`--skip-unsolvable` to keep solving the remaining pairs. If every pair
+fails, the command raises an aggregate error rather than writing an
+empty lockfile.
 
 Users can restrict a run with `conda workspace lock --platform
 <subdir>` (repeatable) to regenerate just a subset, e.g. when a new

--- a/README.md
+++ b/README.md
@@ -105,11 +105,14 @@ and also provides `cw` and `ct` as shorter aliases.
 | `conda workspace lock` | Generate/update `conda.lock` |
 | `conda workspace list` | List packages in an environment |
 | `conda workspace envs` | List defined environments |
-| `conda workspace info [ENV]` | Show environment details |
+| `conda workspace info -e ENV` | Show environment details |
 | `conda workspace add SPECS...` | Add dependencies |
 | `conda workspace remove SPECS...` | Remove dependencies |
-| `conda workspace shell [ENV]` | Spawn a shell with an environment activated |
-| `conda workspace activate [ENV]` | Print activation instructions |
+| `conda workspace export` | Export environments and manifests through conda exporters |
+| `conda workspace import FILE` | Import supported project manifests |
+| `conda workspace quickstart SPECS...` | Bootstrap a workspace, install it, and optionally open a shell |
+| `conda workspace shell -e ENV` | Spawn a shell with an environment activated |
+| `conda workspace activate -e ENV` | Print activation instructions |
 | `conda workspace clean` | Remove installed environments |
 | `conda workspace archive` | Create a portable workspace archive |
 | `conda workspace unarchive` | Extract and optionally verify a workspace archive |

--- a/conda_workspaces/envs.py
+++ b/conda_workspaces/envs.py
@@ -127,7 +127,8 @@ def _build_pypi_specs(
     Uses ``conda_pypi.translate.pypi_to_conda_name`` to map PyPI package
     names to their conda equivalents (via the grayskull mapping).  Only
     simple version-spec dependencies are translated; path, git, and URL
-    deps are skipped (handled separately by ``_install_editable_deps``).
+    deps are skipped. Local path deps are handled separately by
+    ``_install_path_deps``; git and URL deps are not installed yet.
 
     Returns an empty list if ``conda-pypi`` is not installed.
     """
@@ -248,10 +249,11 @@ def install_environment(
     avoids the overhead of a subprocess and gives full control over
     the solve/install transaction.
 
-    PyPI dependencies are translated to conda names and merged into
-    the same solver call as conda dependencies, relying on
+    Version-only PyPI dependencies are translated to conda names and
+    merged into the same solver call as conda dependencies, relying on
     ``conda-pypi`` and ``conda-rattler-solver`` to resolve and install
-    them in a single pass.
+    them in a single pass. Local path PyPI dependencies are built and
+    installed after the conda transaction.
 
     Raises ``SolveError`` if dependency resolution fails.
     """

--- a/conda_workspaces/models.py
+++ b/conda_workspaces/models.py
@@ -48,10 +48,12 @@ class LockfileStatus:
 class PyPIDependency:
     """A PyPI dependency (PEP 508 string).
 
-    Names are translated to conda equivalents via ``conda-pypi``'s
-    grayskull mapping and merged into the same solver call as conda
-    deps.  Path/git/URL deps are handled post-solve via conda-pypi's
-    build system.
+    Version-only dependencies are translated to conda equivalents via
+    ``conda-pypi``'s grayskull mapping and merged into the same solver
+    call as conda deps. Local ``path`` dependencies are built and
+    installed post-solve via conda-pypi's build system. Git and URL
+    dependencies are parsed for pixi manifest compatibility but are not
+    installed yet.
     """
 
     name: str

--- a/conda_workspaces/plugin.py
+++ b/conda_workspaces/plugin.py
@@ -15,6 +15,7 @@ from conda.plugins.types import (
     CondaEnvironmentExporter,
     CondaEnvironmentSpecifier,
     CondaSubcommand,
+    EnvironmentFormat,
 )
 
 if TYPE_CHECKING:
@@ -66,6 +67,7 @@ def conda_environment_specifiers() -> Iterable[CondaEnvironmentSpecifier]:
         aliases=lockfile.ALIASES,
         default_filenames=lockfile.DEFAULT_FILENAMES,
         description="conda workspaces lockfile (conda.lock)",
+        environment_format=EnvironmentFormat.lockfile,
         environment_spec=lockfile.CondaLockLoader,
     )
 
@@ -80,6 +82,7 @@ def conda_environment_exporters() -> Iterable[CondaEnvironmentExporter]:
         aliases=lockfile.ALIASES,
         default_filenames=lockfile.DEFAULT_FILENAMES,
         description="conda workspaces lockfile (conda.lock)",
+        environment_format=EnvironmentFormat.lockfile,
         multiplatform_export=export.multiplatform_export,
     )
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,7 @@ task.
 ## Workspace search order
 
 1. `conda.toml` — conda-native workspace manifest
-2. `pixi.toml` — pixi-native format (compatibility)
+2. `pixi.toml` — pixi-native format (workspace/task compatibility)
 3. `pyproject.toml` — embedded under `[tool.conda.*]` or `[tool.pixi.*]`
 
 ## Task search order
@@ -90,9 +90,9 @@ consume `conda.lock`, conda-workspaces' own lockfile.  It is a
 derivative of rattler-lock v6 (`pixi.lock`): the YAML schema is the
 same, the converters in `conda-lockfiles` are reused, and only the
 on-disk `version` byte differs (`conda.lock` uses `version: 1`,
-`pixi.lock` uses `version: 6`).  The same relationship holds between
-`conda.toml` and `pixi.toml` — conda-workspaces owns the filename and
-the version byte, rattler-lock owns the schema.
+`pixi.lock` uses `version: 6`). A tool can translate between the two
+lockfile names by changing that version field. A plain rename is not a
+valid conversion.
 
 See [Plugin format names and
 aliases](reference/format-aliases.md) for the canonical and alias
@@ -103,9 +103,11 @@ strings accepted by `conda env create --file conda.lock` and
 
 ### conda.toml
 
-The conda-native format. Structurally identical to `pixi.toml` but uses
-`[workspace]` exclusively (no `[project]` fallback). Supports both
-workspace and task definitions in a single file.
+The conda-native format. Its core workspace, feature, environment,
+dependency, and task tables follow the same shape as `pixi.toml`, but it
+uses `[workspace]` exclusively (no `[project]` fallback) and can include
+conda-workspaces-specific extensions. Supports both workspace and task
+definitions in a single file.
 
 ```toml
 [workspace]
@@ -154,8 +156,8 @@ build = "python -m build --wheel"
 
 ### pixi.toml
 
-The pixi-native format. conda-workspaces reads this with full
-compatibility for workspace and task fields:
+The pixi-native format. conda-workspaces reads the workspace and task
+fields documented here, including pixi-style rich platform entries:
 
 ```toml
 [workspace]
@@ -255,7 +257,7 @@ The `[workspace]` (or `[project]`) table defines workspace metadata:
 | `version` | string | Workspace version (optional) |
 | `description` | string | Short description (optional) |
 | `channels` | list of strings | Conda channels, in priority order |
-| `platforms` | list of strings | Supported platforms (e.g. `linux-64`, `osx-arm64`) |
+| `platforms` | list of strings or rich platform tables | Supported platforms (e.g. `linux-64`, `osx-arm64`, `{ platform = "linux-64", cuda = "12.0" }`) |
 | `channel-priority` | string | Channel priority mode: `strict`, `flexible`, or `disabled` |
 
 ## Dependencies
@@ -271,8 +273,8 @@ cuda-toolkit = { version = ">=12", build = "*cuda*" }
 ```
 
 Shared conda specs can live under `[workspace.dependencies]`. Any conda
-dependency table can opt into a shared spec with `{ workspace = true }`;
-the consuming entry may add non-version fields such as `build` or
+dependency table can opt into a shared spec with `{ workspace = true }`.
+The consuming entry may add non-version fields such as `build` or
 `channel`. This matches the workspace dependency inheritance syntax
 that pixi added in 0.70.0.
 
@@ -302,6 +304,8 @@ Each `[feature.<name>]` table can contain:
 | `system-requirements` | table | System-level requirements |
 | `activation.scripts` | list | Activation scripts |
 | `activation.env` | table | Environment variables set on activation |
+| `target` | table | Per-platform dependency overrides for this feature |
+| `tasks` | table | Tasks contributed by this feature |
 
 ## Environments table
 
@@ -310,6 +314,7 @@ Each entry in `[environments]` defines a named environment:
 | Field | Type | Description |
 |---|---|---|
 | `features` | list of strings | Features to include (in addition to default) |
+| `solve-group` | string | Accepted for pixi compatibility. Currently ignored by conda-workspaces |
 | `no-default-feature` | bool | Exclude the default feature (default: false) |
 
 Shorthand forms are supported:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,8 +30,13 @@ key differences:
 
 ## What happens if I add keys to conda.toml that conda-workspaces doesn't recognize?
 
-Unknown keys are silently preserved and do not produce warnings. This is
-intentional: it allows other tools or future extensions to use the same
-file without causing noise. The `[workspace]` table already supports
-optional fields like `description` and `version` that not every workflow
-uses.
+The runtime parser is permissive when reading manifests and ignores
+unknown keys in most tables. Commands that edit TOML with `tomlkit`,
+such as `conda workspace add` and `conda task add`, generally preserve
+unrelated tables and comments because they modify the existing document
+in place.
+
+The JSON schema is stricter: it rejects unknown keys so `conda.toml` has
+a stable validation target for the fields conda-workspaces standardizes
+today. Put pixi-only metadata in `pixi.toml` or `[tool.pixi.*]` when you
+need pixi's full manifest surface.

--- a/docs/features.md
+++ b/docs/features.md
@@ -292,7 +292,7 @@ cmake = { workspace = true, build = "h*" }
 
 The root spec supplies the version and any other base match fields. The
 consuming entry may add non-version fields such as `build`, `channel`,
-or `subdir`; restating `version` alongside `workspace = true` is an
+or `subdir`. Restating `version` alongside `workspace = true` is an
 error.
 
 ## Channels
@@ -393,10 +393,12 @@ To use PyPI dependencies you need:
   which serves pure Python packages from PyPI as conda packages using
   sharded repodata (requires the rattler solver)
 
-Editable, git, and URL dependencies (e.g. `path = "."`, `git = "..."`)
-are handled separately via `conda-pypi`'s build system after the main
-solve completes. If `conda-pypi` is not installed, PyPI dependencies
-are skipped with a warning.
+Local path dependencies (e.g. `path = "."`) are handled separately via
+`conda-pypi`'s build system after the main solve completes. Git and URL
+dependencies are parsed for pixi manifest compatibility but are not
+installed yet. `conda workspace install` skips them with a warning. If
+`conda-pypi` is not installed, version-only and path PyPI dependencies
+are skipped with warnings.
 
 See the [PyPI dependencies tutorial](tutorials/pypi-dependencies.md)
 for a full walkthrough including editable installs and troubleshooting.
@@ -474,7 +476,7 @@ overridden so conda's virtual package plugins (`__linux`, `__osx`,
 
 :::{versionadded} 0.4.0
 `--platform <subdir>` (repeatable) restricts the lock run to a
-subset of declared platforms; unknown platforms raise
+subset of declared platforms. Unknown platforms raise
 `PlatformError` before any solve runs. `--skip-unsolvable` keeps
 locking the remaining `(environment, platform)` pairs when an
 individual solve fails, aggregating the failures into
@@ -650,7 +652,7 @@ is mutually exclusive with `--environment`, `--platform`,
 You can also point to a specific manifest with `--file` / `-f`:
 
 ```bash
-conda workspace install -f path/to/conda.toml
+conda workspace --file path/to/conda.toml install
 ```
 
 ## Export
@@ -663,7 +665,7 @@ conda workspace install -f path/to/conda.toml
 reachable through `conda export` — and anything registered by a
 third-party plugin such as `conda-lockfiles` — is also reachable
 through `conda workspace export`. `--from-lockfile` and
-`--from-prefix` select alternative sources; `--platform`
+`--from-prefix` select alternative sources. `--platform`
 (repeatable) drives multi-platform exports for exporters that opt
 into `multiplatform_export`.
 :::
@@ -683,7 +685,7 @@ vice versa.
 # Default: environment-yaml from the declared manifest (no install needed)
 conda workspace export -e default --file environment.yml
 
-# environment.json; format auto-detected from the filename
+# environment.json, format auto-detected from the filename
 conda workspace export -e default --file environment.json
 
 # Re-emit the workspace as a conda.toml manifest (cross-format export)
@@ -719,9 +721,9 @@ Three sources feed the exporter:
 `--platform` (repeatable) intersects declared / available platforms
 with the chosen subset. Passing multiple platforms requires an
 exporter that opts into `multiplatform_export` — the
-`conda-workspaces-lock-v1`, rattler-lock, and the three manifest
-exporters (`conda-toml`, `pixi-toml`, `pyproject-toml`) do; the
-single-platform yaml / json ones raise a clear error.
+`conda-workspaces-lock-v1`, rattler-lock-v6, and the three manifest
+exporters (`conda-toml`, `pixi-toml`, `pyproject-toml`) do. The
+single-platform yaml / json exporters raise a clear error.
 
 ### Manifest-format exporters
 
@@ -739,7 +741,7 @@ already reads, so `conda workspace import` and `conda workspace
 export` together form a bidirectional translator across every
 supported format. Declared specs that appear on every requested
 platform land under the top-level `[dependencies]` /
-`[pypi-dependencies]` tables; platform-specific deltas move under
+`[pypi-dependencies]` tables. Platform-specific deltas move under
 `[target.<platform>.*]`. The `pyproject-toml` exporter wraps the
 same content under `[tool.conda]`, and when the target
 `pyproject.toml` already exists it splices the `[tool.conda]`
@@ -773,7 +775,7 @@ conda workspace archive -o my-project.tar.zst
 
 When `-o/--output` is omitted, the archive is written in the workspace
 root using the workspace name as the filename stem. That default name
-must be a single filename segment; use `-o/--output` for other paths.
+must be a single filename segment. Use `-o/--output` for other paths.
 
 In git repos, only tracked files are included. Built-in exclusions
 (`.git`, `__pycache__`, `.conda/envs`, `.pixi`, and common credential

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,8 +105,8 @@ This means:
 
 - Workspaces and tasks read from `conda.toml`, `pixi.toml`, or
   `pyproject.toml` — one manifest, multiple tools
-- Environments are solved by conda / libmamba and installed as regular
-  conda prefixes
+- Environments are solved by conda's configured solver backend and
+  installed as regular conda prefixes
 - Lock files (`conda.lock`) capture exact package URLs for reproducible
   installs without re-solving
 - Task dependencies, caching, Jinja2 templates, and platform overrides

--- a/docs/motivation.md
+++ b/docs/motivation.md
@@ -29,7 +29,7 @@ definitions, and installation. Running `pixi install` uses rattler
 |---|---|---|
 | Define workspace & envs | `pixi.toml` or `pyproject.toml` | `conda.toml`, `pixi.toml`, or `pyproject.toml` |
 | Define tasks | `pixi.toml` or `pyproject.toml` `[tasks]` | Same manifest file |
-| Solve dependencies | rattler (bundled) | conda / libmamba (existing) |
+| Solve dependencies | rattler (bundled) | configured conda solver backend |
 | Install packages | rattler (into `.pixi/envs/`) | conda (into `.conda/envs/`) |
 | Manage environments | `pixi install` | `conda workspace install` (delegates to conda) |
 | Run tasks | `pixi run <task>` | `conda task run <task>` |
@@ -38,7 +38,7 @@ definitions, and installation. Running `pixi install` uses rattler
 
 This approach has advantages:
 
-- Uses conda's mature solver and package cache
+- Uses conda's configured solver backend and mature package cache
 - Environments are standard conda prefixes (compatible with all conda tooling)
 - No additional resolver or package installation system to maintain
 - Works with existing conda channels, mirrors, and authentication
@@ -64,8 +64,9 @@ check = { depends-on = ["test", "lint"] }
 
 ## Compatibility with pixi
 
-conda-workspaces reads the same manifest format as pixi. A project with a
-`pixi.toml` or `pyproject.toml` can use both tools:
+conda-workspaces reads the supported workspace and task portions of
+pixi manifests. A project with a `pixi.toml` or `pyproject.toml` can use
+both tools when it stays within that shared surface:
 
 - pixi users run `pixi install` and `pixi run` as usual
 - conda users run `conda workspace install` and `conda task run` using conda's solver
@@ -81,7 +82,7 @@ for the compatibility mapping.
 
 | Tool | Scope | Tasks | Multi-env | Lock files | Solver |
 |---|---|---|---|---|---|
-| conda-workspaces | Workspaces + tasks | Yes | Yes | Yes (`conda.lock`) | conda / libmamba |
+| conda-workspaces | Workspaces + tasks | Yes | Yes | Yes (`conda.lock`) | configured conda solver backend |
 | pixi | Full project mgmt | Yes | Yes | Yes | rattler (bundled) |
 | conda-project | Project management | Commands only | Yes | Yes | conda (via conda-lock) |
 | anaconda-project | Project management | Commands only | Yes | Yes | conda |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -202,7 +202,7 @@ generated automatically after solving.
 You can point to a specific manifest with `--file` / `-f`:
 
 ```bash
-conda workspace install -f path/to/conda.toml
+conda workspace --file path/to/conda.toml install
 ```
 
 To recreate environments from scratch, use `--force-reinstall`:

--- a/docs/reference/conda-toml-spec.md
+++ b/docs/reference/conda-toml-spec.md
@@ -7,7 +7,7 @@ material for the future [Conda Enhancement Proposal][ceps] that will
 standardise the format across the conda ecosystem.
 
 For tutorials and examples see [Configuration](../configuration.md) and
-[Quickstart](../quickstart.md); for plugin name aliases see [Plugin
+[Quickstart](../quickstart.md). For plugin name aliases see [Plugin
 format names and aliases](format-aliases.md).
 
 [schema]: https://github.com/conda-incubator/conda-workspaces/blob/main/schema/conda-toml-1.schema.json
@@ -29,12 +29,13 @@ format names and aliases](format-aliases.md).
 `conda.toml` describes a *workspace*: a project root that may declare
 one or more conda environments composed from reusable *features*, plus
 a set of *tasks* that run inside those environments.  It is the
-conda-native sibling of `pixi.toml`; the schema is a constrained
-subset of `pixi.toml` plus one conda-specific extension, with the
-explicit goal that the conda-vouched-for subset can also be consumed
-by pixi.  The reverse direction (pixi.toml → conda.toml) holds only
-when the `pixi.toml` keeps to the fields described here; see *Pixi
-compatibility ladder* below for the precise asymmetry.
+conda-native sibling of `pixi.toml`. The core workspace, dependency,
+feature, environment, and task tables deliberately overlap with pixi,
+while conda-workspaces also owns conda-specific extensions such as
+`default-environment` and `[workspace.archive]`. The reverse direction
+(pixi.toml → conda.toml) holds only when the `pixi.toml` keeps to the
+fields described here. See *Pixi compatibility ladder* below for the
+precise asymmetry.
 
 Out of scope: package build recipes (use `recipe.yaml`), package
 distribution metadata (`pyproject.toml` `[project]`), and lockfile
@@ -95,6 +96,7 @@ Workspace metadata.
 | `channel-priority` | string | no | One of `"strict"`, `"flexible"`, `"disabled"`.  Maps to conda's solver setting. |
 | `envs-dir` | string | no | Where per-env prefixes live, relative to the workspace root.  Default: `.conda/envs`. |
 | `dependencies` | conda deps | no | Root-level dependency pool used by `{ workspace = true }` entries in dependency tables. |
+| `archive` | table | no | Archive filters and compression settings. See `[workspace.archive]`. |
 
 A *channel* is either:
 
@@ -124,9 +126,20 @@ When `name` is omitted, conda-workspaces follows Pixi's
 generated-name style, for example
 `{ platform = "linux-64", cuda = "12.0" }` becomes
 `linux-64-cuda-12-0`. The declared name is used by feature
-`platforms` restrictions and as the `conda.lock` platform key; the
+`platforms` restrictions and as the `conda.lock` platform key. The
 backing `platform` subdir is used for conda solves and package URL
 validation.
+
+### `[workspace.archive]`
+
+Archive settings used by `conda workspace archive`.
+
+| Field | Type | Description |
+|---|---|---|
+| `include` | array of string | Glob patterns for files to include. When set, only matching files are archived. |
+| `exclude` | array of string | Glob patterns for files to exclude. |
+| `compression` | string | One of `"zst"`, `"gz"`, or `"bz2"`. |
+| `compression-level` | integer | Compression level passed to the selected compressor. |
 
 ### `[workspace.dependencies]`
 
@@ -153,13 +166,13 @@ The inherited entry uses the root spec as a base. Non-version fields such
 as `build`, `channel`, `subdir`, `md5`, `sha256`, `url`, `file-name`,
 `license`, `license-family`, `features`, and `track-features` may be
 set on the consuming dependency to layer on top. `version` is owned by
-the workspace entry; setting both `workspace = true` and `version` is an
+the workspace entry. Setting both `workspace = true` and `version` is an
 error. `workspace = false` is also rejected.
 
 ### `[dependencies]`
 
 Conda packages that belong to the *default feature*.  Keys are package
-names; values are either a version constraint string or a *detailed
+names. Values are either a version constraint string or a *detailed
 dependency spec*. Detailed specs may also inherit from
 `[workspace.dependencies]` with `{ workspace = true }`.
 
@@ -185,23 +198,25 @@ A detailed conda dependency accepts:
 | `file-name` | string | Exact package filename. |
 | `license` / `license-family` | string | License constraints. |
 | `features` / `track-features` | array of strings | Feature constraints. |
-| `workspace` | boolean | Must be `true`; inherit from `[workspace.dependencies]`. Mutually exclusive with `version`. |
+| `workspace` | boolean | Must be `true`. Inherits from `[workspace.dependencies]`. Mutually exclusive with `version`. |
 
 ### `[pypi-dependencies]`
 
 PyPI packages that belong to the default feature.  Keys are package
-names; values are either a PEP 508 version-constraint string or a
+names. Values are either a PEP 508 version-constraint string or a
 *detailed PyPI dependency spec*:
 
 | Field | Type | Description |
 |---|---|---|
 | `version` | string | PEP 508 constraint. |
+| `extras` | array of string | Extras to request, e.g. `["http2"]`. |
 | `path` | string | Local path to the package. |
 | `editable` | boolean | Install in editable mode. |
 | `git` | string | Git repository URL. |
 | `branch` | string | Branch (with `git`). |
 | `tag` | string | Tag (with `git`). |
 | `rev` | string | Revision (with `git`). |
+| `url` | string | Direct package URL. |
 
 ### `[activation]`
 
@@ -215,9 +230,10 @@ Default-feature activation settings.
 ### `[system-requirements]`
 
 Default-feature system-level constraints (e.g. minimum glibc, macOS
-version).  All keys are strings; values are stringified version
-constraints.  Recognised keys mirror conda's virtual-package names
-(`__glibc`, `__osx`, `__cuda`, …).
+version). Recognised keys mirror conda's virtual-package names
+(`__glibc`, `__osx`, `__cuda`, …). Values are stringified version
+constraints, except `libc` may also use pixi's inline table form
+`{ family = "glibc", version = "2.28" }`.
 
 ### `[target.<platform>]`
 
@@ -241,11 +257,11 @@ arbitrary identifier referenced from `[environments]`.
 | `dependencies` | conda deps | Conda dependencies for this feature. |
 | `pypi-dependencies` | PyPI deps | PyPI dependencies for this feature. |
 | `channels` | array of *channel* | Additional channels. |
-| `platforms` | array of *platform* | Restrict the feature to these platform names. |
+| `platforms` | array of string | Restrict the feature to declared platform names or subdirs. |
 | `system-requirements` | table | Per-feature system requirements. |
 | `activation` | table | Per-feature activation. |
 | `target` | table of `[target.<platform>]` | Per-platform dep overrides for the feature. |
-| `tasks` | table | Tasks contributed by this feature; merged into the workspace task set. |
+| `tasks` | table | Tasks contributed by this feature and merged into the workspace task set. |
 
 ### `[environments]`
 
@@ -265,7 +281,7 @@ docs = { features = ["docs"], no-default-feature = false }
 | Field | Type | Description |
 |---|---|---|
 | `features` | array of string | Feature names to include in addition to the default feature. |
-| `solve-group` | string | Solve-group identifier; environments in the same solve-group are version-coordinated. |
+| `solve-group` | string | Accepted for pixi compatibility. Currently ignored. Environments are solved independently. |
 | `no-default-feature` | boolean | If `true`, exclude the default feature from this environment.  Default: `false`. |
 
 When `[environments]` is omitted entirely, a single implicit
@@ -313,7 +329,7 @@ When a tool resolves an environment named `<env>`:
    `[pypi-dependencies]`, `[activation]`, `[system-requirements]`,
    `[target]`) unless the environment sets `no-default-feature = true`.
 2. Merge in each named feature listed in `features`, in order.  Later
-   features override earlier ones for conflicting keys; lists are
+   features override earlier ones for conflicting keys. Lists are
    concatenated and de-duplicated.
 3. Apply `[target.<platform>]` overrides for the host's platform last.
 
@@ -330,7 +346,7 @@ derived from [rattler-lock v6][rattler-lock] (the same schema
 `version: 1` instead of `version: 6` so tools can identify the file as
 conda-workspaces-owned at a glance.  The remainder of the document —
 `environments`, `packages`, channels, platform package lists — is
-byte-compatible.
+structure-compatible with rattler-lock v6.
 
 See [Plugin format names and aliases](format-aliases.md) for the
 canonical and alias strings under which `conda.lock` is registered.
@@ -403,22 +419,22 @@ relationship is:
 
 | Direction | Holds? | Why |
 |---|---|---|
-| Every valid `conda.toml` is a valid `pixi.toml` (modulo filename). | **Yes** | The fields enumerated in this spec are all accepted by pixi. |
-| Every valid `pixi.toml` is a valid `conda.toml`. | **No** | Pixi's `[workspace]` accepts additional fields (`authors`, `license`, `readme`, `homepage`, `repository`, `documentation`, `requires-pixi`, `preview`, `build-variants`, `conda-pypi-map`, …) that this v1 schema does not list.  The schema rejects unknown keys (`additionalProperties: false`); pixi-only fields are therefore not accepted in a `conda.toml`. |
-| pixi reads our `default-environment` task field. | **No** | `default-environment` (in `[tasks]` and `[feature.*.tasks]`) is the only conda-workspaces extension; pixi will silently ignore it. |
-| conda-workspaces reads `pixi.toml`. | **Yes** | conda-workspaces ships a separate compatibility reader for `pixi.toml` and `[tool.pixi.*]`; that reader is *out of scope* for this spec and is documented in [Configuration](../configuration.md). |
+| Every valid `conda.toml` is a valid `pixi.toml` (modulo filename). | **No** | The core workspace/dependency/task fields overlap intentionally, but conda-workspaces extensions such as `default-environment` and `[workspace.archive]` are not pixi schema guarantees. |
+| Every valid `pixi.toml` is a valid `conda.toml`. | **No** | Pixi's `[workspace]` accepts additional fields (`authors`, `license`, `readme`, `homepage`, `repository`, `documentation`, `requires-pixi`, `preview`, `build-variants`, `conda-pypi-map`, …) that this v1 schema does not list. The schema is a strict validation target and rejects unknown keys (`additionalProperties: false`). |
+| pixi reads our `default-environment` task field. | **No** | `default-environment` (in `[tasks]` and `[feature.*.tasks]`) is a conda-workspaces extension. Pixi may ignore it. |
+| conda-workspaces reads `pixi.toml`. | **Yes** | conda-workspaces ships a separate compatibility reader for `pixi.toml` and `[tool.pixi.*]`. That reader is *out of scope* for this spec and is documented in [Configuration](../configuration.md). |
 
 Two intentional differences from `pixi.toml`:
 
-- `conda.toml` accepts only `[workspace]`; the legacy pixi `[project]`
+- `conda.toml` accepts only `[workspace]`. The legacy pixi `[project]`
   table is not part of this specification.
-- conda-workspaces resolves dependencies with conda's solver
-  (libmamba) and installs them as conventional conda prefixes; pixi's
+- conda-workspaces resolves dependencies with conda's configured solver
+  backend and installs them as conventional conda prefixes. Pixi's
   build-process options (e.g. `[package]`-style build recipes) are not
   part of this specification.
 
 If you need pixi-only fields, write a `pixi.toml` and let
-conda-workspaces' compatibility reader handle it; do not extend
+conda-workspaces' compatibility reader handle it. Do not extend
 `conda.toml` with them.
 
 ## Versioning policy
@@ -431,9 +447,10 @@ canonical name (`conda-workspaces-v2`).  Aliases follow the rules in
 [`format-aliases.md`](format-aliases.md).
 
 Backwards-compatible additions (new optional fields, new platforms in
-the *platform* enum) do *not* bump the version.  Tools MUST ignore
-unknown top-level keys and unknown keys inside known tables in the
-same major version.
+the *platform* enum) do *not* bump the version.  The JSON schema is the
+strict validation target for this version. The conda-workspaces runtime
+parser is intentionally more permissive for pixi and forward
+compatibility and may ignore unknown fields when reading manifests.
 
 ## Open questions (non-normative)
 
@@ -441,8 +458,8 @@ These are tracked for the CEP draft and are not part of `v1`:
 
 - Whether `[workspace]` should be required to carry `version` and
   `name` (currently both optional).
-- Whether `solve-group` semantics need a normative description beyond
-  "version-coordinated".
+- Whether `solve-group` should ever gain conda-workspaces semantics, or
+  remain an accepted no-op compatibility field.
 - Whether to standardise an `[envs]` shorthand that maps a feature
   one-to-one to an environment of the same name.
 - Discovery rules for nested workspaces (currently parent-directory
@@ -451,8 +468,8 @@ These are tracked for the CEP draft and are not part of `v1`:
   or in a separate "compatibility" CEP.
 - Whether `conda.toml` should exist as a separate filename at all, or
   whether the spec should describe a "conda-workspaces dialect of
-  `pixi.toml`" — i.e. a `pixi.toml` plus the single
-  `default-environment` extension, without a parallel filename or
-  schema URL.  Trade-off: governance ownership (conda community vs.
-  Prefix.dev) versus format proliferation.  See the CEP tracker for
-  discussion.
+  `pixi.toml`" — i.e. a `pixi.toml` plus conda-workspaces extensions
+  such as `default-environment` and `[workspace.archive]`, without a
+  parallel filename or schema URL.  Trade-off: governance ownership
+  (conda community vs. Prefix.dev) versus format proliferation.  See
+  the CEP tracker for discussion.

--- a/docs/tutorials/coming-from/anaconda-project.md
+++ b/docs/tutorials/coming-from/anaconda-project.md
@@ -45,7 +45,7 @@ and interactive variable prompting have no direct equivalent.
 | Downloads | `downloads:` (auto-fetched files) | not supported (use tasks instead) |
 | Services | `services:` (e.g. Redis) | not supported (use tasks or Docker instead) |
 | Archives | `anaconda-project archive` | `conda workspace archive` / `unarchive` |
-| Solver | conda | conda / libmamba |
+| Solver | conda | configured conda solver backend |
 | pixi compatibility | no | reads `pixi.toml` and `pyproject.toml` |
 
 ## Command mapping

--- a/docs/tutorials/coming-from/conda-project.md
+++ b/docs/tutorials/coming-from/conda-project.md
@@ -15,7 +15,7 @@ commands to their conda-workspaces equivalents.
 | Multiple environments | separate `environment.yml` files | composable features in one manifest |
 | Commands | flat `commands:` map | `[tasks]` with dependency graphs, caching, templates |
 | Variables | `variables:` with `.env` file | Jinja2 templates + environment variables |
-| Solver | conda / conda-lock | conda / libmamba |
+| Solver | conda / conda-lock | configured conda solver backend |
 | pixi compatibility | no | reads `pixi.toml` and `pyproject.toml` |
 | Platform overrides | per-platform lock only | per-platform dependencies and tasks |
 

--- a/docs/tutorials/coming-from/conda.md
+++ b/docs/tutorials/coming-from/conda.md
@@ -7,10 +7,11 @@ already know.
 
 ## What stays the same
 
-conda-workspaces is a conda plugin — it uses conda's solver, channels,
-and package infrastructure under the hood. Your `.condarc` settings,
-channel configuration, and package cache all carry over. Environments
-are real conda prefixes you can inspect with `conda list`.
+conda-workspaces is a conda plugin — it uses conda's configured solver
+backend, channels, and package infrastructure under the hood. Your
+`.condarc` settings, channel configuration, and package cache all carry
+over. Environments are real conda prefixes you can inspect with
+`conda list`.
 
 ## What changes
 

--- a/docs/tutorials/coming-from/pixi.md
+++ b/docs/tutorials/coming-from/pixi.md
@@ -10,7 +10,7 @@ how the two tools relate and how to use them side by side.
 
 | Aspect | pixi | conda-workspaces |
 |---|---|---|
-| Solver | rattler (bundled) | conda / libmamba |
+| Solver | rattler (bundled) | configured conda solver backend |
 | Environment location | `.pixi/envs/` | `.conda/envs/` |
 | Lock file | `pixi.lock` | `conda.lock` (same schema family as `pixi.lock`, distinct filename and on-disk version byte) |
 | Task runner | Built-in | Built-in (`conda task`) |
@@ -34,8 +34,8 @@ conda workspace install
 conda task run test
 ```
 
-Both read the same `pixi.toml` (or `pyproject.toml`) manifest —
-workspace definitions and task definitions alike.
+Both read the same supported `pixi.toml` (or `pyproject.toml`)
+workspace and task definitions.
 
 ## Command mapping
 
@@ -99,7 +99,8 @@ clean = "{% if conda.is_win %}rd /s /q build{% else %}rm -rf build/{% endif %}"
 ## Using conda.toml instead
 
 If your team uses only conda, you can use `conda.toml` instead of
-`pixi.toml`. The format is structurally identical:
+`pixi.toml`. The core workspace, feature, environment, dependency, and
+task tables use the same structure:
 
 ```bash
 conda workspace init --format conda
@@ -148,7 +149,7 @@ output, or `-o custom.toml` to choose a different output path.
 To export only tasks, use the task export command instead:
 
 ```bash
-conda task export --file pixi.toml -o conda.toml
+conda task --file pixi.toml export -o conda.toml
 ```
 
 ## Cross-platform solving
@@ -211,8 +212,8 @@ A `[system-requirements]` version is lifted into the baseline
 override so the solver's `__<pkg> >=<version>` spec and the virtual
 package record it matches against agree. `__cuda` and `__archspec`
 are *not* auto-seeded — opt in via `[system-requirements]` or
-`CONDA_OVERRIDE_*` when you need them. Every setting here is also
-honoured by `pixi`.
+`CONDA_OVERRIDE_*` when you need them. The `[system-requirements]`
+manifest form is shared with pixi. `CONDA_OVERRIDE_*` is conda-specific.
 
 ## What's not supported
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -27,7 +27,7 @@ Migrate from conda, pixi, anaconda-project, or conda-project.
 :link: pypi-dependencies
 :link-type: doc
 
-Add PyPI packages, editable local installs, and git dependencies.
+Add PyPI packages and editable local installs, with notes on unsupported git/URL forms.
 :::
 
 :::{grid-item-card} {octicon}`globe` Multi-platform locking

--- a/docs/tutorials/pypi-dependencies.md
+++ b/docs/tutorials/pypi-dependencies.md
@@ -37,8 +37,11 @@ packages from PyPI available as conda packages. It uses sharded
 repodata, which requires the rattler solver to read. Without this
 channel, the solver has no source for PyPI-originated packages.
 
-If conda-pypi or conda-rattler-solver is missing, `conda workspace
-install` prints a warning and skips PyPI dependencies.
+If conda-pypi is missing, `conda workspace install` prints warnings and
+skips version-only and local path PyPI dependencies. If
+conda-rattler-solver is missing, install still translates version-only
+PyPI dependencies into specs but warns that the configured solver may
+not be able to read the `conda-pypi` channel.
 
 :::{seealso}
 These tools build on the conda plugin architecture defined in
@@ -72,7 +75,8 @@ pydantic = ">=2.0,<3"
 PyPI package names are translated to their conda equivalents via the
 [grayskull mapping](https://github.com/conda/grayskull) and merged
 into the same solver call as conda dependencies. The solver resolves
-everything together, so conda and PyPI packages cannot conflict.
+everything together, so incompatible conda and PyPI requirements fail
+as a single solve instead of being discovered after installation.
 
 Install as usual:
 
@@ -134,7 +138,8 @@ as conda or versioned PyPI dependencies in the manifest.
 
 ## Git and URL dependencies
 
-You can also install packages directly from git repositories or URLs:
+The manifest parser accepts git and URL dependency forms for pixi
+compatibility:
 
 ```toml
 [pypi-dependencies]
@@ -142,8 +147,9 @@ my-fork = { git = "https://github.com/user/project.git", branch = "main" }
 some-wheel = { url = "https://example.com/pkg-1.0-py3-none-any.whl" }
 ```
 
-Like editable installs, these are built post-solve by conda-pypi and
-do not participate in the solver pass.
+These are not installed yet. `conda workspace install` skips them with
+a warning, so use local path dependencies for editable project code or
+publish the package to a channel that conda can solve from.
 
 ## Troubleshooting
 

--- a/schema/conda-toml-1.schema.json
+++ b/schema/conda-toml-1.schema.json
@@ -102,7 +102,7 @@
           "type": "array",
           "description": "Supported platforms.",
           "items": {
-            "$ref": "#/$defs/platform"
+            "$ref": "#/$defs/workspacePlatform"
           },
           "uniqueItems": true
         },
@@ -118,9 +118,81 @@
         "dependencies": {
           "$ref": "#/$defs/workspaceCondaDependencies",
           "description": "Root-level conda dependency pool. Dependency tables may opt into these specs with { workspace = true }."
+        },
+        "archive": {
+          "$ref": "#/$defs/archive",
+          "description": "Archive include/exclude and compression settings."
         }
       },
       "required": ["channels", "platforms"],
+      "additionalProperties": false
+    },
+    "workspacePlatform": {
+      "description": "A workspace platform, either a conda subdir string or a Pixi rich-platform table.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/platform"
+        },
+        {
+          "$ref": "#/$defs/richPlatform"
+        }
+      ]
+    },
+    "platformName": {
+      "type": "string",
+      "description": "A declared workspace platform name. This may be a conda subdir or a rich-platform name."
+    },
+    "richPlatform": {
+      "type": "object",
+      "description": "Pixi-compatible rich platform entry with an optional workspace-scoped name and virtual package constraints.",
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/platformName"
+        },
+        "platform": {
+          "$ref": "#/$defs/platform"
+        },
+        "archspec": {
+          "type": "string"
+        },
+        "cuda": {
+          "type": "string"
+        },
+        "glibc": {
+          "type": "string"
+        },
+        "libc": {
+          "$ref": "#/$defs/libcSystemRequirement"
+        },
+        "linux": {
+          "type": "string"
+        },
+        "macos": {
+          "type": "string"
+        },
+        "osx": {
+          "type": "string"
+        },
+        "win": {
+          "type": "string"
+        },
+        "windows": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^__": {
+          "type": "string"
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["name"]
+        },
+        {
+          "required": ["platform"]
+        }
+      ],
       "additionalProperties": false
     },
     "channel": {
@@ -291,6 +363,13 @@
               "type": "string",
               "description": "Version constraint (e.g. '>=2.28')."
             },
+            "extras": {
+              "type": "array",
+              "description": "PyPI extras to request.",
+              "items": {
+                "type": "string"
+              }
+            },
             "path": {
               "type": "string",
               "description": "Local path to the package."
@@ -314,6 +393,10 @@
             "rev": {
               "type": "string",
               "description": "Git revision to use."
+            },
+            "url": {
+              "type": "string",
+              "description": "Direct package URL."
             }
           },
           "additionalProperties": false
@@ -351,15 +434,40 @@
     "systemRequirements": {
       "type": "object",
       "description": "System-level requirements (e.g. minimum glibc or macOS version).",
+      "properties": {
+        "libc": {
+          "$ref": "#/$defs/libcSystemRequirement"
+        }
+      },
       "additionalProperties": {
         "type": "string"
       }
+    },
+    "libcSystemRequirement": {
+      "description": "Pixi-style libc requirement, either as a version string or a family/version table.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "family": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "targets": {
       "type": "object",
       "description": "Per-platform dependency overrides keyed by platform name.",
       "propertyNames": {
-        "$ref": "#/$defs/platform"
+        "$ref": "#/$defs/platformName"
       },
       "additionalProperties": {
         "$ref": "#/$defs/targetOverride"
@@ -403,7 +511,7 @@
           "type": "array",
           "description": "Platform restrictions for this feature.",
           "items": {
-            "$ref": "#/$defs/platform"
+            "$ref": "#/$defs/platformName"
           },
           "uniqueItems": true
         },
@@ -429,6 +537,36 @@
       "additionalProperties": {
         "$ref": "#/$defs/task"
       }
+    },
+    "archive": {
+      "type": "object",
+      "description": "Workspace archive filters and compression settings.",
+      "properties": {
+        "include": {
+          "type": "array",
+          "description": "Glob patterns for files to include.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "exclude": {
+          "type": "array",
+          "description": "Glob patterns for files to exclude.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "compression": {
+          "type": "string",
+          "description": "Archive compression algorithm.",
+          "enum": ["zst", "gz", "bz2"]
+        },
+        "compression-level": {
+          "type": "integer",
+          "description": "Compression level passed to the selected compressor."
+        }
+      },
+      "additionalProperties": false
     },
     "task": {
       "description": "A task definition: either a command string/array or a task table.",

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from conda.plugins.types import EnvironmentFormat
 
 from conda_workspaces import env_spec, lockfile
 from conda_workspaces.plugin import (
@@ -38,6 +39,10 @@ def test_conda_environment_specifiers(name: str, expected_cls_name: str) -> None
     items = {s.name: s for s in conda_environment_specifiers()}
     assert name in items
     assert items[name].environment_spec.__name__ == expected_cls_name
+    if name == lockfile.FORMAT:
+        assert items[name].environment_format == EnvironmentFormat.lockfile
+    else:
+        assert items[name].environment_format == EnvironmentFormat.environment
 
 
 def test_conda_environment_exporters_yields_lockfile_and_manifests() -> None:
@@ -53,6 +58,7 @@ def test_conda_environment_exporters_yields_lockfile_and_manifests() -> None:
     lock_exp = items[lockfile.FORMAT]
     assert lock_exp.aliases == lockfile.ALIASES
     assert lock_exp.default_filenames == lockfile.DEFAULT_FILENAMES
+    assert lock_exp.environment_format == EnvironmentFormat.lockfile
     assert callable(lock_exp.multiplatform_export)
 
     for name, filename in [
@@ -62,6 +68,7 @@ def test_conda_environment_exporters_yields_lockfile_and_manifests() -> None:
     ]:
         exp = items[name]
         assert exp.default_filenames == (filename,)
+        assert exp.environment_format == EnvironmentFormat.environment
         assert callable(exp.multiplatform_export)
 
 


### PR DESCRIPTION
## Summary
- Mark the conda-workspaces lockfile specifier/exporter as a lockfile environment format so conda 26.5 groups it correctly.
- Refresh DESIGN, README, and docs for the configured conda solver backend, current lockfile version-byte behavior, parent `--file` placement, PyPI support boundaries, and pixi compatibility limits.
- Align the `conda.toml` JSON schema with the current parser/docs for rich workspace platforms, `[workspace.archive]`, PyPI `extras`/`url`, `libc` system-requirement tables, and named platform references.

## Validation
- `pixi run -e test pytest`
- `pixi run ruff check`
- `pixi run format-check`
- `pixi run -e docs docs`
- `pixi run python -m json.tool schema/conda-toml-1.schema.json >/tmp/conda-toml-schema.json`
- `pixi run ruff format --check` was run and currently fails on an unrelated untracked `demos/generate-voiceover.py` file outside this PR.