### PR TITLE
Simplify over-engineered helpers

### DIFF
--- a/conda_workspaces/archive.py
+++ b/conda_workspaces/archive.py
@@ -760,13 +760,13 @@ def is_excluded_by_builtins(rel_path: str) -> bool:
     for excl in BUILTIN_EXCLUDE_DIRS:
         if rel_path == excl or rel_path.startswith(excl + "/"):
             return True
-    if is_excluded_by_patterns(rel_path, BUILTIN_SENSITIVE_EXCLUDE_EXCEPTIONS):
+    if matches_patterns(rel_path, BUILTIN_SENSITIVE_EXCLUDE_EXCEPTIONS):
         return False
-    return is_excluded_by_patterns(rel_path, BUILTIN_SENSITIVE_EXCLUDE_PATTERNS)
+    return matches_patterns(rel_path, BUILTIN_SENSITIVE_EXCLUDE_PATTERNS)
 
 
-def is_excluded_by_patterns(rel_path: str, patterns: tuple[str, ...]) -> bool:
-    """Return True if *rel_path* matches any of the user-supplied glob *patterns*."""
+def matches_patterns(rel_path: str, patterns: tuple[str, ...]) -> bool:
+    """Return True if *rel_path* or any parent matches one glob pattern."""
     for pattern in patterns:
         if fnmatch.fnmatch(rel_path, pattern):
             return True
@@ -797,11 +797,9 @@ def collect_archive_files(
         rel = path.relative_to(root).as_posix()
         if is_excluded_by_builtins(rel):
             continue
-        if archive_config.include and not is_included_by_patterns(
-            rel, archive_config.include
-        ):
+        if archive_config.include and not matches_patterns(rel, archive_config.include):
             continue
-        if is_excluded_by_patterns(rel, archive_config.exclude):
+        if matches_patterns(rel, archive_config.exclude):
             continue
         result.append(path)
 
@@ -839,19 +837,6 @@ def zstd_module() -> Any:
             "or choose an archive name ending in .tar.gz or .tar.bz2.",
         ],
     )
-
-
-def is_included_by_patterns(rel_path: str, patterns: tuple[str, ...]) -> bool:
-    """Return True if *rel_path* matches any include pattern."""
-    for pattern in patterns:
-        if fnmatch.fnmatch(rel_path, pattern):
-            return True
-        parts = rel_path.split("/")
-        for i in range(len(parts)):
-            partial = "/".join(parts[: i + 1])
-            if fnmatch.fnmatch(partial, pattern):
-                return True
-    return False
 
 
 @contextmanager

--- a/conda_workspaces/cache.py
+++ b/conda_workspaces/cache.py
@@ -5,8 +5,7 @@ Cache entries are stored in a platform-appropriate directory via
 of the project root path. Within that, each task has a JSON file
 containing fingerprints of its inputs and outputs.
 
-SHA-256 digests are the authoritative file identity. ``mtime`` and
-``size`` are retained as metadata and for older cache entries.
+SHA-256 digests are the file identity.
 """
 
 from __future__ import annotations
@@ -14,7 +13,6 @@ from __future__ import annotations
 import glob
 import hashlib
 import json
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -42,15 +40,6 @@ def _cache_file(project_root: Path, task_name: str) -> Path:
     return _project_cache_dir(project_root) / f"{task_name}.json"
 
 
-def _file_stat(path: str) -> tuple[float, int] | None:
-    """Return ``(mtime, size)`` for *path*, or None if missing."""
-    try:
-        st = os.stat(path)
-        return (st.st_mtime, st.st_size)
-    except OSError:
-        return None
-
-
 def _file_sha256(path: str) -> str:
     """Return the hex SHA-256 digest of the file at *path*."""
     h = hashlib.sha256()
@@ -70,17 +59,14 @@ def _expand_globs(patterns: list[str], cwd: Path) -> list[str]:
 
 
 def _fingerprint_files(paths: list[str]) -> dict[str, dict[str, Any]]:
-    """Build a fingerprint dict: ``{path: {mtime, size, sha256}}``."""
+    """Build a fingerprint dict: ``{path: {sha256}}``."""
     fp: dict[str, dict[str, Any]] = {}
     for p in paths:
-        stat = _file_stat(p)
-        if stat is None:
+        try:
+            digest = _file_sha256(p)
+        except OSError:
             continue
-        fp[p] = {
-            "mtime": stat[0],
-            "size": stat[1],
-            "sha256": _file_sha256(p),
-        }
+        fp[p] = {"sha256": digest}
     return fp
 
 
@@ -121,8 +107,7 @@ def is_cached(
 
     1. A cache entry exists for the task.
     2. The command and env hashes match.
-    3. All input files match by SHA-256 digest, falling back to
-       ``(mtime, size)`` only for older entries without digests.
+    3. All input files match by SHA-256 digest.
     4. All output files still exist and match.
     """
     cf = _cache_file(project_root, task_name)
@@ -160,17 +145,8 @@ def _files_match(cached: dict[str, Any], current: dict[str, Any]) -> bool:
         prev = cached.get(path)
         if prev is None:
             return False
-        prev_sha = prev.get("sha256")
-        cur_sha = cur.get("sha256")
-        if prev_sha is not None and cur_sha is not None:
-            if prev_sha != cur_sha or prev.get("size") != cur.get("size"):
-                return False
-            continue
-        if prev.get("mtime") == cur.get("mtime") and prev.get("size") == cur.get(
-            "size"
-        ):
-            continue
-        return False
+        if prev.get("sha256") != cur.get("sha256"):
+            return False
     return True
 
 

--- a/conda_workspaces/cli/workspace/archive.py
+++ b/conda_workspaces/cli/workspace/archive.py
@@ -10,12 +10,6 @@ from rich.markup import escape
 
 from ...archive import (
     WorkspaceArchive,
-    extract_verified_archive,
-    file_contains_bytes,
-    is_absolute_runtime_prefix,
-    receipt_environment_prefixes,
-    resolve_receipt_path,
-    runtime_prefix_relative_path,
     scan_prefix_references,
 )
 from ...exceptions import ArchiveError
@@ -23,18 +17,6 @@ from .. import status
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-__all__ = (
-    "execute_archive",
-    "execute_unarchive",
-    "extract_verified_archive",
-    "file_contains_bytes",
-    "is_absolute_runtime_prefix",
-    "receipt_environment_prefixes",
-    "resolve_receipt_path",
-    "runtime_prefix_relative_path",
-    "scan_prefix_references",
-)
 
 
 def warn_staging_prefix_references(

--- a/conda_workspaces/graph.py
+++ b/conda_workspaces/graph.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import deque
+from graphlib import CycleError, TopologicalSorter
 from typing import TYPE_CHECKING
 
 from .exceptions import CyclicDependencyError, TaskNotFoundError
@@ -19,7 +20,7 @@ def resolve_execution_order(
 ) -> list[str]:
     """Return task names in the order they should execute to run *target*.
 
-    Uses Kahn's algorithm for topological sort. Only the transitive
+    Uses :class:`graphlib.TopologicalSorter`. Only the transitive
     closure of *target*'s dependencies is included -- unrelated tasks
     are omitted.
 
@@ -54,62 +55,13 @@ def _collect_reachable(target: str, tasks: dict[str, Task]) -> set[str]:
 
 
 def _topological_sort(names: set[str], tasks: dict[str, Task]) -> list[str]:
-    """Kahn's algorithm over the subset *names*."""
-    in_degree: dict[str, int] = {n: 0 for n in names}
-    adjacency: dict[str, list[str]] = {n: [] for n in names}
-
-    for name in names:
-        for dep in tasks[name].depends_on:
-            if dep.task in names:
-                adjacency[dep.task].append(name)
-                in_degree[name] += 1
-
-    queue: deque[str] = deque(sorted(n for n in names if in_degree[n] == 0))
-    order: list[str] = []
-
-    while queue:
-        node = queue.popleft()
-        order.append(node)
-        for successor in sorted(adjacency[node]):
-            in_degree[successor] -= 1
-            if in_degree[successor] == 0:
-                queue.append(successor)
-
-    if len(order) != len(names):
-        remaining = names - set(order)
-        cycle = _find_cycle(remaining, tasks)
-        raise CyclicDependencyError(cycle)
-
-    return order
-
-
-def _find_cycle(names: set[str], tasks: dict[str, Task]) -> list[str]:
-    """Find and return one cycle in the dependency graph as a path."""
-    visited: set[str] = set()
-    path: list[str] = []
-    on_stack: set[str] = set()
-
-    def dfs(node: str) -> list[str] | None:
-        visited.add(node)
-        on_stack.add(node)
-        path.append(node)
-        for dep in tasks[node].depends_on:
-            if dep.task not in names:
-                continue
-            if dep.task in on_stack:
-                idx = path.index(dep.task)
-                return path[idx:] + [dep.task]
-            if dep.task not in visited:
-                result = dfs(dep.task)
-                if result is not None:
-                    return result
-        path.pop()
-        on_stack.discard(node)
-        return None
-
-    for name in sorted(names):
-        if name not in visited:
-            result = dfs(name)
-            if result is not None:
-                return result
-    return list(names)
+    """Topologically sort over the subset *names*."""
+    graph = {
+        name: sorted(dep.task for dep in tasks[name].depends_on if dep.task in names)
+        for name in sorted(names)
+    }
+    try:
+        return list(TopologicalSorter(graph).static_order())
+    except CycleError as exc:
+        cycle = list(exc.args[1]) if len(exc.args) > 1 else sorted(names)
+        raise CyclicDependencyError(cycle) from exc

--- a/conda_workspaces/importers/anaconda_project.py
+++ b/conda_workspaces/importers/anaconda_project.py
@@ -129,6 +129,3 @@ class AnacondaProjectImporter(ManifestImporter):
         if len(task) == 1 and "cmd" in task:
             return task["cmd"]
         return task
-
-
-convert = AnacondaProjectImporter().convert

--- a/conda_workspaces/importers/conda_project.py
+++ b/conda_workspaces/importers/conda_project.py
@@ -139,6 +139,3 @@ class CondaProjectImporter(ManifestImporter):
                     " directory and avoid symlinks that point outside it.",
                 ],
             ) from exc
-
-
-convert = CondaProjectImporter().convert

--- a/conda_workspaces/importers/environment_yml.py
+++ b/conda_workspaces/importers/environment_yml.py
@@ -41,6 +41,3 @@ class EnvironmentYmlImporter(ManifestImporter):
             doc.add("pypi-dependencies", tomlkit.item(pypi_deps))
 
         return doc
-
-
-convert = EnvironmentYmlImporter().convert

--- a/conda_workspaces/importers/pixi_toml.py
+++ b/conda_workspaces/importers/pixi_toml.py
@@ -26,6 +26,3 @@ class PixiTomlImporter(ManifestImporter):
         config = parser.parse(path)
         tasks = parser.parse_tasks(path)
         return config_to_toml(config, tasks)
-
-
-convert = PixiTomlImporter().convert

--- a/conda_workspaces/importers/pyproject_toml.py
+++ b/conda_workspaces/importers/pyproject_toml.py
@@ -26,6 +26,3 @@ class PyprojectTomlImporter(ManifestImporter):
         config = parser.parse(path)
         tasks = parser.parse_tasks(path)
         return config_to_toml(config, tasks)
-
-
-convert = PyprojectTomlImporter().convert

--- a/conda_workspaces/manifests/base.py
+++ b/conda_workspaces/manifests/base.py
@@ -12,7 +12,7 @@ import tomlkit
 from conda.base.constants import KNOWN_SUBDIRS
 from packaging.requirements import InvalidRequirement, Requirement
 
-from ..exceptions import ManifestExistsError, WorkspaceParseError
+from ..exceptions import ManifestExistsError, TaskNotFoundError, WorkspaceParseError
 from ..models import WorkspaceConfig
 
 _PYPI_NAME_TAIL_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)(.*)$")
@@ -557,16 +557,25 @@ class ManifestParser(ABC):
         return {}
 
     def add_task(self, path: Path, name: str, task: Task) -> None:
-        """Persist a new task definition into *path*."""
-        raise NotImplementedError(
-            f"{type(self).__name__} does not support writing tasks to {path.name}."
-        )
+        """Persist a top-level task definition into *path*."""
+        if path.exists():
+            doc = tomlkit.loads(path.read_text(encoding="utf-8"))
+        else:
+            doc = tomlkit.document()
+
+        tasks_section = doc.setdefault("tasks", tomlkit.table())
+        tasks_section[name] = self.task_to_toml_inline(task)
+        path.write_text(tomlkit.dumps(doc), encoding="utf-8")
 
     def remove_task(self, path: Path, name: str) -> None:
-        """Remove the task named *name* from *path*."""
-        raise NotImplementedError(
-            f"{type(self).__name__} does not support writing tasks to {path.name}."
-        )
+        """Remove the top-level task named *name* from *path*."""
+        doc = tomlkit.loads(path.read_text(encoding="utf-8"))
+        tasks_section = doc.get("tasks", {})
+        if name not in tasks_section:
+            raise TaskNotFoundError(name, list(tasks_section.keys()))
+        del tasks_section[name]
+        self.remove_target_overrides(doc, name)
+        path.write_text(tomlkit.dumps(doc), encoding="utf-8")
 
     def task_to_toml_inline(self, task: Task) -> str | InlineTable:
         """Convert a *task* to a TOML-serializable value (string or inline table)."""

--- a/conda_workspaces/manifests/pixi_toml.py
+++ b/conda_workspaces/manifests/pixi_toml.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 
 import tomlkit
 
-from ..exceptions import TaskNotFoundError, TaskParseError, WorkspaceParseError
+from ..exceptions import TaskParseError, WorkspaceParseError
 from ..models import WorkspaceConfig
 from .base import ManifestParser
 from .normalize import parse_feature_tasks, parse_tasks_and_targets
@@ -99,22 +99,3 @@ class PixiTomlParser(ManifestParser):
         tasks = parse_tasks_and_targets(data)
         parse_feature_tasks(data, tasks)
         return tasks
-
-    def add_task(self, path: Path, name: str, task: Task) -> None:
-        if path.exists():
-            doc = tomlkit.loads(path.read_text(encoding="utf-8"))
-        else:
-            doc = tomlkit.document()
-
-        tasks_section = doc.setdefault("tasks", tomlkit.table())
-        tasks_section[name] = self.task_to_toml_inline(task)
-        path.write_text(tomlkit.dumps(doc), encoding="utf-8")
-
-    def remove_task(self, path: Path, name: str) -> None:
-        doc = tomlkit.loads(path.read_text(encoding="utf-8"))
-        tasks_section = doc.get("tasks", {})
-        if name not in tasks_section:
-            raise TaskNotFoundError(name, list(tasks_section.keys()))
-        del tasks_section[name]
-        self.remove_target_overrides(doc, name)
-        path.write_text(tomlkit.dumps(doc), encoding="utf-8")

--- a/conda_workspaces/manifests/toml.py
+++ b/conda_workspaces/manifests/toml.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 import tomlkit
 
-from ..exceptions import TaskNotFoundError, TaskParseError, WorkspaceParseError
+from ..exceptions import TaskParseError, WorkspaceParseError
 from ..models import (
     ArchiveConfig,
     Channel,
@@ -77,25 +77,6 @@ class CondaTomlParser(ManifestParser):
         except Exception as exc:
             raise TaskParseError(str(path), str(exc)) from exc
         return parse_tasks_and_targets(data)
-
-    def add_task(self, path: Path, name: str, task: Task) -> None:
-        if path.exists():
-            doc = tomlkit.loads(path.read_text(encoding="utf-8"))
-        else:
-            doc = tomlkit.document()
-
-        tasks_section = doc.setdefault("tasks", tomlkit.table())
-        tasks_section[name] = self.task_to_toml_inline(task)
-        path.write_text(tomlkit.dumps(doc), encoding="utf-8")
-
-    def remove_task(self, path: Path, name: str) -> None:
-        doc = tomlkit.loads(path.read_text(encoding="utf-8"))
-        tasks_section = doc.get("tasks", {})
-        if name not in tasks_section:
-            raise TaskNotFoundError(name, list(tasks_section.keys()))
-        del tasks_section[name]
-        self.remove_target_overrides(doc, name)
-        path.write_text(tomlkit.dumps(doc), encoding="utf-8")
 
 
 def tasks_to_toml(tasks: dict[str, Task]) -> str:

--- a/tests/cli/workspace/test_archive.py
+++ b/tests/cli/workspace/test_archive.py
@@ -12,10 +12,8 @@ from typing import TYPE_CHECKING
 import pytest
 from rich.console import Console
 
-from conda_workspaces.archive import create_archive
-from conda_workspaces.cli.workspace.archive import (
-    execute_archive,
-    execute_unarchive,
+from conda_workspaces.archive import (
+    create_archive,
     extract_verified_archive,
     file_contains_bytes,
     is_absolute_runtime_prefix,
@@ -24,6 +22,7 @@ from conda_workspaces.cli.workspace.archive import (
     runtime_prefix_relative_path,
     scan_prefix_references,
 )
+from conda_workspaces.cli.workspace.archive import execute_archive, execute_unarchive
 from conda_workspaces.exceptions import ArchiveError
 from conda_workspaces.models import ArchiveConfig
 from conda_workspaces.receipts import ArchiveReceipt

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -7,26 +7,11 @@ import pytest
 from conda_workspaces.cache import (
     _expand_globs,
     _file_sha256,
-    _file_stat,
     _files_match,
     _fingerprint_files,
     is_cached,
     save_cache,
 )
-
-
-def test_file_stat(tmp_path):
-    f = tmp_path / "file.txt"
-    f.write_text("hello")
-    stat = _file_stat(str(f))
-    assert stat is not None
-    mtime, size = stat
-    assert size == 5
-    assert mtime > 0
-
-
-def test_file_stat_missing():
-    assert _file_stat("/nonexistent/file") is None
 
 
 def test_file_sha256(tmp_path):
@@ -71,7 +56,7 @@ def test_expand_globs(tmp_path, pattern, setup, expected_count):
 @pytest.mark.parametrize(
     ("paths", "expected_keys"),
     [
-        (["file.txt"], {"mtime", "size", "sha256"}),
+        (["file.txt"], {"sha256"}),
     ],
 )
 def test_fingerprint_files(tmp_path, paths, expected_keys):
@@ -92,32 +77,26 @@ def test_fingerprint_missing_file():
     ("cached", "current", "expected"),
     [
         pytest.param(
-            {"main.py": {"mtime": 1.0, "size": 2, "sha256": "old"}},
-            {"main.py": {"mtime": 1.0, "size": 2, "sha256": "new"}},
+            {"main.py": {"sha256": "old"}},
+            {"main.py": {"sha256": "new"}},
             False,
-            id="same-stat-different-digest",
+            id="different-digest",
         ),
         pytest.param(
-            {"main.py": {"mtime": 1.0, "size": 2, "sha256": "same"}},
-            {"main.py": {"mtime": 2.0, "size": 2, "sha256": "same"}},
+            {"main.py": {"sha256": "same"}},
+            {"main.py": {"sha256": "same"}},
             True,
-            id="same-digest-different-mtime",
+            id="same-digest",
         ),
         pytest.param(
-            {"main.py": {"mtime": 1.0, "size": 2}},
-            {"main.py": {"mtime": 1.0, "size": 2}},
-            True,
-            id="legacy-same-stat",
-        ),
-        pytest.param(
-            {"main.py": {"mtime": 1.0, "size": 2}},
-            {"main.py": {"mtime": 2.0, "size": 2}},
+            {"main.py": {}},
+            {"main.py": {"sha256": "same"}},
             False,
-            id="legacy-mtime-change",
+            id="legacy-missing-digest",
         ),
     ],
 )
-def test_files_match_compares_digests_when_available(cached, current, expected):
+def test_files_match_compares_digests(cached, current, expected):
     assert _files_match(cached, current) is expected
 
 


### PR DESCRIPTION
## Summary
- Replace the custom task DAG sorter with `graphlib.TopologicalSorter`.
- Simplify task cache fingerprints to SHA-256 only.
- Deduplicate TOML task writing, archive pattern matching, archive CLI exports, and unused importer aliases.

## Tests
- `pixi run -e test pytest`
- `pixi run ruff check`
- `pixi run ruff format --check conda_workspaces tests`
- `git ls-files -z '*.py' | xargs -0 pixi run ruff format --check`

## Notes
- Repository-wide `pixi run ruff format --check` still sees the unrelated untracked `demos/generate-voiceover.py` file and would reformat it; it is not included in this PR.